### PR TITLE
Rank lambda search with fuzzy subsequence matcher

### DIFF
--- a/addin/lambda-boss.Tests/FuzzyMatcherTests.cs
+++ b/addin/lambda-boss.Tests/FuzzyMatcherTests.cs
@@ -1,0 +1,63 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+public class FuzzyMatcherTests
+{
+    [Fact]
+    public void EmptyQuery_ReturnsZero()
+    {
+        Assert.Equal(0, FuzzyMatcher.Score("", "Anything"));
+    }
+
+    [Fact]
+    public void NoSubsequence_ReturnsNoMatch()
+    {
+        Assert.Equal(FuzzyMatcher.NoMatch, FuzzyMatcher.Score("xyz", "ConsecGroups"));
+    }
+
+    [Fact]
+    public void QueryLongerThanCandidate_ReturnsNoMatch()
+    {
+        Assert.Equal(FuzzyMatcher.NoMatch, FuzzyMatcher.Score("abcdef", "abc"));
+    }
+
+    [Fact]
+    public void SubsequenceOutOfOrder_ReturnsNoMatch()
+    {
+        Assert.Equal(FuzzyMatcher.NoMatch, FuzzyMatcher.Score("ba", "abc"));
+    }
+
+    [Fact]
+    public void CaseInsensitive_MatchesRegardlessOfCase()
+    {
+        Assert.NotEqual(FuzzyMatcher.NoMatch, FuzzyMatcher.Score("CG", "consecgroups"));
+        Assert.NotEqual(FuzzyMatcher.NoMatch, FuzzyMatcher.Score("cg", "ConsecGroups"));
+    }
+
+    [Fact]
+    public void CamelCaseInitialism_OutranksMidWordMatch()
+    {
+        var initialism = FuzzyMatcher.Score("cg", "ConsecGroups");
+        var midWord = FuzzyMatcher.Score("cg", "Contiguous");
+        Assert.True(initialism > midWord,
+            $"CamelCase initialism score {initialism} should beat mid-word {midWord}");
+    }
+
+    [Fact]
+    public void WordBoundaryAfterNonLetter_ScoresHigher()
+    {
+        var boundary = FuzzyMatcher.Score("r", "_range");
+        var midWord = FuzzyMatcher.Score("r", "orange");
+        Assert.True(boundary > midWord,
+            $"Boundary score {boundary} should beat mid-word {midWord}");
+    }
+
+    [Fact]
+    public void ConsecutiveMatches_BeatGapMatches()
+    {
+        var consecutive = FuzzyMatcher.Score("abc", "abcdef");
+        var gapped = FuzzyMatcher.Score("abc", "axbxcx");
+        Assert.True(consecutive > gapped);
+    }
+}

--- a/addin/lambda-boss/FuzzyMatcher.cs
+++ b/addin/lambda-boss/FuzzyMatcher.cs
@@ -1,0 +1,71 @@
+namespace LambdaBoss;
+
+/// <summary>
+///     Subsequence fuzzy matcher with word-boundary ranking. Query characters
+///     must appear in order (not necessarily contiguous) within the candidate.
+///     Matches on word boundaries (start of string, after non-letter/digit, or
+///     a capital letter following a lowercase letter) score higher, which
+///     surfaces initialism-style matches (e.g. "cg" → "ConsecGroups").
+/// </summary>
+public static class FuzzyMatcher
+{
+    public const int NoMatch = -1;
+
+    private const int BaseScore = 1;
+    private const int BoundaryBonus = 10;
+    private const int ConsecutiveBonus = 5;
+
+    /// <summary>
+    ///     Returns a match score for the query against the candidate, or
+    ///     <see cref="NoMatch"/> if the query is not a subsequence of the
+    ///     candidate. Matching is case-insensitive. Higher is better.
+    /// </summary>
+    public static int Score(string query, string candidate)
+    {
+        if (string.IsNullOrEmpty(query))
+            return 0;
+        if (string.IsNullOrEmpty(candidate))
+            return NoMatch;
+
+        var score = 0;
+        var candidateIndex = 0;
+        var lastMatchIndex = -2;
+
+        foreach (var qc in query)
+        {
+            var target = char.ToLowerInvariant(qc);
+
+            while (candidateIndex < candidate.Length
+                   && char.ToLowerInvariant(candidate[candidateIndex]) != target)
+                candidateIndex++;
+
+            if (candidateIndex >= candidate.Length)
+                return NoMatch;
+
+            score += BaseScore;
+            if (IsWordBoundary(candidate, candidateIndex))
+                score += BoundaryBonus;
+            if (candidateIndex == lastMatchIndex + 1)
+                score += ConsecutiveBonus;
+
+            lastMatchIndex = candidateIndex;
+            candidateIndex++;
+        }
+
+        return score;
+    }
+
+    private static bool IsWordBoundary(string s, int index)
+    {
+        if (index == 0)
+            return true;
+        var prev = s[index - 1];
+        var curr = s[index];
+        if (!char.IsLetterOrDigit(prev))
+            return true;
+        // CamelCase boundary: lowercase → uppercase
+        if (char.IsUpper(curr) && char.IsLower(prev))
+            return true;
+        return false;
+    }
+}

--- a/addin/lambda-boss/UI/LambdaPopup.xaml
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml
@@ -99,6 +99,7 @@
                  Visibility="Collapsed">
             <ListBox.ItemTemplate>
                 <DataTemplate>
+                    <!-- ReSharper disable once Xaml.BindingWithContextNotResolved -->
                     <Grid Margin="4,2"
                           ToolTip="{Binding DescriptionToolTip}">
                         <Grid.ColumnDefinitions>

--- a/addin/lambda-boss/UI/LambdaPopup.xaml.cs
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml.cs
@@ -240,8 +240,26 @@ public partial class LambdaPopup
                 LambdaList.ItemsSource = _allLambdas;
             else
             {
+                // Name matches rank above description-only matches; this bonus
+                // must exceed any realistic description score.
+                const int nameBonus = 10_000;
+
                 LambdaList.ItemsSource = _allLambdas
-                    .Where(l => l.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
+                    .Select(l =>
+                    {
+                        var nameScore = FuzzyMatcher.Score(query, l.Name);
+                        var descScore = FuzzyMatcher.Score(query, l.Description);
+                        var best = FuzzyMatcher.NoMatch;
+                        if (nameScore != FuzzyMatcher.NoMatch)
+                            best = nameScore + nameBonus;
+                        if (descScore != FuzzyMatcher.NoMatch && descScore > best)
+                            best = descScore;
+                        return (Item: l, Score: best);
+                    })
+                    .Where(x => x.Score != FuzzyMatcher.NoMatch)
+                    .OrderByDescending(x => x.Score)
+                    .ThenBy(x => x.Item.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(x => x.Item)
                     .ToList();
             }
 


### PR DESCRIPTION
## Summary
- Add `FuzzyMatcher` that scores subsequence matches with word-boundary and consecutive-char bonuses (case-insensitive).
- Replace the name-only `Contains()` filter in `LambdaPopup` with a ranked fuzzy match across name + description; name hits get a +10,000 bonus so they always outrank description-only hits.
- Results sort by score descending, tie-broken by name.

Closes #71

## Test plan
- [x] 9 new `FuzzyMatcherTests` cover initialism ranking, case-insensitivity, boundary boost, consecutive-match boost, and no-match cases.
- [x] Full suite: 292/292 passing.
- [x] Manual smoke in Excel: "CG" surfaces `ConsecGroups` above mid-word matches; empty query shows all lambdas.