### PR TITLE
Add local directory sources for Lambda Boss

### DIFF
--- a/addin/lambda-boss.Tests/LibraryProviderLocalTests.cs
+++ b/addin/lambda-boss.Tests/LibraryProviderLocalTests.cs
@@ -1,0 +1,127 @@
+using Xunit;
+
+#pragma warning disable CA1707
+
+namespace LambdaBoss.Tests;
+
+public class LibraryProviderLocalTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public LibraryProviderLocalTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "LambdaBoss_ProviderLocal_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    private void CreateTestLibrary(string name, string prefix, params string[] lambdaNames)
+    {
+        var libDir = Path.Combine(_tempDir, name);
+        Directory.CreateDirectory(libDir);
+        File.WriteAllText(Path.Combine(libDir, "_library.yaml"),
+            $"name: {name}\ndescription: Test lib\ndefault_prefix: {prefix}");
+
+        foreach (var lambdaName in lambdaNames)
+        {
+            File.WriteAllText(Path.Combine(libDir, $"{lambdaName}.lambda"),
+                $"{lambdaName} = LAMBDA(x, x);");
+        }
+    }
+
+    [Fact]
+    public async Task RefreshAsync_IncludesLocalSources()
+    {
+        CreateTestLibrary("math", "m", "Double", "Triple");
+
+        var localConfig = new LocalSourceConfig { Path = _tempDir };
+        var provider = new LibraryProvider(
+            Array.Empty<RepoConfig>(),
+            localSources: new[] { localConfig });
+
+        var libraries = await provider.GetLibrariesAsync();
+
+        Assert.Single(libraries);
+        Assert.Equal("math", libraries[0].DisplayName);
+        Assert.True(libraries[0].IsLocal);
+        Assert.Equal(2, libraries[0].LambdaCount);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_LocalSourcePopulatesLambdas()
+    {
+        CreateTestLibrary("string", "str", "Split", "Join");
+
+        var localConfig = new LocalSourceConfig { Path = _tempDir };
+        var provider = new LibraryProvider(
+            Array.Empty<RepoConfig>(),
+            localSources: new[] { localConfig });
+
+        var lambdas = await provider.GetAllLambdasAsync();
+
+        Assert.Equal(2, lambdas.Count);
+        Assert.Contains(lambdas, l => l.Name == "Split");
+        Assert.Contains(lambdas, l => l.Name == "Join");
+    }
+
+    [Fact]
+    public void LoadLocalLibrary_ReturnsPrefixedFormulas()
+    {
+        CreateTestLibrary("math", "m", "Double");
+
+        var localConfig = new LocalSourceConfig { Path = _tempDir };
+        var provider = new LibraryProvider(
+            Array.Empty<RepoConfig>(),
+            localSources: new[] { localConfig });
+
+        var results = provider.LoadLocalLibrary(localConfig, "math", "m");
+
+        Assert.Single(results);
+        Assert.Equal("m.Double", results[0].Name);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_DisabledLocalSource_IsExcluded()
+    {
+        CreateTestLibrary("math", "m", "Double");
+
+        var localConfig = new LocalSourceConfig { Path = _tempDir, Enabled = false };
+        var provider = new LibraryProvider(
+            Array.Empty<RepoConfig>(),
+            localSources: new[] { localConfig });
+
+        var libraries = await provider.GetLibrariesAsync();
+
+        Assert.Empty(libraries);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_AlwaysReadsFreshFromDisk()
+    {
+        CreateTestLibrary("math", "m", "Double");
+
+        var localConfig = new LocalSourceConfig { Path = _tempDir };
+        var provider = new LibraryProvider(
+            Array.Empty<RepoConfig>(),
+            localSources: new[] { localConfig });
+
+        // First load
+        var lambdas1 = await provider.GetAllLambdasAsync();
+        Assert.Single(lambdas1);
+
+        // Add a new lambda file
+        var libDir = Path.Combine(_tempDir, "math");
+        File.WriteAllText(Path.Combine(libDir, "Triple.lambda"), "Triple = LAMBDA(x, x*3);");
+
+        // Force refresh (simulates reload)
+        await provider.RefreshAsync();
+        var lambdas2 = await provider.GetAllLambdasAsync();
+
+        Assert.Equal(2, lambdas2.Count);
+    }
+}

--- a/addin/lambda-boss.Tests/LocalDirectorySourceTests.cs
+++ b/addin/lambda-boss.Tests/LocalDirectorySourceTests.cs
@@ -1,0 +1,115 @@
+using Xunit;
+
+#pragma warning disable CA1707
+
+namespace LambdaBoss.Tests;
+
+public class LocalDirectorySourceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public LocalDirectorySourceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "LambdaBoss_LocalSrc_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void ListLibraries_ReturnsDirectoriesWithLibraryYaml()
+    {
+        // Arrange: two dirs, only one has _library.yaml
+        var lib1 = Path.Combine(_tempDir, "string");
+        var lib2 = Path.Combine(_tempDir, "math");
+        var notLib = Path.Combine(_tempDir, "random");
+
+        Directory.CreateDirectory(lib1);
+        Directory.CreateDirectory(lib2);
+        Directory.CreateDirectory(notLib);
+
+        File.WriteAllText(Path.Combine(lib1, "_library.yaml"), "name: String\ndescription: String ops\ndefault_prefix: str");
+        File.WriteAllText(Path.Combine(lib2, "_library.yaml"), "name: Math\ndescription: Math ops\ndefault_prefix: math");
+        // notLib has no _library.yaml
+
+        var config = new LocalSourceConfig { Path = _tempDir };
+        var source = new LocalDirectorySource(config);
+
+        // Act
+        var libraries = source.ListLibraries();
+
+        // Assert
+        Assert.Equal(2, libraries.Count);
+        Assert.Contains("string", libraries);
+        Assert.Contains("math", libraries);
+        Assert.DoesNotContain("random", libraries);
+    }
+
+    [Fact]
+    public void ListLibraries_WhenPathDoesNotExist_ReturnsEmpty()
+    {
+        var config = new LocalSourceConfig { Path = @"C:\nonexistent\path\12345" };
+        var source = new LocalDirectorySource(config);
+
+        var libraries = source.ListLibraries();
+
+        Assert.Empty(libraries);
+    }
+
+    [Fact]
+    public void FetchLibrary_ReadsMetadataAndLambdaFiles()
+    {
+        // Arrange
+        var libDir = Path.Combine(_tempDir, "string");
+        Directory.CreateDirectory(libDir);
+
+        File.WriteAllText(Path.Combine(libDir, "_library.yaml"),
+            "name: String Functions\ndescription: String ops\ndefault_prefix: str");
+        File.WriteAllText(Path.Combine(libDir, "Split.lambda"),
+            "Split = LAMBDA([text], [delimiter], TEXTSPLIT(text, delimiter));");
+        File.WriteAllText(Path.Combine(libDir, "Join.lambda"),
+            "Join = LAMBDA([parts], [delimiter], TEXTJOIN(delimiter, TRUE, parts));");
+
+        var config = new LocalSourceConfig { Path = _tempDir };
+        var source = new LocalDirectorySource(config);
+
+        // Act
+        var library = source.FetchLibrary("string");
+
+        // Assert
+        Assert.Equal("String Functions", library.Metadata.Name);
+        Assert.Equal("String ops", library.Metadata.Description);
+        Assert.Equal("str", library.Metadata.DefaultPrefix);
+        Assert.Equal(2, library.Files.Count);
+        Assert.True(library.Files.ContainsKey("Split.lambda"));
+        Assert.True(library.Files.ContainsKey("Join.lambda"));
+    }
+
+    [Fact]
+    public void FetchLibrary_ReadsOnlyLambdaFiles()
+    {
+        // Arrange
+        var libDir = Path.Combine(_tempDir, "test");
+        Directory.CreateDirectory(libDir);
+
+        File.WriteAllText(Path.Combine(libDir, "_library.yaml"),
+            "name: Test\ndescription: Test lib\ndefault_prefix: tst");
+        File.WriteAllText(Path.Combine(libDir, "Func.lambda"), "Func = LAMBDA(x, x);");
+        File.WriteAllText(Path.Combine(libDir, "notes.txt"), "Some notes");
+        File.WriteAllText(Path.Combine(libDir, "Func.tests.yaml"), "tests: []");
+
+        var config = new LocalSourceConfig { Path = _tempDir };
+        var source = new LocalDirectorySource(config);
+
+        // Act
+        var library = source.FetchLibrary("test");
+
+        // Assert
+        Assert.Single(library.Files);
+        Assert.True(library.Files.ContainsKey("Func.lambda"));
+    }
+}

--- a/addin/lambda-boss.Tests/LocalSourceSettingsTests.cs
+++ b/addin/lambda-boss.Tests/LocalSourceSettingsTests.cs
@@ -1,0 +1,138 @@
+using Xunit;
+
+#pragma warning disable CA1707
+
+namespace LambdaBoss.Tests;
+
+public class LocalSourceSettingsTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _settingsPath;
+
+    public LocalSourceSettingsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "LambdaBoss_LocalSettings_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _settingsPath = Path.Combine(_tempDir, "settings.json");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void DefaultSettings_HasEmptyLocalSources()
+    {
+        var settings = new Settings();
+        Assert.Empty(settings.LocalSources);
+    }
+
+    [Fact]
+    public void AddLocalSource_NewPath_ReturnsTrue()
+    {
+        var settings = new Settings();
+        var result = settings.AddLocalSource(@"C:\Users\test\lambdas");
+
+        Assert.True(result);
+        Assert.Single(settings.LocalSources);
+        Assert.Equal(@"C:\Users\test\lambdas", settings.LocalSources[0].Path);
+    }
+
+    [Fact]
+    public void AddLocalSource_DuplicatePath_ReturnsFalse()
+    {
+        var settings = new Settings();
+        settings.AddLocalSource(@"C:\Users\test\lambdas");
+        var result = settings.AddLocalSource(@"C:\Users\test\lambdas");
+
+        Assert.False(result);
+        Assert.Single(settings.LocalSources);
+    }
+
+    [Fact]
+    public void AddLocalSource_DuplicateWithTrailingSlash_ReturnsFalse()
+    {
+        var settings = new Settings();
+        settings.AddLocalSource(@"C:\Users\test\lambdas");
+        var result = settings.AddLocalSource(@"C:\Users\test\lambdas\");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void AddLocalSource_CaseInsensitive_ReturnsFalse()
+    {
+        var settings = new Settings();
+        settings.AddLocalSource(@"C:\Users\Test\Lambdas");
+        var result = settings.AddLocalSource(@"c:\users\test\lambdas");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void RemoveLocalSource_ExistingPath_ReturnsTrue()
+    {
+        var settings = new Settings();
+        settings.AddLocalSource(@"C:\Users\test\lambdas");
+
+        var result = settings.RemoveLocalSource(@"C:\Users\test\lambdas");
+
+        Assert.True(result);
+        Assert.Empty(settings.LocalSources);
+    }
+
+    [Fact]
+    public void RemoveLocalSource_NonExistentPath_ReturnsFalse()
+    {
+        var settings = new Settings();
+        var result = settings.RemoveLocalSource(@"C:\nonexistent");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void EnabledLocalSources_ExcludesDisabled()
+    {
+        var settings = new Settings();
+        settings.AddLocalSource(@"C:\enabled");
+        settings.AddLocalSource(@"C:\disabled");
+        settings.LocalSources[1].Enabled = false;
+
+        var enabled = settings.EnabledLocalSources;
+
+        Assert.Single(enabled);
+        Assert.Equal(@"C:\enabled", enabled[0].Path);
+    }
+
+    [Fact]
+    public void Save_ThenLoad_RoundTripsLocalSources()
+    {
+        var settings = new Settings();
+        settings.AddLocalSource(@"C:\Users\test\lambdas");
+        settings.LocalSources[0].Enabled = true;
+
+        settings.Save(_settingsPath);
+
+        var loaded = Settings.Load(_settingsPath);
+
+        Assert.Single(loaded.LocalSources);
+        Assert.Equal(@"C:\Users\test\lambdas", loaded.LocalSources[0].Path);
+        Assert.True(loaded.LocalSources[0].Enabled);
+    }
+
+    [Fact]
+    public void LocalSourceConfig_DisplayName_ReturnsFolderName()
+    {
+        var config = new LocalSourceConfig { Path = @"C:\Users\trjac\repositories\lambda-boss\lambdas" };
+        Assert.Equal("lambdas", config.DisplayName);
+    }
+
+    [Fact]
+    public void LocalSourceConfig_DisplayName_HandlesTrailingSlash()
+    {
+        var config = new LocalSourceConfig { Path = @"C:\Users\trjac\lambdas\" };
+        Assert.Equal("lambdas", config.DisplayName);
+    }
+}

--- a/addin/lambda-boss/Commands/ShowLambdaPopupCommand.cs
+++ b/addin/lambda-boss/Commands/ShowLambdaPopupCommand.cs
@@ -198,7 +198,9 @@ public static class ShowLambdaPopupCommand
         {
             _windowDispatcher?.Invoke(() => _window?.SetStatus("Loading libraries..."));
 
-            _provider ??= new LibraryProvider(Settings.Current.EnabledRepos);
+            _provider ??= new LibraryProvider(
+                Settings.Current.EnabledRepos,
+                localSources: Settings.Current.EnabledLocalSources);
 
             var libraries = await _provider.GetLibrariesAsync();
             var lambdas = await _provider.GetAllLambdasAsync();
@@ -261,13 +263,26 @@ public static class ShowLambdaPopupCommand
                 _windowDispatcher?.Invoke(() =>
                     _window?.SetStatus($"Loading {request.DisplayName}..."));
 
-                _provider ??= new LibraryProvider(Settings.Current.EnabledRepos);
+                _provider ??= new LibraryProvider(
+                    Settings.Current.EnabledRepos,
+                    localSources: Settings.Current.EnabledLocalSources);
 
-                // Invalidate cache so we always get fresh data
-                _provider.InvalidateCache(request.RepoConfig, request.LibraryName);
+                IReadOnlyList<(string Name, string Formula)> lambdas;
 
-                var lambdas = await _provider.LoadLibraryAsync(
-                    request.RepoConfig, request.LibraryName, request.Prefix);
+                if (request.IsLocal)
+                {
+                    // Local sources always read fresh from disk — no cache
+                    lambdas = _provider.LoadLocalLibrary(
+                        request.LocalSourceConfig!, request.LibraryName, request.Prefix);
+                }
+                else
+                {
+                    // Invalidate cache so we always get fresh data
+                    _provider.InvalidateCache(request.RepoConfig!, request.LibraryName);
+
+                    lambdas = await _provider.LoadLibraryAsync(
+                        request.RepoConfig!, request.LibraryName, request.Prefix);
+                }
 
                 ExcelAsyncUtil.QueueAsMacro(() =>
                 {
@@ -278,11 +293,14 @@ public static class ShowLambdaPopupCommand
                         try
                         {
                             var allScanned = LambdaLoader.ScanLoadedLibraries();
+                            var sourceKey = request.IsLocal
+                                ? request.LocalSourceConfig!.Path
+                                : request.RepoConfig!.Url;
                             existing = allScanned.FirstOrDefault(s =>
                                 string.Equals(s.LibraryName, request.LibraryName, StringComparison.OrdinalIgnoreCase)
                                 && string.Equals(
-                                    s.RepoUrl.TrimEnd('/'),
-                                    request.RepoConfig.Url.TrimEnd('/'),
+                                    s.RepoUrl.TrimEnd('/', '\\'),
+                                    sourceKey.TrimEnd('/', '\\'),
                                     StringComparison.OrdinalIgnoreCase));
                         }
                         catch
@@ -290,8 +308,11 @@ public static class ShowLambdaPopupCommand
                             // If scan fails, proceed without diff
                         }
 
+                        var sourceLabel = request.IsLocal
+                            ? request.LocalSourceConfig!.Path
+                            : request.RepoConfig!.Url;
                         var comment = LambdaLoader.BuildComment(
-                            request.RepoConfig.Url, request.LibraryName, request.Prefix);
+                            sourceLabel, request.LibraryName, request.Prefix);
 
                         var added = 0;
                         var updated = 0;

--- a/addin/lambda-boss/LibraryProvider.cs
+++ b/addin/lambda-boss/LibraryProvider.cs
@@ -13,13 +13,16 @@ public class LibraryProvider
     private readonly HttpClient _httpClient;
     private readonly SourceCache _cache;
     private readonly List<RepoConfig> _repos;
+    private readonly List<LocalSourceConfig> _localSources;
 
     private List<LibraryInfo>? _libraries;
     private List<LambdaInfo>? _lambdas;
 
-    public LibraryProvider(IEnumerable<RepoConfig> repos, HttpClient? httpClient = null, SourceCache? cache = null)
+    public LibraryProvider(IEnumerable<RepoConfig> repos, HttpClient? httpClient = null,
+        SourceCache? cache = null, IEnumerable<LocalSourceConfig>? localSources = null)
     {
         _repos = repos.ToList();
+        _localSources = localSources?.ToList() ?? new List<LocalSourceConfig>();
         _httpClient = httpClient ?? new HttpClient();
         _cache = cache ?? new SourceCache();
     }
@@ -70,6 +73,17 @@ public class LibraryProvider
             }
         }
 
+        return library.LoadWithPrefix(prefix);
+    }
+
+    /// <summary>
+    ///     Loads a library from a local directory source. Always reads fresh from disk.
+    /// </summary>
+    public IReadOnlyList<(string Name, string Formula)> LoadLocalLibrary(
+        LocalSourceConfig config, string libraryName, string prefix)
+    {
+        var source = new LocalDirectorySource(config);
+        var library = source.FetchLibrary(libraryName);
         return library.LoadWithPrefix(prefix);
     }
 
@@ -161,6 +175,66 @@ public class LibraryProvider
             }
         }
 
+        // Load from local directory sources
+        foreach (var localConfig in _localSources.Where(s => s.Enabled))
+        {
+            try
+            {
+                var source = new LocalDirectorySource(localConfig);
+                var libraryNames = source.ListLibraries();
+
+                foreach (var libName in libraryNames)
+                {
+                    FetchedLibrary fetched;
+                    try
+                    {
+                        fetched = source.FetchLibrary(libName);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"LibraryProvider: Failed to read local library '{libName}' from {localConfig.Path}", ex);
+                        continue;
+                    }
+
+                    var info = new LibraryInfo
+                    {
+                        RepoConfig = null!,
+                        LocalSourceConfig = localConfig,
+                        RepoLabel = localConfig.DisplayName,
+                        FolderName = libName,
+                        DisplayName = fetched.Metadata.Name,
+                        Description = fetched.Metadata.Description,
+                        DefaultPrefix = fetched.Metadata.DefaultPrefix,
+                        LambdaCount = fetched.Files.Count
+                    };
+                    libraries.Add(info);
+
+                    foreach (var (fileName, content) in fetched.Files)
+                    {
+                        try
+                        {
+                            var (name, formula) = LambdaParser.Parse(content);
+                            lambdas.Add(new LambdaInfo
+                            {
+                                Name = name,
+                                Formula = formula,
+                                LibraryInfo = info,
+                                FileName = fileName
+                            });
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error($"LibraryProvider: Failed to parse '{fileName}' in local {libName}", ex);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"LibraryProvider: Failed to list local libraries from {localConfig.Path}", ex);
+            }
+        }
+
         _libraries = libraries;
         _lambdas = lambdas;
 
@@ -174,12 +248,18 @@ public class LibraryProvider
 public sealed class LibraryInfo
 {
     public RepoConfig RepoConfig { get; init; } = null!;
+    public LocalSourceConfig? LocalSourceConfig { get; init; }
     public string RepoLabel { get; init; } = "";
     public string FolderName { get; init; } = "";
     public string DisplayName { get; init; } = "";
     public string Description { get; init; } = "";
     public string DefaultPrefix { get; init; } = "";
     public int LambdaCount { get; init; }
+
+    /// <summary>
+    ///     Whether this library comes from a local directory source.
+    /// </summary>
+    public bool IsLocal => LocalSourceConfig != null;
 }
 
 /// <summary>

--- a/addin/lambda-boss/LocalDirectorySource.cs
+++ b/addin/lambda-boss/LocalDirectorySource.cs
@@ -1,0 +1,63 @@
+using Taglo.Excel.Common;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     Reads LAMBDA library contents from a local filesystem directory.
+///     Always reads fresh from disk — no caching.
+/// </summary>
+public class LocalDirectorySource
+{
+    private readonly LocalSourceConfig _config;
+
+    public LocalDirectorySource(LocalSourceConfig config)
+    {
+        _config = config;
+    }
+
+    /// <summary>
+    ///     Discovers all library sub-folders (directories containing _library.yaml).
+    /// </summary>
+    public IReadOnlyList<string> ListLibraries()
+    {
+        if (!Directory.Exists(_config.Path))
+        {
+            Logger.Info($"LocalDirectorySource: Path does not exist: {_config.Path}");
+            return Array.Empty<string>();
+        }
+
+        var libraries = new List<string>();
+        foreach (var dir in Directory.GetDirectories(_config.Path))
+        {
+            var yamlPath = Path.Combine(dir, "_library.yaml");
+            if (File.Exists(yamlPath))
+            {
+                libraries.Add(Path.GetFileName(dir));
+            }
+        }
+
+        Logger.Info($"LocalDirectorySource: Found {libraries.Count} libraries in {_config.Path}");
+        return libraries;
+    }
+
+    /// <summary>
+    ///     Reads a complete library from disk: metadata + all .lambda file contents.
+    /// </summary>
+    public FetchedLibrary FetchLibrary(string libraryName)
+    {
+        var libraryDir = Path.Combine(_config.Path, libraryName);
+        var yamlPath = Path.Combine(libraryDir, "_library.yaml");
+
+        var metadata = LibraryMetadata.LoadFromFile(yamlPath);
+
+        var files = new Dictionary<string, string>();
+        foreach (var filePath in Directory.GetFiles(libraryDir, "*.lambda"))
+        {
+            var fileName = Path.GetFileName(filePath);
+            files[fileName] = File.ReadAllText(filePath);
+        }
+
+        Logger.Info($"LocalDirectorySource: Read library '{libraryName}' ({files.Count} files) from {_config.Path}");
+        return new FetchedLibrary(libraryName, metadata, files);
+    }
+}

--- a/addin/lambda-boss/LocalSourceConfig.cs
+++ b/addin/lambda-boss/LocalSourceConfig.cs
@@ -1,0 +1,25 @@
+namespace LambdaBoss;
+
+/// <summary>
+///     Configuration for a local filesystem directory source of LAMBDA libraries.
+/// </summary>
+public sealed class LocalSourceConfig
+{
+    /// <summary>
+    ///     The absolute path to the directory containing library sub-folders
+    ///     (e.g. "C:\Users\trjac\repositories\lambda-boss\lambdas").
+    /// </summary>
+    public string Path { get; set; } = "";
+
+    /// <summary>
+    ///     Whether this local source is enabled for loading.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    ///     Returns the folder name from the path, used as the display name.
+    /// </summary>
+    public string DisplayName => string.IsNullOrEmpty(Path)
+        ? ""
+        : System.IO.Path.GetFileName(Path.TrimEnd('\\', '/'));
+}

--- a/addin/lambda-boss/Settings.cs
+++ b/addin/lambda-boss/Settings.cs
@@ -37,6 +37,11 @@ public sealed class Settings
     public List<RepoConfig> Repos { get; set; } = new() { DefaultRepo };
 
     /// <summary>
+    ///     Configured local directory sources.
+    /// </summary>
+    public List<LocalSourceConfig> LocalSources { get; set; } = new();
+
+    /// <summary>
     ///     Excel keyboard shortcut string (ExcelDNA format). Default: Ctrl+Shift+L.
     /// </summary>
     public string KeyboardShortcut { get; set; } = "^+L";
@@ -110,6 +115,12 @@ public sealed class Settings
         Repos.Where(r => r.Enabled).ToList();
 
     /// <summary>
+    ///     Returns only the enabled local sources.
+    /// </summary>
+    public IReadOnlyList<LocalSourceConfig> EnabledLocalSources =>
+        LocalSources.Where(s => s.Enabled).ToList();
+
+    /// <summary>
     ///     Adds a repo by URL if not already present. Returns true if added.
     /// </summary>
     public bool AddRepo(string url)
@@ -131,6 +142,31 @@ public sealed class Settings
         url = url.TrimEnd('/');
         return Repos.RemoveAll(r =>
             string.Equals(r.Url.TrimEnd('/'), url, StringComparison.OrdinalIgnoreCase)) > 0;
+    }
+
+    /// <summary>
+    ///     Adds a local directory source if not already present. Returns true if added.
+    /// </summary>
+    public bool AddLocalSource(string path)
+    {
+        path = path.TrimEnd('\\', '/');
+
+        if (LocalSources.Any(s => string.Equals(
+            s.Path.TrimEnd('\\', '/'), path, StringComparison.OrdinalIgnoreCase)))
+            return false;
+
+        LocalSources.Add(new LocalSourceConfig { Path = path });
+        return true;
+    }
+
+    /// <summary>
+    ///     Removes a local directory source by path. Returns true if removed.
+    /// </summary>
+    public bool RemoveLocalSource(string path)
+    {
+        path = path.TrimEnd('\\', '/');
+        return LocalSources.RemoveAll(s =>
+            string.Equals(s.Path.TrimEnd('\\', '/'), path, StringComparison.OrdinalIgnoreCase)) > 0;
     }
 
     /// <summary>

--- a/addin/lambda-boss/UI/LambdaPopup.xaml
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml
@@ -66,6 +66,8 @@
                     <StackPanel Margin="4,3">
                         <StackPanel Orientation="Horizontal">
                             <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                            <TextBlock Text="{Binding SourceIcon}" Foreground="#cccccc" FontSize="11"
+                                       VerticalAlignment="Center" Margin="0,0,4,0" />
                             <TextBlock Text="{Binding DisplayName}" FontWeight="Bold" Foreground="#dcdcaa" />
                             <TextBlock Text="  " />
                             <TextBlock Text="{Binding LambdaCountLabel}" Foreground="#569cd6" FontSize="11"

--- a/addin/lambda-boss/UI/LambdaPopup.xaml.cs
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml.cs
@@ -53,7 +53,9 @@ public partial class LambdaPopup
             .Select(l => new LambdaDisplayItem
             {
                 Name = l.Name,
-                LibraryLabel = l.LibraryInfo.DisplayName,
+                LibraryLabel = l.LibraryInfo.IsLocal
+                    ? $"{l.LibraryInfo.DisplayName} [Local]"
+                    : l.LibraryInfo.DisplayName,
                 LibraryInfo = l.LibraryInfo
             })
             .ToList();

--- a/addin/lambda-boss/UI/LambdaPopup.xaml.cs
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml.cs
@@ -41,8 +41,9 @@ public partial class LambdaPopup
                 DefaultPrefix = l.DefaultPrefix,
                 RepoLabel = l.RepoLabel,
                 FolderName = l.FolderName,
-                RepoConfig = l.RepoConfig,
-                LoadedLabel = loadedLibraryKeys != null
+                RepoConfig = l.IsLocal ? null : l.RepoConfig,
+                LocalSourceConfig = l.LocalSourceConfig,
+                LoadedLabel = !l.IsLocal && loadedLibraryKeys != null
                     && loadedLibraryKeys.Contains(MakeLoadedKey(l.RepoConfig.Url, l.FolderName))
                     ? "✓ loaded" : ""
             })
