### PR TITLE
Add outbound sync to manage-ideas skill

### DIFF
--- a/.claude/skills/manage-ideas/SKILL.md
+++ b/.claude/skills/manage-ideas/SKILL.md
@@ -1,27 +1,83 @@
 ---
 name: manage-ideas
-description: "Sync LAMBDA ideas from Notion to GitHub Issues. Usage: /manage-ideas"
-allowed-tools: Bash, Read, Glob, Grep, mcp__claude_ai_Notion__notion-fetch, mcp__claude_ai_Notion__notion-search, mcp__claude_ai_Notion__notion-create-pages, mcp__claude_ai_Notion__notion-move-pages
+description: "Sync LAMBDA ideas between Notion and GitHub Issues, and refresh the Current Lambdas catalogue in Notion. Usage: /manage-ideas"
+allowed-tools: Bash, Read, Glob, Grep, mcp__claude_ai_Notion__notion-fetch, mcp__claude_ai_Notion__notion-search, mcp__claude_ai_Notion__notion-create-pages, mcp__claude_ai_Notion__notion-move-pages, mcp__claude_ai_Notion__notion-update-page
 ---
 
 # Manage Ideas — lambda-boss
 
-Sync LAMBDA ideas from Notion to GitHub Issues, completing the idea capture bridge.
+Keep the Notion ⇄ GitHub idea bridge in sync, in both directions:
+
+- **Inbound**: sync new LAMBDA ideas from Notion to GitHub Issues.
+- **Outbound**: refresh the "Current Lambdas" Notion page with the LAMBDAs already shipped in this repo, so new ideas can be vetted for duplication.
+
+## Key Notion page IDs
+
+| Page | ID |
+| --- | --- |
+| Excel eSports (parent) | `3407b3d23d2f80e49224f99b577224db` |
+| LAMBDA ideas (inbox) | `3407b3d23d2f80aa9ac4e4903868d7c8` |
+| Current Lambdas (catalogue) | `3437b3d23d2f819595bac162a5268640` |
+| Synced to GitHub (archive, child of LAMBDA ideas) | discovered at runtime — created if missing |
 
 ## Flow
 
-1. Fetch the "LAMBDA ideas" Notion page (ID: `3407b3d23d2f80aa9ac4e4903868d7c8`)
-2. Identify child pages — these are unsynced idea pages
-3. Ignore any child page titled "Synced to GitHub" — that is the archive folder
-4. For each unsynced idea page:
-   a. Fetch the full page content
-   b. Create a GitHub Issue on `TagloGit/lambda-boss` with the idea content
-   c. Move the Notion page into the "Synced to GitHub" child page
-5. Report what was synced
+1. **Refresh Current Lambdas** — rebuild the Notion catalogue from the repo so the Outbound view is current.
+2. **Sync ideas inbound** — fetch `LAMBDA ideas`, create GitHub Issues for any unsynced child pages, move them to `Synced to GitHub`.
+3. Report what was done in both directions.
 
-## Instructions
+---
 
