### PR TITLE
Add automated test harness for LAMBDAs

### DIFF
--- a/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
+++ b/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
@@ -1,8 +1,7 @@
+using System.Globalization;
 using System.Runtime.InteropServices;
-
 using Xunit;
 using Xunit.Abstractions;
-
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -11,7 +10,7 @@ namespace LambdaBoss.AddinTests;
 [Collection("Excel Addin")]
 public class LambdaHarnessTests
 {
-    private static readonly HashSet<string> InjectedNames = new();
+    private static readonly HashSet<string> InjectedNames = [];
     private static readonly object InjectionLock = new();
 
     private readonly ExcelAddinFixture _excel;
@@ -44,16 +43,14 @@ public class LambdaHarnessTests
             var suite = deserializer.Deserialize<TestSuite>(yamlContent);
 
             foreach (var test in suite.Tests)
-            {
-                yield return new object[]
-                {
+                yield return
+                [
                     lambdaPath,
                     test.Name,
-                    test.Args ?? new List<object>(),
-                    test.Expected,
+                    test.Args ?? [],
+                    test.Expected ?? "",
                     test.ExpectedType ?? ""
-                };
-            }
+                ];
         }
     }
 
@@ -79,17 +76,11 @@ public class LambdaHarnessTests
                 Thread.Sleep(500);
 
                 if (!string.IsNullOrEmpty(expectedType))
-                {
                     AssertType(cell, expectedType, testName);
-                }
                 else if (expected is List<object> expectedRows)
-                {
                     AssertArray(cell, expectedRows, testName);
-                }
                 else