@@ -76,7 +77,8 @@ public partial class LambdaPopup
                 RepoLabel = l.RepoLabel,
                 FolderName = l.FolderName,
                 RepoConfig = l.RepoConfig,
-                LoadedLabel = loadedLibraryKeys != null
+                LocalSourceConfig = l.LocalSourceConfig,
+                LoadedLabel = !l.IsLocal && l.RepoConfig != null && loadedLibraryKeys != null
                     && loadedLibraryKeys.Contains(MakeLoadedKey(l.RepoConfig.Url, l.FolderName))
                     ? "✓ loaded" : ""
             })
@@ -277,30 +279,21 @@ public partial class LambdaPopup
 
     private void BeginLoad()
     {
-        LibraryInfo? libraryInfo = null;
+        string? defaultPrefix = null;
 
         if (_mode == Mode.Library && LibraryList.SelectedItem is LibraryDisplayItem libItem)
         {
-            libraryInfo = new LibraryInfo
-            {
-                RepoConfig = libItem.RepoConfig,
-                RepoLabel = libItem.RepoLabel,
-                FolderName = libItem.FolderName,
-                DisplayName = libItem.DisplayName,
-                Description = libItem.Description,
-                DefaultPrefix = libItem.DefaultPrefix,
-                LambdaCount = 0
-            };
+            defaultPrefix = libItem.DefaultPrefix;
         }
         else if (_mode == Mode.Search && LambdaList.SelectedItem is LambdaDisplayItem lambdaItem)
         {
-            libraryInfo = lambdaItem.LibraryInfo;
+            defaultPrefix = lambdaItem.LibraryInfo.DefaultPrefix;
         }
 
-        if (libraryInfo == null)
+        if (defaultPrefix == null)
             return;
 
-        ShowPrefixPrompt(libraryInfo.DefaultPrefix);
+        ShowPrefixPrompt(defaultPrefix);
     }
 
     private void ShowPrefixPrompt(string defaultPrefix)