-### Step 1 — Fetch the LAMBDA ideas page
+## Part A — Refresh "Current Lambdas" (Outbound)
+
+### A1 — Enumerate the LAMBDAs in the repo
+
+Use Glob on `lambdas/**/*.lambda`. Group by the library folder (e.g. `array`, `string`). For each library, also read `lambdas/<library>/_library.yaml` to get its `name` and `description`.
+
+For every `.lambda` file, extract:
+
+- **Name** — the function name, from the `FUNCTION NAME:` header.
+- **Description** — the one-line blurb inside the `/**...*/` JavaDoc comment on line 2.
+- **Calculation** — the meaningful formula logic from the `//  Procedure` section, **excluding**:
+  - the `Help` TEXTSPLIT block,
+  - the `//  Check inputs` bindings (`Help?`, `ISOMITTED(...)` guards, default-value normalisers like `IF(ISOMITTED(x), default, x)`),
+  - the final `IF(Help?, Help, result)` return.
+
+Collapse to a compact inline formula. Intermediate LET bindings can be inlined or described in prose (e.g. "… where `_count = CEILING(LEN(text)/_size, 1)`"). Aim for a single backticked expression per row; use prose only when inlining would hurt readability.
+
+### A2 — Build the page content
+
+Produce Notion-flavoured Markdown with one H2 per library (sorted alphabetically by library name), each containing:
+
+- The library's `description` in italics.
+- A three-column table: **Name** | **Description** | **Calculation**.
+
+Rows sorted alphabetically by LAMBDA name.
+
+Header block at the top of the page:
+
+```markdown
+Catalogue of LAMBDAs already implemented in [TagloGit/lambda-boss](https://github.com/TagloGit/lambda-boss). Check this list before proposing new LAMBDA ideas to avoid duplicates.
+
+_Last synced: <YYYY-MM-DD>_
+```
+
+### A3 — Replace the Current Lambdas page content
+
+```
+notion-update-page
+  page_id: 3437b3d23d2f819595bac162a5268640
+  command: replace_content
+  new_str: <the markdown from A2>
+```
+
+Use `replace_content` (not `update_content`) so the page is fully rebuilt each run — this is the source of truth.
+
+---
+
+## Part B — Sync ideas inbound (Notion → GitHub)
+
+### B1 — Fetch the LAMBDA ideas page
 
 ```
 notion-fetch id: 3407b3d23d2f80aa9ac4e4903868d7c8
@@ -29,13 +85,13 @@ notion-fetch id: 3407b3d23d2f80aa9ac4e4903868d7c8
 
 Parse the child pages from the `<content>` block. Each `<page>` element is a potential idea. Extract the page URL/ID and title.
 
-Skip any child page whose title is "Synced to GitHub" — this is the archive container.
+Skip any child page titled "Synced to GitHub" — this is the archive container.
 
-If there are no unsynced child pages, report "No new ideas to sync" and stop.
+If there are no unsynced child pages, skip to Part C.
 
-### Step 2 — Ensure "Synced to GitHub" page exists
+### B2 — Ensure "Synced to GitHub" archive page exists
 
-Check if a child page titled "Synced to GitHub" already exists under the LAMBDA ideas page (from Step 1 results).
+Check whether a child page titled "Synced to GitHub" already exists under the LAMBDA ideas page (from Step B1 results).
 
 If it does NOT exist, create it:
 
@@ -45,9 +101,9 @@ notion-create-pages
   pages: [{ properties: { "title": "Synced to GitHub" }, content: "Archive of LAMBDA ideas that have been synced to GitHub Issues." }]
 ```
 
-Save the page ID of the "Synced to GitHub" page for use in Step 4.
+Save the page ID of the "Synced to GitHub" page for use in Step B4.
 
-### Step 3 — For each unsynced idea page
+### B3 — For each unsynced idea page
 
 Fetch the full content of the idea page:
 
@@ -55,7 +111,12 @@ Fetch the full content of the idea page:
 notion-fetch id: <page-id>
 ```
 
-Convert the Notion content into a GitHub Issue body using this template:
+**Duplicate check** — compare the idea's title/intent against the Current Lambdas catalogue you just rebuilt in Part A. If it clearly duplicates an existing LAMBDA, do NOT create an issue. Instead:
+
+- Leave the Notion page where it is (do not archive it).
+- Add it to the "Skipped (duplicates)" section of the final report, noting the existing LAMBDA it matches.
+
+Otherwise, convert the Notion content into a GitHub Issue body:
 
 ```markdown
 ## Origin
@@ -67,16 +128,7 @@ Synced from Notion: [<page-title>](<page-url>)
 <paste the idea page content here, converted to GitHub-flavoured markdown>
 ```
 
-Create the GitHub Issue:
-
-```bash
-gh issue create -R TagloGit/lambda-boss \
-  --title "<page-title>" \
-  --label "enhancement" --label "lambda-idea" --label "status: backlog" \
-  --body "<issue-body>"
-```
-
-Use a HEREDOC for the body to preserve formatting:
+Create the GitHub Issue with a HEREDOC body:
 
 ```bash
 gh issue create -R TagloGit/lambda-boss \
