### PR TITLE
Parse and surface Lambda descriptions in the search UI

### DIFF
--- a/addin/lambda-boss.Tests/LambdaParserTests.cs
+++ b/addin/lambda-boss.Tests/LambdaParserTests.cs
@@ -164,4 +164,73 @@ AddN = LAMBDA(
 
         Assert.Equal("MyFunc", name);
     }
+
+    [Fact]
+    public void ExtractDescription_StandardHeader_ReturnsDescription()
+    {
+        var content = @"/*  FUNCTION NAME:      CONSECGROUPS
+    DESCRIPTION:*//**Decomposes a string into an array of consecutive-character run groups.*/
+/*  REVISIONS: ...
+*/
+CONSECGROUPS = LAMBDA(x, x);";
+
+        var description = LambdaParser.ExtractDescription(content);
+
+        Assert.Equal("Decomposes a string into an array of consecutive-character run groups.", description);
+    }
+
+    [Fact]
+    public void ExtractDescription_Missing_ReturnsNull()
+    {
+        var content = @"/*  FUNCTION NAME:      NoDesc
+*/
+NoDesc = LAMBDA(x, x);";
+
+        var description = LambdaParser.ExtractDescription(content);
+
+        Assert.Null(description);
+    }
+
+    [Fact]
+    public void ExtractDescription_EmptyBlock_ReturnsNull()
+    {
+        var content = @"/*  FUNCTION NAME:      Empty
+    DESCRIPTION:*//***/
+*/
+Empty = LAMBDA(x, x);";
+
+        var description = LambdaParser.ExtractDescription(content);
+
+        Assert.Null(description);
+    }
+
+    [Fact]
+    public void ExtractDescription_MultiLine_CollapsesWhitespace()
+    {
+        var content = @"/*  FUNCTION NAME:      Multi
+    DESCRIPTION:*//**Line one
+        and line two.*/
+*/
+Multi = LAMBDA(x, x);";
+
+        var description = LambdaParser.ExtractDescription(content);
+
+        Assert.Equal("Line one and line two.", description);
+    }
+
+    [Fact]
+    public void ExtractDescription_DoesNotBreakParse()
+    {
+        // Sanity check: description extraction and formula parsing work on the same content.
+        var content = @"/*  FUNCTION NAME:      Double
+    DESCRIPTION:*//**Doubles a number.*/
+Double = LAMBDA(x, x * 2);";
+
+        var (name, formula) = LambdaParser.Parse(content);
+        var description = LambdaParser.ExtractDescription(content);
+
+        Assert.Equal("Double", name);
+        Assert.StartsWith("=LAMBDA(", formula);
+        Assert.Equal("Doubles a number.", description);
+    }
 }

--- a/addin/lambda-boss.Tests/LibraryProviderLocalTests.cs
+++ b/addin/lambda-boss.Tests/LibraryProviderLocalTests.cs
@@ -101,6 +101,32 @@ public class LibraryProviderLocalTests : IDisposable
     }
 
     [Fact]
+    public async Task RefreshAsync_PopulatesLambdaDescription()
+    {
+        var libDir = Path.Combine(_tempDir, "math");
+        Directory.CreateDirectory(libDir);
+        File.WriteAllText(Path.Combine(libDir, "_library.yaml"),
+            "name: math\ndescription: Test lib\ndefault_prefix: m");
+        File.WriteAllText(Path.Combine(libDir, "Double.lambda"),
+            "/*  FUNCTION NAME:      Double\r\n    DESCRIPTION:*//**Doubles a number.*/\r\nDouble = LAMBDA(x, x * 2);");
+        File.WriteAllText(Path.Combine(libDir, "NoDesc.lambda"),
+            "NoDesc = LAMBDA(x, x);");
+
+        var localConfig = new LocalSourceConfig { Path = _tempDir };
+        var provider = new LibraryProvider(
+            Array.Empty<RepoConfig>(),
+            localSources: new[] { localConfig });
+
+        var lambdas = await provider.GetAllLambdasAsync();
+
+        var withDesc = lambdas.Single(l => l.Name == "Double");
+        Assert.Equal("Doubles a number.", withDesc.Description);
+
+        var noDesc = lambdas.Single(l => l.Name == "NoDesc");
+        Assert.Equal("", noDesc.Description);
+    }
+
+    [Fact]
     public async Task RefreshAsync_AlwaysReadsFreshFromDisk()
     {
         CreateTestLibrary("math", "m", "Double");

--- a/addin/lambda-boss/LambdaParser.cs
+++ b/addin/lambda-boss/LambdaParser.cs
@@ -12,6 +12,14 @@ public static class LambdaParser
         @"^\s*(\w+)\s*=\s*LAMBDA\s*\(",
         RegexOptions.Multiline);
 
+    // Matches description text in the header convention:
+    //   DESCRIPTION:*//**<text>*/
+    // i.e. the first block comment closes immediately after "DESCRIPTION:",
+    // then a second /** ... */ block comment contains the description.
+    private static readonly Regex DescriptionPattern = new(
+        @"DESCRIPTION:\s*\*/\s*/\*\*(.*?)\*/",
+        RegexOptions.Singleline);
+
     /// <summary>
     ///     Parses a .lambda file and returns the function name and formula.
     ///     The formula is returned with an = prefix, ready for Name Manager injection.