-                {
                     AssertScalar(cell, expected, testName);
-                }
             }
             finally
             {
@@ -150,7 +141,7 @@ public class LambdaHarnessTests
             // Check that the spill range has more than one cell.
             try
             {
-                dynamic spillRange = cell.SpillingToRange;
+                var spillRange = cell.SpillingToRange;
                 int cellCount = spillRange.Cells.Count;
                 _output.WriteLine($"[{testName}] Spill range has {cellCount} cells");
                 Assert.True(cellCount > 1,
@@ -166,30 +157,27 @@ public class LambdaHarnessTests
             }
         }
         else
-        {
             throw new NotSupportedException($"Unknown expected_type: {expectedType}");
-        }
     }
 
     private void AssertArray(dynamic cell, List<object> expectedRows, string testName)
     {
-        dynamic spillRange = cell.SpillingToRange;
+        var spillRange = cell.SpillingToRange;
         try
         {
             object[,] values = spillRange.Value;
 
-            int actualRows = values.GetLength(0);
-            int actualCols = values.GetLength(1);
+            var actualRows = values.GetLength(0);
+            var actualCols = values.GetLength(1);
             _output.WriteLine($"[{testName}] Array result: {actualRows}x{actualCols}");
 
             Assert.Equal(expectedRows.Count, actualRows);
 
-            for (int r = 0; r < expectedRows.Count; r++)
-            {
+            for (var r = 0; r < expectedRows.Count; r++)
                 if (expectedRows[r] is List<object> cols)
                 {
                     Assert.Equal(cols.Count, actualCols);
-                    for (int c = 0; c < cols.Count; c++)
+                    for (var c = 0; c < cols.Count; c++)
                     {
                         var exp = Convert.ToDouble(cols[c]);
                         var act = Convert.ToDouble(values[r + 1, c + 1]); // COM arrays are 1-based
@@ -204,7 +192,6 @@ public class LambdaHarnessTests
                     Assert.True(Math.Abs(exp - act) < 1e-10,
                         $"[{testName}] [{r}] Expected {exp} but got {act}");
                 }
-            }
         }
         finally
         {
@@ -218,7 +205,7 @@ public class LambdaHarnessTests
         {
             bool b => b ? "TRUE" : "FALSE",
             string s => $"\"{s}\"",
-            _ => Convert.ToString(arg, System.Globalization.CultureInfo.InvariantCulture) ?? ""
+            _ => Convert.ToString(arg, CultureInfo.InvariantCulture) ?? ""
         };
     }
 
@@ -229,8 +216,10 @@ public class LambdaHarnessTests
         var lambdasDir = Path.Combine(repoRoot, "lambdas");
 
         if (!Directory.Exists(lambdasDir))
+        {
             throw new DirectoryNotFoundException(
                 $"Could not find lambdas directory. Searched: {lambdasDir}");
+        }
 
         return lambdasDir;
     }
@@ -238,7 +227,7 @@ public class LambdaHarnessTests
 
 public class TestSuite
 {
-    public List<TestCase> Tests { get; set; } = new();
+    public List<TestCase> Tests { get; set; } = [];
 }
 
 public class TestCase

--- a/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
+++ b/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
@@ -1,0 +1,250 @@
+using System.Runtime.InteropServices;
+
+using Xunit;
+using Xunit.Abstractions;
+
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace LambdaBoss.AddinTests;
+
+[Collection("Excel Addin")]
+public class LambdaHarnessTests
+{
+    private static readonly HashSet<string> InjectedNames = new();
+    private static readonly object InjectionLock = new();
+
+    private readonly ExcelAddinFixture _excel;
+    private readonly ITestOutputHelper _output;
+
+    public LambdaHarnessTests(ExcelAddinFixture excel, ITestOutputHelper output)
+    {
+        _excel = excel;
+        _output = output;
+    }
+
+    public static IEnumerable<object[]> TestCases()
+    {
+        var lambdasDir = FindLambdasDirectory();
+        var yamlFiles = Directory.GetFiles(lambdasDir, "*.tests.yaml", SearchOption.AllDirectories);
+
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .Build();
+
+        foreach (var yamlPath in yamlFiles)
+        {
+            var lambdaFileName = Path.GetFileName(yamlPath).Replace(".tests.yaml", ".lambda");
+            var lambdaPath = Path.Combine(Path.GetDirectoryName(yamlPath)!, lambdaFileName);
+
+            if (!File.Exists(lambdaPath))
+                continue;
+
+            var yamlContent = File.ReadAllText(yamlPath);
+            var suite = deserializer.Deserialize<TestSuite>(yamlContent);
+
+            foreach (var test in suite.Tests)
+            {
+                yield return new object[]
+                {
+                    lambdaPath,
+                    test.Name,
+                    test.Args ?? new List<object>(),
+                    test.Expected,
+                    test.ExpectedType ?? ""
+                };
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void LambdaTest(string lambdaPath, string testName, List<object> args,
+        object? expected, string expectedType)
+    {
+        var (name, formula) = LambdaParser.ParseFile(lambdaPath);
+        EnsureInjected(name, formula);
+
+        var argsStr = string.Join(",", args.Select(FormatArg));
+        var cellFormula = $"={name}({argsStr})";
+        _output.WriteLine($"[{testName}] {cellFormula}");
+
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            var cell = ws.Range["A1"];
+            try
+            {
+                cell.Formula2 = cellFormula;
+                Thread.Sleep(500);
+
+                if (!string.IsNullOrEmpty(expectedType))
+                {
+                    AssertType(cell, expectedType, testName);
+                }
+                else if (expected is List<object> expectedRows)
+                {
+                    AssertArray(cell, expectedRows, testName);
+                }
+                else
+                {
+                    AssertScalar(cell, expected, testName);
+                }
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(cell);
+            }
+        }
+        finally
+        {
+            try
+            {
+                ws.Delete();
+                Marshal.ReleaseComObject(ws);
+            }
+            catch
+            {
+                // Ignore cleanup
+            }
+        }
+    }
+
+    private void EnsureInjected(string name, string formula)
+    {
+        lock (InjectionLock)
+        {
+            if (InjectedNames.Contains(name))
+                return;
+
+            _output.WriteLine($"Injecting {name}: {formula[..Math.Min(80, formula.Length)]}...");
+            _excel.Workbook.Names.Add(name, formula);
+            InjectedNames.Add(name);
+        }
+    }
+
+    private void AssertScalar(dynamic cell, object? expected, string testName)
+    {
+        object? actual = cell.Value;
+        _output.WriteLine($"[{testName}] Expected: {expected}, Actual: {actual}");
+
+        if (expected == null)
+        {
+            Assert.Null(actual);
+            return;
+        }
+
+        var expectedDouble = Convert.ToDouble(expected);
+        var actualDouble = Convert.ToDouble(actual);
+
+        Assert.True(
+            Math.Abs(expectedDouble - actualDouble) < 1e-10,
+            $"[{testName}] Expected {expectedDouble} but got {actualDouble}");
+    }
+
+    private void AssertType(dynamic cell, string expectedType, string testName)
+    {
+        if (expectedType == "array")
+        {
+            // A dynamic array formula spills into multiple cells.
+            // Check that the spill range has more than one cell.
+            try
+            {
+                dynamic spillRange = cell.SpillingToRange;
+                int cellCount = spillRange.Cells.Count;
+                _output.WriteLine($"[{testName}] Spill range has {cellCount} cells");
+                Assert.True(cellCount > 1,
+                    $"[{testName}] Expected array result (spill range > 1 cell), but got {cellCount} cell(s)");
+                Marshal.ReleaseComObject(spillRange);
+            }
+            catch (COMException)
+            {
+                // SpillingToRange may not be available; fall back to checking the value
+                object? val = cell.Value;
+                _output.WriteLine($"[{testName}] SpillingToRange not available, value type: {val?.GetType().Name}");
+                Assert.NotNull(val);
+            }
+        }
+        else
+        {
+            throw new NotSupportedException($"Unknown expected_type: {expectedType}");
+        }
+    }
+
+    private void AssertArray(dynamic cell, List<object> expectedRows, string testName)
+    {
+        dynamic spillRange = cell.SpillingToRange;
+        try
+        {
+            object[,] values = spillRange.Value;
+
+            int actualRows = values.GetLength(0);
+            int actualCols = values.GetLength(1);
+            _output.WriteLine($"[{testName}] Array result: {actualRows}x{actualCols}");
+
+            Assert.Equal(expectedRows.Count, actualRows);
+
+            for (int r = 0; r < expectedRows.Count; r++)
+            {
+                if (expectedRows[r] is List<object> cols)
+                {
+                    Assert.Equal(cols.Count, actualCols);
+                    for (int c = 0; c < cols.Count; c++)
+                    {
+                        var exp = Convert.ToDouble(cols[c]);
+                        var act = Convert.ToDouble(values[r + 1, c + 1]); // COM arrays are 1-based
+                        Assert.True(Math.Abs(exp - act) < 1e-10,
+                            $"[{testName}] [{r},{c}] Expected {exp} but got {act}");
+                    }
+                }
+                else
+                {
+                    var exp = Convert.ToDouble(expectedRows[r]);
+                    var act = Convert.ToDouble(values[r + 1, 1]);
+                    Assert.True(Math.Abs(exp - act) < 1e-10,
+                        $"[{testName}] [{r}] Expected {exp} but got {act}");
+                }
+            }
+        }
+        finally
+        {
+            Marshal.ReleaseComObject(spillRange);
+        }
+    }
+
+    private static string FormatArg(object arg)
+    {
+        return arg switch
+        {
+            bool b => b ? "TRUE" : "FALSE",
+            string s => $"\"{s}\"",
+            _ => Convert.ToString(arg, System.Globalization.CultureInfo.InvariantCulture) ?? ""
+        };
+    }
+
+    private static string FindLambdasDirectory()
+    {
+        var testDir = AppContext.BaseDirectory;
+        var repoRoot = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "..", ".."));
+        var lambdasDir = Path.Combine(repoRoot, "lambdas");
+
+        if (!Directory.Exists(lambdasDir))
+            throw new DirectoryNotFoundException(
+                $"Could not find lambdas directory. Searched: {lambdasDir}");
+
+        return lambdasDir;
+    }
+}
+
+public class TestSuite
+{
+    public List<TestCase> Tests { get; set; } = new();
+}
+
+public class TestCase
+{
+    public string Name { get; set; } = "";
+    public List<object>? Args { get; set; }
+    public object? Expected { get; set; }
+    public string? ExpectedType { get; set; }
+}

--- a/addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj
+++ b/addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj
@@ -18,4 +18,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\lambda-boss\lambda-boss.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+  </ItemGroup>
+
 </Project>

--- a/addin/lambda-boss.Tests/LambdaFormatTests.cs
+++ b/addin/lambda-boss.Tests/LambdaFormatTests.cs
@@ -1,13 +1,12 @@
-using System.IO;
-using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Xunit;
 
 namespace LambdaBoss.Tests;
 
 /// <summary>
-/// Validates that all .lambda files conform to the required format.
-/// Runs in CI — no Excel required.
+///     Validates that all .lambda files conform to the required format.
+///     Runs in CI — no Excel required.
 /// </summary>
 public class LambdaFormatTests
 {
@@ -24,17 +23,17 @@ public class LambdaFormatTests
                 return candidate;
             dir = Directory.GetParent(dir)?.FullName;
         }
-        throw new DirectoryNotFoundException("Could not find 'lambdas' directory from " + Directory.GetCurrentDirectory());
+
+        throw new DirectoryNotFoundException("Could not find 'lambdas' directory from " +
+                                             Directory.GetCurrentDirectory());
     }
 
     public static TheoryData<string> LambdaFiles()
     {
         var data = new TheoryData<string>();
         foreach (var file in Directory.EnumerateFiles(LambdasRoot, "*.lambda", SearchOption.AllDirectories))
-        {
             // Store path relative to the lambdas root for readable test names
             data.Add(Path.GetRelativePath(LambdasRoot, file));
-        }
         return data;
     }
 
