### PR TITLE
Add MAXOF and MINOF lambdas

### DIFF
--- a/lambdas/array/MAXOF.lambda
+++ b/lambdas/array/MAXOF.lambda
@@ -1,0 +1,32 @@
+/*  FUNCTION NAME:      MAXOF
+    DESCRIPTION:*//**Returns the label corresponding to the largest value in a range.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-04-13  Claude      Initial version
+*/
+MAXOF = LAMBDA(
+//  Parameter Declarations
+    [values],
+    [labels],
+    [sentinel],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →MAXOF(values, labels, sentinel)¶" &
+                "DESCRIPTION:   →Returns the label corresponding to the largest value in a range.¶" &
+                "VERSION:       →Apr 13 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   values         →(Required) A 1D range of numeric values.¶" &
+                "   labels         →(Required) A 1D range of labels, same size as values.¶" &
+                "   sentinel       →(Optional) Lookup value for approximate match. Default: 10^10.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=MAXOF({33,6,21,12}, {""Harry"",""Evie"",""Hugh"",""James""})¶" &
+                "Result         →Harry",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(values),
+        _sentinel, IF(ISOMITTED(sentinel), 10^10, sentinel),
+    //  Procedure
+        result, XLOOKUP(_sentinel, values, labels, , -1),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/MAXOF.tests.yaml
+++ b/lambdas/array/MAXOF.tests.yaml
@@ -1,0 +1,20 @@
+tests:
+  - name: basic max lookup
+    args: ["={33,6,21,12}", '={"Harry","Evie","Hugh","James"}']
+    expected: Harry
+
+  - name: single element
+    args: ["={42}", '={"Solo"}']
+    expected: Solo
+
+  - name: tied values returns first match
+    args: ["={10,10,5}", '={"Alpha","Beta","Gamma"}']
+    expected: Alpha
+
+  - name: negative values
+    args: ["={-3,-1,-7}", '={"A","B","C"}']
+    expected: B
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/array/MINOF.lambda
+++ b/lambdas/array/MINOF.lambda
@@ -1,0 +1,29 @@
+/*  FUNCTION NAME:      MINOF
+    DESCRIPTION:*//**Returns the label corresponding to the smallest value in a range.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-04-13  Claude      Initial version
+*/
+MINOF = LAMBDA(
+//  Parameter Declarations
+    [values],
+    [labels],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →MINOF(values, labels)¶" &
+                "DESCRIPTION:   →Returns the label corresponding to the smallest value in a range.¶" &
+                "VERSION:       →Apr 13 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   values         →(Required) A 1D range of numeric values.¶" &
+                "   labels         →(Required) A 1D range of labels, same size as values.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=MINOF({33,6,21,12}, {""Harry"",""Evie"",""Hugh"",""James""})¶" &
+                "Result         →Evie",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(values),
+    //  Procedure
+        result, INDEX(labels, MATCH(MIN(values), values, 0)),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/MINOF.lambda
+++ b/lambdas/array/MINOF.lambda
@@ -23,7 +23,7 @@ MINOF = LAMBDA(
     //  Check inputs
         Help?, ISOMITTED(values),
     //  Procedure
-        result, INDEX(labels, MATCH(MIN(values), values, 0)),
+        result, INDEX(labels, XMATCH(MIN(values), values)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/array/MINOF.tests.yaml
+++ b/lambdas/array/MINOF.tests.yaml
@@ -1,0 +1,20 @@
+tests:
+  - name: basic min lookup
+    args: ["={33,6,21,12}", '={"Harry","Evie","Hugh","James"}']
+    expected: Evie
+
+  - name: single element
+    args: ["={42}", '={"Solo"}']
+    expected: Solo
+
+  - name: tied values returns first match
+    args: ["={5,5,10}", '={"Alpha","Beta","Gamma"}']
+    expected: Alpha
+
+  - name: negative values
+    args: ["={-3,-1,-7}", '={"A","B","C"}']
+    expected: C
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary
- **MAXOF**: Returns the label corresponding to the largest value in a parallel range, using `XLOOKUP` with approximate match (sentinel defaults to 10^10)
- **MINOF**: Returns the label corresponding to the smallest value in a parallel range, using `INDEX/MATCH` on `MIN(values)` (XLOOKUP match_mode 1 returned #N/A on unsorted data)
- Both include full Help text and test suites

Closes #34
Closes #35

## Test plan
- [x] Format validation tests pass (96/96)
- [x] Functional tests pass in Excel (65/65)
- [ ] Manual verification in Excel with real-world data

🤖 Generated with [Claude Code](https://claude.com/claude-code)