@@ -94,7 +146,7 @@ EOF
 )"
 ```
 
-### Step 4 — Move synced page to archive
+### B4 — Move synced page to archive
 
 After the issue is created successfully, move the Notion page to "Synced to GitHub":
 
@@ -104,26 +156,36 @@ notion-move-pages
   new_parent: { type: "page_id", page_id: "<synced-to-github-page-id>" }
 ```
 
-### Step 5 — Report results
+---
 
-Summarise what was done:
+## Part C — Report results
+
+Summarise both directions:
 
 ```
+Current Lambdas refreshed: N LAMBDAs across M libraries.
+
 Synced N idea(s) from Notion to GitHub:
 - "Weighted Score Calculator" -> TagloGit/lambda-boss#NN
+
+Skipped as duplicates:
+- "Running Total" — matches existing CUMSUMGRID
 ```
 
-If nothing was synced: "No new ideas to sync."
+If nothing was synced and nothing was skipped: "No new ideas to sync."
+If the catalogue was unchanged from last run, still report "Current Lambdas refreshed".
 
 ## Idempotency
 
 This skill is safe to run repeatedly:
-- Ideas already moved to "Synced to GitHub" won't appear as child pages of "LAMBDA ideas" on the next run
-- The "Synced to GitHub" page is created only if it doesn't exist
+- Part A rebuilds the catalogue every run — content is replaced, not appended.
+- Ideas already moved to "Synced to GitHub" won't appear as child pages of "LAMBDA ideas" on the next run.
+- The "Synced to GitHub" page is created only if it doesn't exist.
 
 ## Behaviour Notes
 
-- Do NOT modify the content of idea pages — sync them as-is
-- Do NOT create specs or plans from ideas — they go to the backlog for triage
-- Strip the "LAMBDA: " prefix from page titles when creating issue titles (use "LAMBDA idea: <name>" format)
-- If a Notion page fetch fails, skip it and report the error — don't stop the whole sync
+- Do NOT modify the content of idea pages — sync them as-is.
+- Do NOT create specs or plans from ideas — they go to the backlog for triage.
+- Strip the "LAMBDA: " prefix from page titles when creating issue titles (use "LAMBDA idea: <name>" format).
+- If a Notion page fetch fails, skip it and report the error — don't stop the whole sync.
+- When extracting the Calculation column, prefer fidelity over prettiness — the reader is checking for duplicate *logic*, so the formula must be recognisable, not necessarily runnable.


### PR DESCRIPTION
## Summary

- Extend `/manage-ideas` with an outbound sync step that rebuilds a **Current Lambdas** catalogue page in Notion from the repo's `.lambda` files.
- Page lives at https://www.notion.so/3437b3d23d2f819595bac162a5268640 (sibling of the existing LAMBDA ideas inbox, under Excel eSports).
- Table has three columns: Name, Description, Calculation — the Calculation column strips Help/input-check boilerplate and shows the core formula so duplicates can be spotted at a glance.
- New duplicate-check step: if an inbound Notion idea matches something in the freshly-rebuilt catalogue, skip the GitHub issue and leave the Notion page in place.
- Key Notion page IDs collected in a table at the top of the skill for easy reference.

The catalogue page has already been seeded manually; on the next `/manage-ideas` run it will be rebuilt from code.

## Test plan

- [x] Run `/manage-ideas` with no new idea pages — catalogue is refreshed, report says no ideas to sync.
- [x] Drop a new idea page in Notion, run `/manage-ideas` — catalogue refreshed, issue created, page moved to Synced to GitHub.
- [x] Drop a Notion idea that duplicates an existing LAMBDA (e.g. "running cumulative sum") — skipped with a note in the report, page stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)