@@ -322,38 +315,28 @@ public partial class LambdaPopup
 
     private void ConfirmLoad()
     {
-        LibraryInfo? libraryInfo = null;
+        LibraryLoadRequest? request = null;
+        var prefix = PrefixBox.Text.Trim();
 
         if (_mode == Mode.Library && LibraryList.SelectedItem is LibraryDisplayItem libItem)
         {
-            libraryInfo = new LibraryInfo
-            {
-                RepoConfig = libItem.RepoConfig,
-                RepoLabel = libItem.RepoLabel,
-                FolderName = libItem.FolderName,
-                DisplayName = libItem.DisplayName,
-                Description = libItem.Description,
-                DefaultPrefix = libItem.DefaultPrefix,
-                LambdaCount = 0
-            };
+            request = libItem.IsLocal
+                ? new LibraryLoadRequest(libItem.LocalSourceConfig!, libItem.FolderName, prefix, libItem.DisplayName)
+                : new LibraryLoadRequest(libItem.RepoConfig!, libItem.FolderName, prefix, libItem.DisplayName);
         }
         else if (_mode == Mode.Search && LambdaList.SelectedItem is LambdaDisplayItem lambdaItem)
         {
-            libraryInfo = lambdaItem.LibraryInfo;
+            var info = lambdaItem.LibraryInfo;
+            request = info.IsLocal
+                ? new LibraryLoadRequest(info.LocalSourceConfig!, info.FolderName, prefix, info.DisplayName)
+                : new LibraryLoadRequest(info.RepoConfig, info.FolderName, prefix, info.DisplayName);
         }
 
-        if (libraryInfo == null)
+        if (request == null)
             return;
 
-        var prefix = PrefixBox.Text.Trim();
         HidePrefixPrompt();
-
-        LibraryLoadRequested?.Invoke(this, new LibraryLoadRequest(
-            libraryInfo.RepoConfig,
-            libraryInfo.FolderName,
-            prefix,
-            libraryInfo.DisplayName));
-
+        LibraryLoadRequested?.Invoke(this, request);
         Hide();
     }
 
