### PR TITLE
Add BICOL and BIROW lambdas

### DIFF
--- a/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
+++ b/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
@@ -211,6 +211,7 @@ public class LambdaHarnessTests
         return arg switch
         {
             bool b => b ? "TRUE" : "FALSE",
+            string s when s.StartsWith("=") => s[1..],
             string s => $"\"{s}\"",
             _ => Convert.ToString(arg, CultureInfo.InvariantCulture) ?? ""
         };

--- a/lambdas/array/BICOL.lambda
+++ b/lambdas/array/BICOL.lambda
@@ -1,0 +1,36 @@
+/*  FUNCTION NAME:      BICOL
+    DESCRIPTION:*//**Applies a LAMBDA to each column of an array, preserving the full array shape.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-04-13  Tim Jacks   Initial version
+*/
+BICOL = LAMBDA(
+//  Parameter Declarations
+    [array],
+    [function],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →BICOL(array, function)¶" &
+                "DESCRIPTION:   →Applies a LAMBDA to each column of an array, preserving the full array shape.¶" &
+                "VERSION:       →Apr 13 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   array          →(Required) A 2D array.¶" &
+                "   function       →(Required) A LAMBDA that takes a single column and returns an array of the same size.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=BICOL({1,2,3;4,5,6}, LAMBDA(c, c*2))¶" &
+                "Result         →{2,4,6;8,10,12}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(array),
+    //  Procedure
+        result, IF(
+                    COLUMNS(array) = 1,
+                    IF(ROWS(array) = 1, function(@array), function(array)),
+                    HSTACK(
+                        BICOL(TAKE(array, , COLUMNS(array) / 2), function),
+                        BICOL(DROP(array, , COLUMNS(array) / 2), function)
+                    )
+                ),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/BICOL.tests.yaml
+++ b/lambdas/array/BICOL.tests.yaml
@@ -1,0 +1,20 @@
+tests:
+  - name: double each column value
+    args: ["={1,2,3;4,5,6}", "=LAMBDA(c, c*2)"]
+    expected: [[2, 4, 6], [8, 10, 12]]
+
+  - name: single column array
+    args: ["={1;2;3}", "=LAMBDA(c, c+10)"]
+    expected: [[11], [12], [13]]
+
+  - name: single cell array
+    args: ["={5}", "=LAMBDA(c, c*3)"]
+    expected: 15
+
+  - name: single row multi column
+    args: ["={10,20,30}", "=LAMBDA(c, c/10)"]
+    expected: [[1, 2, 3]]
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/array/BIROW.lambda
+++ b/lambdas/array/BIROW.lambda
@@ -1,0 +1,36 @@
+/*  FUNCTION NAME:      BIROW
+    DESCRIPTION:*//**Applies a LAMBDA to each row of an array, preserving the full array shape.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-04-13  Tim Jacks   Initial version
+*/
+BIROW = LAMBDA(
+//  Parameter Declarations
+    [array],
+    [function],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →BIROW(array, function)¶" &
+                "DESCRIPTION:   →Applies a LAMBDA to each row of an array, preserving the full array shape.¶" &
+                "VERSION:       →Apr 13 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   array          →(Required) A 2D array.¶" &
+                "   function       →(Required) A LAMBDA that takes a single row and returns an array of the same size.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=BIROW({1,2,3;4,5,6}, LAMBDA(r, r*2))¶" &
+                "Result         →{2,4,6;8,10,12}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(array),
+    //  Procedure
+        result, IF(
+                    ROWS(array) = 1,
+                    IF(COLUMNS(array) = 1, function(@array), function(array)),
+                    VSTACK(
+                        BIROW(TAKE(array, ROWS(array) / 2), function),
+                        BIROW(DROP(array, ROWS(array) / 2), function)
+                    )
+                ),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/BIROW.tests.yaml
+++ b/lambdas/array/BIROW.tests.yaml
@@ -1,0 +1,20 @@
+tests:
+  - name: double each row value
+    args: ["={1,2,3;4,5,6}", "=LAMBDA(r, r*2)"]
+    expected: [[2, 4, 6], [8, 10, 12]]
+
+  - name: single row array
+    args: ["={1,2,3}", "=LAMBDA(r, r+10)"]
+    expected: [[11, 12, 13]]
+
+  - name: single cell array
+    args: ["={5}", "=LAMBDA(r, r*3)"]
+    expected: 15
+
+  - name: single column multi row
+    args: ["={10;20;30}", "=LAMBDA(r, r/10)"]
+    expected: [[1], [2], [3]]
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/array/_library.yaml
+++ b/lambdas/array/_library.yaml
@@ -1,0 +1,3 @@
+name: Array
+description: Array manipulation and transformation utilities
+default_prefix: array


### PR DESCRIPTION
## Summary
- Adds **BICOL** and **BIROW** lambdas in new `lambdas/array/` category — recursive divide-and-conquer functions that apply a LAMBDA to each column or row of an array, preserving the full array shape
- Adds raw expression support (`=` prefix) to test harness `FormatArg` so array literals and LAMBDA expressions can be passed unquoted in `.tests.yaml` files
- Includes functional test cases for both lambdas (normal, single-col/row, single-cell, help text)

Closes #38

## Test plan
- [x] Format validation: 72 tests pass
- [x] Functional tests in Excel: all 46 harness tests pass (10 new + 36 existing)
- [x] Manual verification in Excel with cumulative sum / normalise examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)