@@ -105,7 +104,7 @@ public class LambdaFormatTests
     {
         // Read raw bytes to detect \r before any normalisation
         var bytes = File.ReadAllBytes(Path.Combine(LambdasRoot, relativePath));
-        var raw = System.Text.Encoding.UTF8.GetString(bytes);
+        var raw = Encoding.UTF8.GetString(bytes);
 
         Assert.DoesNotContain("\r", raw);
     }
@@ -135,7 +134,7 @@ public class LambdaFormatTests
     }
 
     /// <summary>
-    /// Extracts the lambda name from the first "Name = LAMBDA(" assignment line.
+    ///     Extracts the lambda name from the first "Name = LAMBDA(" assignment line.
     /// </summary>
     private static string? GetNameAssignment(string content)
     {
@@ -144,12 +143,12 @@ public class LambdaFormatTests
     }
 
     /// <summary>
-    /// Returns the first line that isn't a block comment or inside a block comment.
+    ///     Returns the first line that isn't a block comment or inside a block comment.
     /// </summary>
     private static string? GetFirstNonCommentLine(string content)
     {
         var lines = content.Split('\n');
-        bool inBlock = false;
+        var inBlock = false;
         foreach (var rawLine in lines)
         {
             var line = rawLine.TrimEnd('\r');
@@ -170,12 +169,13 @@ public class LambdaFormatTests
             {
                 if (!line.Contains("*/"))
                     inBlock = true;
-                else if (line.LastIndexOf("*/") < line.Length - 2)
+                else if (line.LastIndexOf("*/", StringComparison.Ordinal) < line.Length - 2)
                 {
                     // There's content after the closing */ on the same line —
                     // but in the header format this is another comment line
                     // Check if there's meaningful non-comment content after last */
                 }
+
                 continue;
             }
 
@@ -185,6 +185,7 @@ public class LambdaFormatTests
 
             return line.Trim();
         }
+
         return null;
     }
 }