@@ -372,14 +355,28 @@ public partial class LambdaPopup
 /// </summary>
 public sealed class LibraryLoadRequest
 {
-    public RepoConfig RepoConfig { get; }
+    public RepoConfig? RepoConfig { get; }
+    public LocalSourceConfig? LocalSourceConfig { get; }
     public string LibraryName { get; }
     public string Prefix { get; }
     public string DisplayName { get; }
 
+    /// <summary>
+    ///     Whether this request is for a local directory source.
+    /// </summary>
+    public bool IsLocal => LocalSourceConfig != null;
+
     public LibraryLoadRequest(RepoConfig repoConfig, string libraryName, string prefix, string displayName)
     {
         RepoConfig = repoConfig;
+        LibraryName = libraryName;
+        Prefix = prefix;
+        DisplayName = displayName;
+    }
+
+    public LibraryLoadRequest(LocalSourceConfig localConfig, string libraryName, string prefix, string displayName)
+    {
+        LocalSourceConfig = localConfig;
         LibraryName = libraryName;
         Prefix = prefix;
         DisplayName = displayName;
@@ -394,8 +391,11 @@ internal class LibraryDisplayItem
     public string DefaultPrefix { get; init; } = "";
     public string RepoLabel { get; init; } = "";
     public string FolderName { get; init; } = "";
-    public RepoConfig RepoConfig { get; init; } = null!;
+    public RepoConfig? RepoConfig { get; init; }
+    public LocalSourceConfig? LocalSourceConfig { get; init; }
     public string LoadedLabel { get; init; } = "";
+    public bool IsLocal => LocalSourceConfig != null;
+    public string SourceIcon => IsLocal ? "\U0001F4C1" : "";
 }
 
 internal class LambdaDisplayItem

--- a/addin/lambda-boss/UI/SettingsWindow.xaml
+++ b/addin/lambda-boss/UI/SettingsWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Lambda Boss — Settings"
-        Width="480" Height="340"
+        Width="480" Height="480"
         WindowStyle="ToolWindow"
         ShowInTaskbar="True"
         Topmost="True"
@@ -14,6 +14,9 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
@@ -120,9 +123,113 @@
             </ListBox.ItemTemplate>
         </ListBox>
 
+        <!-- Local Sources Header -->
+        <TextBlock Grid.Row="3"
+                   Text="Local Directory Sources"
+                   FontSize="13"
+                   FontWeight="Bold"
+                   Foreground="#dcdcaa"
+                   Margin="0,12,0,8" />
+
+        <!-- Add local source input -->
+        <Border Grid.Row="4" Margin="0,0,0,6"
+                Padding="6,4"
+                Background="#2d2d2d"
+                BorderBrush="#3e3e3e"
+                BorderThickness="1"
+                CornerRadius="2">
+            <DockPanel>
+                <Button x:Name="AddLocalButton"
+                        DockPanel.Dock="Right"
+                        Content="Add"
+                        Padding="12,2"
+                        Margin="6,0,0,0"
+                        Background="#0e639c"
+                        Foreground="#ffffff"
+                        BorderThickness="0"
+                        Click="AddLocalButton_Click" />
+                <TextBox x:Name="LocalPathBox"
+                         Padding="4,2"
+                         FontSize="13"
+                         Background="#1e1e1e"
+                         Foreground="#cccccc"
+                         CaretBrush="#cccccc"
+                         BorderThickness="0"
+                         KeyDown="LocalPathBox_KeyDown">
+                    <TextBox.Style>
+                        <Style TargetType="TextBox">
+                            <Style.Resources>
+                                <VisualBrush x:Key="LocalPlaceholderBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
+                                    <VisualBrush.Visual>
+                                        <TextBlock Text="C:\path\to\lambdas" FontSize="13"
+                                                   Foreground="#555555" Margin="5,0,0,0" />
+                                    </VisualBrush.Visual>
+                                </VisualBrush>
+                            </Style.Resources>
+                            <Style.Triggers>
+                                <Trigger Property="Text" Value="">
+                                    <Setter Property="Background" Value="{StaticResource LocalPlaceholderBrush}" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+            </DockPanel>
+        </Border>
+
+        <!-- Local sources list -->
+        <ListBox x:Name="LocalSourceList"
+                 Grid.Row="5"
+                 Background="#252526"
+                 Foreground="#cccccc"
+                 BorderBrush="#3e3e3e"
+                 BorderThickness="1"
+                 FontFamily="Consolas"
+                 FontSize="13"
+                 SelectionMode="Single"
+                 HorizontalContentAlignment="Stretch"
+                 MaxHeight="120">
+            <ListBox.ItemContainerStyle>
+                <Style TargetType="ListBoxItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="Padding" Value="0" />
+                </Style>
+            </ListBox.ItemContainerStyle>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <DockPanel Margin="4,3">
+                        <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                        <Button DockPanel.Dock="Right"
+                                Content="Remove"
+                                Padding="8,2"
+                                Margin="8,0,0,0"
+                                Background="Transparent"
+                                Foreground="#e74856"
+                                BorderBrush="#3e3e3e"
+                                BorderThickness="1"
+                                FontSize="11"
+                                Cursor="Hand"
+                                Click="RemoveLocalButton_Click"
+                                Tag="{Binding Path}" />
+                        <CheckBox DockPanel.Dock="Left"
+                                  IsChecked="{Binding Enabled}"
+                                  Margin="0,0,8,0"
+                                  VerticalAlignment="Center"
+                                  Click="LocalEnabledCheckbox_Click" />
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock Text="{Binding DisplayLabel}" FontWeight="Bold" Foreground="#dcdcaa" />
+                            <TextBlock Text="{Binding PathLabel}" Foreground="#808080" FontSize="10" />
+                        </StackPanel>
+                        <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
+                    </DockPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
         <!-- Status bar -->
         <TextBlock x:Name="StatusText"
-                   Grid.Row="3"
+                   Grid.Row="6"
                    Margin="0,4,0,0"
                    Foreground="#808080"
                    FontSize="11"

--- a/addin/lambda-boss/UI/SettingsWindow.xaml
+++ b/addin/lambda-boss/UI/SettingsWindow.xaml
@@ -139,6 +139,15 @@
                 BorderThickness="1"
                 CornerRadius="2">
             <DockPanel>
+                <Button x:Name="BrowseLocalButton"
+                        DockPanel.Dock="Right"
+                        Content="Browse"
+                        Padding="12,2"
+                        Margin="6,0,0,0"
+                        Background="#0e639c"
+                        Foreground="#ffffff"
+                        BorderThickness="0"
+                        Click="BrowseLocalButton_Click" />
                 <Button x:Name="AddLocalButton"
                         DockPanel.Dock="Right"
                         Content="Add"
@@ -161,7 +170,7 @@
                             <Style.Resources>
                                 <VisualBrush x:Key="LocalPlaceholderBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
                                     <VisualBrush.Visual>
-                                        <TextBlock Text="C:\path\to\lambdas" FontSize="13"
+                                        <TextBlock Text="C:\repo\lambdas (folder containing library sub-folders)" FontSize="13"
                                                    Foreground="#555555" Margin="5,0,0,0" />
                                     </VisualBrush.Visual>
                                 </VisualBrush>

--- a/addin/lambda-boss/UI/SettingsWindow.xaml.cs
+++ b/addin/lambda-boss/UI/SettingsWindow.xaml.cs
@@ -2,6 +2,8 @@ using System.ComponentModel;
 using System.Windows;
 using System.Windows.Input;
 
+using Ookii.Dialogs.Wpf;
+
 namespace LambdaBoss.UI;
 
 public partial class SettingsWindow
@@ -186,6 +188,20 @@ public partial class SettingsWindow
     private void AddLocalButton_Click(object sender, RoutedEventArgs e)
     {
         AddLocalSource();
+    }
+
+    private void BrowseLocalButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new VistaFolderBrowserDialog
+        {
+            Description = "Select the folder containing library sub-folders (e.g. repo\\lambdas)",
+            UseDescriptionForTitle = true
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            LocalPathBox.Text = dialog.SelectedPath;
+        }
     }
 
     private void LocalPathBox_KeyDown(object sender, KeyEventArgs e)