@@ -48,6 +56,27 @@ public static class LambdaParser
     {
         var content = File.ReadAllText(filePath);
         return Parse(content);
+    }
+
+    /// <summary>
+    ///     Extracts the description text from the header comment block of a .lambda file.
+    ///     Convention: <c>DESCRIPTION:*//**&lt;text&gt;*/</c>.
+    /// </summary>
+    /// <param name="content">The raw text content of a .lambda file.</param>
+    /// <returns>The description text, or null if none was found or the description is empty.</returns>
+    public static string? ExtractDescription(string content)
+    {
+        var match = DescriptionPattern.Match(content);
+        if (!match.Success)
+            return null;
+
+        // Collapse internal whitespace/newlines so a multi-line description renders cleanly.
+        var raw = match.Groups[1].Value.Trim();
+        if (raw.Length == 0)
+            return null;
+
+        var collapsed = Regex.Replace(raw, @"\s+", " ").Trim();
+        return collapsed.Length == 0 ? null : collapsed;
     }
 
     private static string ExtractBalancedFormula(string text, int openParenIndex)

--- a/addin/lambda-boss/LibraryProvider.cs
+++ b/addin/lambda-boss/LibraryProvider.cs
@@ -154,12 +154,14 @@ public class LibraryProvider
                         try
                         {
                             var (name, formula) = LambdaParser.Parse(content);
+                            var description = LambdaParser.ExtractDescription(content) ?? "";
                             lambdas.Add(new LambdaInfo
                             {
                                 Name = name,
                                 Formula = formula,
                                 LibraryInfo = info,
-                                FileName = fileName
+                                FileName = fileName,
+                                Description = description
                             });
                         }
                         catch (Exception ex)
@@ -214,12 +216,14 @@ public class LibraryProvider
                         try
                         {
                             var (name, formula) = LambdaParser.Parse(content);
+                            var description = LambdaParser.ExtractDescription(content) ?? "";
                             lambdas.Add(new LambdaInfo
                             {
                                 Name = name,
                                 Formula = formula,
                                 LibraryInfo = info,
-                                FileName = fileName
+                                FileName = fileName,
+                                Description = description
                             });
                         }
                         catch (Exception ex)
@@ -271,5 +275,11 @@ public sealed class LambdaInfo
     public string Formula { get; init; } = "";
     public LibraryInfo LibraryInfo { get; init; } = null!;
     public string FileName { get; init; } = "";
+
+    /// <summary>
+    ///     Description extracted from the header comment of the .lambda file.
+    ///     Empty string when no description was found.
+    /// </summary>
+    public string Description { get; init; } = "";
 }
 

--- a/addin/lambda-boss/UI/LambdaPopup.xaml
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml
@@ -99,14 +99,23 @@
                  Visibility="Collapsed">
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <StackPanel Orientation="Horizontal" Margin="4,2">
+                    <Grid Margin="4,2"
+                          ToolTip="{Binding DescriptionToolTip}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
                         <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
-                        <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="#dcdcaa" />
-                        <TextBlock Text="  " />
-                        <TextBlock Text="{Binding LibraryLabel}" Foreground="#569cd6" FontSize="11"
-                                   VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="0" Text="{Binding Name}" FontWeight="Bold"
+                                   Foreground="#dcdcaa" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="1" Text="{Binding Description}" Foreground="#808080"
+                                   FontSize="11" VerticalAlignment="Center"
+                                   TextTrimming="CharacterEllipsis" Margin="8,0,8,0" />
+                        <TextBlock Grid.Column="2" Text="{Binding LibraryLabel}" Foreground="#569cd6"
+                                   FontSize="11" VerticalAlignment="Center" />
                         <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
-                    </StackPanel>
+                    </Grid>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>

--- a/addin/lambda-boss/UI/LambdaPopup.xaml.cs
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml.cs
@@ -56,6 +56,7 @@ public partial class LambdaPopup
                 LibraryLabel = l.LibraryInfo.IsLocal
                     ? $"{l.LibraryInfo.DisplayName} [Local]"
                     : l.LibraryInfo.DisplayName,
+                Description = l.Description,
                 LibraryInfo = l.LibraryInfo
             })
             .ToList();
@@ -404,5 +405,12 @@ internal class LambdaDisplayItem
 {
     public string Name { get; init; } = "";
     public string LibraryLabel { get; init; } = "";
+    public string Description { get; init; } = "";
     public LibraryInfo LibraryInfo { get; init; } = null!;
+
+    /// <summary>
+    ///     Tooltip value for the description. Returns null for empty descriptions so WPF
+    ///     suppresses the tooltip entirely rather than showing a blank popup.
+    /// </summary>
+    public object? DescriptionToolTip => string.IsNullOrEmpty(Description) ? null : Description;
 }


### PR DESCRIPTION
## Summary
- Extracts the header `DESCRIPTION:*//**...*/` text in `LambdaParser.ExtractDescription` and populates `LambdaInfo.Description` on both the GitHub and local-source refresh paths.
- Shows the description inline to the right of the Lambda name in the search popup, truncated with ellipsis to fit horizontal space, with the full text available via ToolTip on hover. Lambdas with no description render blank.
- Adds unit tests for the description extractor and for the provider populating `Description` end-to-end.

Closes #69
Closes #70
Part of #68

## Test plan
- [x] CI: `dotnet build addin/lambda-boss.slnx`
- [x] CI: `dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj` (new tests: `ExtractDescription_*`, `RefreshAsync_PopulatesLambdaDescription`)
- [x] Local smoke: open the popup in Excel, switch to Search mode, confirm descriptions appear next to names and ellipsize on narrow widths; hover shows full text; lambdas without descriptions render cleanly with no empty tooltip.