--- a/addin/lambda-boss/UI/SettingsWindow.xaml.cs
+++ b/addin/lambda-boss/UI/SettingsWindow.xaml.cs
@@ -1,8 +1,8 @@
+using Ookii.Dialogs.Wpf;
 using System.ComponentModel;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
-
-using Ookii.Dialogs.Wpf;
 
 namespace LambdaBoss.UI;
 
@@ -107,7 +107,7 @@ public partial class SettingsWindow
 
     private void RemoveRepoButton_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not System.Windows.Controls.Button { Tag: string url })
+        if (sender is not Button { Tag: string url })
             return;
 
         var settings = Settings.Current;
@@ -128,7 +128,7 @@ public partial class SettingsWindow
 
     private void RepoEnabledCheckbox_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not System.Windows.Controls.CheckBox { DataContext: RepoDisplayItem item })
+        if (sender is not CheckBox { DataContext: RepoDisplayItem item })
             return;
 
         var settings = Settings.Current;
@@ -165,7 +165,7 @@ public partial class SettingsWindow
         if (string.IsNullOrEmpty(path))
             return;
 
-        if (!System.IO.Directory.Exists(path))
+        if (!Directory.Exists(path))
         {
             StatusText.Text = "Directory does not exist";
             return;
@@ -198,10 +198,7 @@ public partial class SettingsWindow
             UseDescriptionForTitle = true
         };
 
-        if (dialog.ShowDialog() == true)
-        {
-            LocalPathBox.Text = dialog.SelectedPath;
-        }
+        if (dialog.ShowDialog() == true) LocalPathBox.Text = dialog.SelectedPath;
     }
 
     private void LocalPathBox_KeyDown(object sender, KeyEventArgs e)