--- a/addin/lambda-boss/UI/SettingsWindow.xaml.cs
+++ b/addin/lambda-boss/UI/SettingsWindow.xaml.cs
@@ -10,6 +10,7 @@ public partial class SettingsWindow
     {
         InitializeComponent();
         RefreshRepoList();
+        RefreshLocalSourceList();
         PreviewKeyDown += OnPreviewKeyDown;
     }
 
@@ -139,6 +140,95 @@ public partial class SettingsWindow
             SettingsChanged?.Invoke(this, EventArgs.Empty);
         }
     }
+
+    // --- Local directory sources ---
+
+    private void RefreshLocalSourceList()
+    {
+        var settings = Settings.Current;
+        LocalSourceList.ItemsSource = settings.LocalSources
+            .Select(s => new LocalSourceDisplayItem
+            {
+                Path = s.Path,
+                Enabled = s.Enabled,
+                DisplayLabel = s.DisplayName,
+                PathLabel = s.Path
+            })
+            .ToList();
+    }
+
+    private void AddLocalSource()
+    {
+        var path = LocalPathBox.Text.Trim();
+        if (string.IsNullOrEmpty(path))
+            return;
+
+        if (!System.IO.Directory.Exists(path))
+        {
+            StatusText.Text = "Directory does not exist";
+            return;
+        }
+
+        var settings = Settings.Current;
+        if (!settings.AddLocalSource(path))
+        {
+            StatusText.Text = "Local source already exists";
+            return;
+        }
+
+        settings.Save();
+        LocalPathBox.Text = "";
+        RefreshLocalSourceList();
+        SettingsChanged?.Invoke(this, EventArgs.Empty);
+        StatusText.Text = $"Added local source: {path}";
+    }
+
+    private void AddLocalButton_Click(object sender, RoutedEventArgs e)
+    {
+        AddLocalSource();
+    }
+
+    private void LocalPathBox_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            AddLocalSource();
+            e.Handled = true;
+        }
+    }
+
+private void RemoveLocalButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not System.Windows.Controls.Button { Tag: string path })
+            return;
+
+        var settings = Settings.Current;
+        if (settings.RemoveLocalSource(path))
+        {
+            settings.Save();
+            RefreshLocalSourceList();
+            SettingsChanged?.Invoke(this, EventArgs.Empty);
+            StatusText.Text = $"Removed local source: {path}";
+        }
+    }
+
+    private void LocalEnabledCheckbox_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not System.Windows.Controls.CheckBox { DataContext: LocalSourceDisplayItem item })
+            return;
+
+        var settings = Settings.Current;
+        var source = settings.LocalSources.FirstOrDefault(s =>
+            string.Equals(s.Path.TrimEnd('\\', '/'), item.Path.TrimEnd('\\', '/'),
+                StringComparison.OrdinalIgnoreCase));
+
+        if (source != null)
+        {
+            source.Enabled = item.Enabled;
+            settings.Save();
+            SettingsChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
 }
 
 internal class RepoDisplayItem
