### PR TITLE
Add CELLTOPOS and POSTOCELL lambdas (new maps category)

### DIFF
--- a/lambdas/maps/CELLTOPOS.lambda
+++ b/lambdas/maps/CELLTOPOS.lambda
@@ -1,0 +1,30 @@
+/*  FUNCTION NAME:      CELLTOPOS
+    DESCRIPTION:*//**Encodes a cell reference as a single integer (ROW * mult + COLUMN) for grid arithmetic.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-04-15  Claude      Initial version
+*/
+CELLTOPOS = LAMBDA(
+//  Parameter Declarations
+    [cell],
+    [mult],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →CELLTOPOS(cell, [mult])¶" &
+                "DESCRIPTION:   →Encodes a cell reference as a single integer (ROW * mult + COLUMN) for grid arithmetic.¶" &
+                "VERSION:       →Apr 15 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   cell           →(Required) A cell reference to encode.¶" &
+                "   mult           →(Optional) Multiplier for the row component. Default: 1000. Must exceed the maximum column number used.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=CELLTOPOS(E5)¶" &
+                "Result         →5005",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(cell),
+    //  Procedure
+        m, IF(ISOMITTED(mult), 1000, mult),
+        result, ROW(cell) * m + COLUMN(cell),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/CELLTOPOS.tests.yaml
+++ b/lambdas/maps/CELLTOPOS.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: default mult E5
+    args: ["=E5"]
+    expected: 5005
+
+  - name: default mult C3
+    args: ["=C3"]
+    expected: 3003
+
+  - name: default mult L12
+    args: ["=L12"]
+    expected: 12012
+
+  - name: custom mult A1
+    args: ["=A1", "=100"]
+    expected: 101
+
+  - name: custom mult Z10 with mult 50
+    args: ["=Z10", "=50"]
+    expected: 526
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/maps/POSTOCELL.lambda
+++ b/lambdas/maps/POSTOCELL.lambda
@@ -1,0 +1,30 @@
+/*  FUNCTION NAME:      POSTOCELL
+    DESCRIPTION:*//**Decodes an integer position (from CELLTOPOS) back to an A1-style cell address string.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-04-15  Claude      Initial version
+*/
+POSTOCELL = LAMBDA(
+//  Parameter Declarations
+    [pos],
+    [mult],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →POSTOCELL(pos, [mult])¶" &
+                "DESCRIPTION:   →Decodes an integer position (from CELLTOPOS) back to an A1-style cell address string.¶" &
+                "VERSION:       →Apr 15 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   pos            →(Required) Integer position to decode.¶" &
+                "   mult           →(Optional) Multiplier used during encoding. Default: 1000. Must match the mult used by CELLTOPOS.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=POSTOCELL(5005)¶" &
+                "Result         →E5",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(pos),
+    //  Procedure
+        m, IF(ISOMITTED(mult), 1000, mult),
+        result, ADDRESS(ROUNDDOWN(pos / m, 0), MOD(pos, m), 4),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/POSTOCELL.tests.yaml
+++ b/lambdas/maps/POSTOCELL.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: default mult 5005
+    args: ["=5005"]
+    expected: "E5"
+
+  - name: default mult 3003
+    args: ["=3003"]
+    expected: "C3"
+
+  - name: default mult 12012
+    args: ["=12012"]
+    expected: "L12"
+
+  - name: custom mult 101
+    args: ["=101", "=100"]
+    expected: "A1"
+
+  - name: custom mult 526 with mult 50
+    args: ["=526", "=50"]
+    expected: "Z10"
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/maps/_library.yaml
+++ b/lambdas/maps/_library.yaml
@@ -1,0 +1,3 @@
+name: Maps
+description: Grid and cell-position utilities for map-like calculations
+default_prefix: maps


### PR DESCRIPTION
## Summary
- Adds `CELLTOPOS(cell, [mult])` — encodes a cell reference as `ROW * mult + COLUMN`.
- Adds `POSTOCELL(pos, [mult])` — decodes an integer position back to an A1-style address.
- Introduces a new `maps` lambda category for grid / cell-position utilities.

Together these enable simple arithmetic for grid movement (directional offsets become constants) and position-based calculations.

Closes #59
Closes #60

## Test plan
- [x] Format validation tests pass (`LambdaFormatTests`)
- [x] Harness tests pass for both lambdas across default mult, custom mult, and help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)