@@ -213,9 +210,9 @@ public partial class SettingsWindow
         }
     }
 
-private void RemoveLocalButton_Click(object sender, RoutedEventArgs e)
+    private void RemoveLocalButton_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not System.Windows.Controls.Button { Tag: string path })
+        if (sender is not Button { Tag: string path })
             return;
 
         var settings = Settings.Current;
@@ -230,7 +227,7 @@ private void RemoveLocalButton_Click(object sender, RoutedEventArgs e)
 
     private void LocalEnabledCheckbox_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not System.Windows.Controls.CheckBox { DataContext: LocalSourceDisplayItem item })
+        if (sender is not CheckBox { DataContext: LocalSourceDisplayItem item })
             return;
 
         var settings = Settings.Current;

--- a/lambdas/math/Clamp.tests.yaml
+++ b/lambdas/math/Clamp.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: clamp high
+    args: [15, 0, 10]
+    expected: 10
+
+  - name: clamp low
+    args: [-5, 0, 10]
+    expected: 0
+
+  - name: within range
+    args: [5, 0, 10]
+    expected: 5
+
+  - name: at minimum
+    args: [0, 0, 10]
+    expected: 0
+
+  - name: at maximum
+    args: [10, 0, 10]
+    expected: 10
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/math/Lerp.tests.yaml
+++ b/lambdas/math/Lerp.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: lerp at 0
+    args: [0, 100, 0]
+    expected: 0
+
+  - name: lerp at 1
+    args: [0, 100, 1]
+    expected: 100
+
+  - name: lerp at 0.25
+    args: [0, 100, 0.25]
+    expected: 25
+
+  - name: lerp at 0.5
+    args: [0, 100, 0.5]
+    expected: 50
+
+  - name: lerp negative range
+    args: [-10, 10, 0.5]
+    expected: 0
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/math/RoundTo.tests.yaml
+++ b/lambdas/math/RoundTo.tests.yaml
@@ -1,0 +1,20 @@
+tests:
+  - name: round to 2 decimals
+    args: [3.14159, 2]
+    expected: 3.14
+
+  - name: round to 0 decimals
+    args: [3.7, 0]
+    expected: 4
+
+  - name: round to 4 decimals
+    args: [1.23456789, 4]
+    expected: 1.2346
+
+  - name: round negative
+    args: [-2.567, 1]
+    expected: -2.6
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/test/AddN.tests.yaml
+++ b/lambdas/test/AddN.tests.yaml
@@ -1,0 +1,16 @@
+tests:
+  - name: add 3 to 5
+    args: [5, 3]
+    expected: 8
+
+  - name: add 0
+    args: [7, 0]
+    expected: 7
+
+  - name: add negative
+    args: [10, -4]
+    expected: 6
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/test/Double.tests.yaml
+++ b/lambdas/test/Double.tests.yaml
@@ -1,0 +1,16 @@
+tests:
+  - name: double 5
+    args: [5]
+    expected: 10
+
+  - name: double 0
+    args: [0]
+    expected: 0
+
+  - name: double negative
+    args: [-3]
+    expected: -6
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/test/Triple.tests.yaml
+++ b/lambdas/test/Triple.tests.yaml
@@ -1,0 +1,16 @@
+tests:
+  - name: triple 5
+    args: [5]
+    expected: 15
+
+  - name: triple 0
+    args: [0]
+    expected: 0
+
+  - name: triple negative
+    args: [-2]
+    expected: -6
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Closes #19

- Adds `LambdaHarnessTests` in `lambda-boss.AddinTests` that discovers `.tests.yaml` companion files, injects the corresponding LAMBDA into Excel, evaluates test cases, and asserts results
- Supports scalar comparison (with `1e-10` tolerance), 2D array comparison, and type checks (`expected_type: array` for help text)
- Adds `.tests.yaml` files for all 6 existing lambdas: Double, Triple, AddN, Clamp, Lerp, RoundTo
- Uses `[Theory]` with `[MemberData]` for per-test-case reporting in xUnit

## Test plan

- [x] Build: `dotnet build addin/lambda-boss.slnx`
- [x] Unit tests still pass: `dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj`
- [x] Run harness tests with Excel: `dotnet test addin/lambda-boss.AddinTests --filter LambdaHarnessTests`
- [x] Verify each lambda's scalar tests pass (correct computation)
- [x] Verify help text tests pass (returns spill array when called with no args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)