@@ -147,4 +237,12 @@ internal class RepoDisplayItem
     public bool Enabled { get; set; }
     public string DisplayLabel { get; init; } = "";
     public string LastFetchedLabel { get; init; } = "";
+}
+
+internal class LocalSourceDisplayItem
+{
+    public string Path { get; init; } = "";
+    public bool Enabled { get; set; }
+    public string DisplayLabel { get; init; } = "";
+    public string PathLabel { get; init; } = "";
 }

--- a/addin/lambda-boss/lambda-boss.csproj
+++ b/addin/lambda-boss/lambda-boss.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="ExcelDna.AddIn" Version="1.*" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
     <PackageReference Include="Taglo.Excel.Common" Version="0.1.*" />
     <PackageReference Include="YamlDotNet" Version="16.*" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

- Adds support for local filesystem directories as LAMBDA sources alongside GitHub repo sources
- Enables pre-merge testing: users point Lambda Boss at their local clone and reload to pick up changes from a development branch
- Local sources always read fresh from disk (no caching) — reload is instant

## Changes

- **LocalSourceConfig** — config model with path + enabled flag
- **LocalDirectorySource** — reads `.lambda` files and `_library.yaml` directly from disk
- **Settings** — new `LocalSources` list with add/remove/enable methods, serialized to settings.json
- **LibraryProvider** — discovers and loads libraries from local sources during refresh
- **Popup UI** — local libraries display with a folder icon to distinguish from GitHub sources
- **Settings window** — new "Local Directory Sources" section for adding/removing paths
- **20 new unit tests** covering all new functionality

## Settings example

```json
{
  "Repos": [...],
  "LocalSources": [
    { "Path": "C:\Users\trjac\repositories\lambda-boss\lambdas", "Enabled": true }
  ]
}
```

## Test plan

- [x] All 102 unit tests pass (82 existing + 20 new)
- [x] Manual: add a local source in Settings, verify libraries appear in popup
- [x] Manual: load a local library, verify LAMBDAs injected into Name Manager
- [x] Manual: modify a .lambda file on disk, reload, verify updated formula

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)