### PR TITLE
Add LET to LAMBDA ribbon converter

### DIFF
--- a/addin/lambda-boss.Tests/ExcelNameValidatorTests.cs
+++ b/addin/lambda-boss.Tests/ExcelNameValidatorTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+public class ExcelNameValidatorTests
+{
+    [Theory]
+    [InlineData("MyLambda")]
+    [InlineData("_underscore")]
+    [InlineData("Name123")]
+    [InlineData("dotted.name")]
+    public void ValidNames(string name)
+    {
+        Assert.True(ExcelNameValidator.Validate(name).IsValid);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("1StartsWithDigit")]
+    [InlineData("has space")]
+    [InlineData("has-dash")]
+    [InlineData("A1")]
+    [InlineData("ZZ999")]
+    [InlineData("R1C1")]
+    [InlineData("TRUE")]
+    [InlineData("false")]
+    [InlineData("C")]
+    public void InvalidNames(string? name)
+    {
+        var result = ExcelNameValidator.Validate(name);
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.Error);
+    }
+}

--- a/addin/lambda-boss.Tests/LetParserTests.cs
+++ b/addin/lambda-boss.Tests/LetParserTests.cs
@@ -1,0 +1,118 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+public class LetParserTests
+{
+    [Fact]
+    public void IsLetFormula_DetectsLet()
+    {
+        Assert.True(LetParser.IsLetFormula("=LET(x, 1, x)"));
+        Assert.True(LetParser.IsLetFormula("=let(x, 1, x)"));
+        Assert.True(LetParser.IsLetFormula("=LET ( x , 1 , x )"));
+    }
+
+    [Fact]
+    public void IsLetFormula_RejectsNonLet()
+    {
+        Assert.False(LetParser.IsLetFormula("=SUM(A1:A10)"));
+        Assert.False(LetParser.IsLetFormula("=IF(A1, LET(x, 1, x), 0)"));
+        Assert.False(LetParser.IsLetFormula(" =LET(x, 1, x)"));
+        Assert.False(LetParser.IsLetFormula(""));
+        Assert.False(LetParser.IsLetFormula(null));
+    }
+
+    [Fact]
+    public void Parse_SingleBinding_ReturnsBindingAndBody()
+    {
+        var parsed = LetParser.Parse("=LET(x, 1, x + 1)");
+
+        Assert.Single(parsed.Bindings);
+        Assert.Equal("x", parsed.Bindings[0].Name);
+        Assert.Equal("1", parsed.Bindings[0].RhsText);
+        Assert.False(parsed.Bindings[0].IsCalculation);
+        Assert.Equal("x + 1", parsed.Body);
+    }
+
+    [Fact]
+    public void Parse_MultipleBindings_PreservesOrder()
+    {
+        var parsed = LetParser.Parse("=LET(a, 1, b, 2, c, 3, a + b + c)");
+
+        Assert.Equal(3, parsed.Bindings.Count);
+        Assert.Equal(new[] { "a", "b", "c" }, parsed.Bindings.Select(b => b.Name));
+        Assert.Equal("a + b + c", parsed.Body);
+    }
+
+    [Fact]
+    public void Parse_ValueRhs_NotClassifiedAsCalculation()
+    {
+        var parsed = LetParser.Parse(
+            "=LET(n, 1, s, \"hello\", c, A1, r, A1:B10, q, Sheet1!A1, nm, myRange, -1)");
+
+        Assert.All(parsed.Bindings, b => Assert.False(b.IsCalculation,
+            $"Binding '{b.Name}' RHS '{b.RhsText}' was classified as calculation."));
+    }
+
+    [Fact]
+    public void Parse_QuotedSheetReference_IsValue()
+    {
+        var parsed = LetParser.Parse("=LET(r, 'My Sheet'!A1:B2, r)");
+        Assert.False(parsed.Bindings[0].IsCalculation);
+    }
+
+    [Fact]
+    public void Parse_CalculationRhs_ClassifiedAsCalculation()
+    {
+        var parsed = LetParser.Parse(
+            "=LET(m, MAX(A1:A10), s, 1 + 2, f, SUM(x, y), ix, A1:A10 B1:B10, n, -SUM(x), m)");
+
+        Assert.All(parsed.Bindings, b => Assert.True(b.IsCalculation,
+            $"Binding '{b.Name}' RHS '{b.RhsText}' was classified as value."));
+    }
+
+    [Fact]
+    public void Parse_StringLiteralWithCommaAndParen_PreservedIntact()
+    {
+        var parsed = LetParser.Parse("=LET(greeting, \"Hello, (world)\", greeting)");
+
+        Assert.Single(parsed.Bindings);
+        Assert.Equal("\"Hello, (world)\"", parsed.Bindings[0].RhsText);
+        Assert.False(parsed.Bindings[0].IsCalculation);
+    }
+
+    [Fact]
+    public void Parse_NestedLetAsRhs_ClassifiedAsCalculation()
+    {
+        var parsed = LetParser.Parse("=LET(inner, LET(x, 1, x + 1), inner * 2)");
+
+        Assert.True(parsed.Bindings[0].IsCalculation);
+        Assert.Equal("LET(x, 1, x + 1)", parsed.Bindings[0].RhsText);
+    }
+
+    [Fact]
+    public void Parse_NonLetFormula_Throws()
+    {
+        Assert.Throws<FormatException>(() => LetParser.Parse("=SUM(A1:A10)"));
+    }
+
+    [Fact]
+    public void Parse_EvenArgCount_Throws()
+    {
+        Assert.Throws<FormatException>(() => LetParser.Parse("=LET(x, 1)"));
+        Assert.Throws<FormatException>(() => LetParser.Parse("=LET(x, 1, y, 2)"));
+    }
+
+    [Fact]
+    public void Parse_RealWorldExample_FromIssue()
+    {
+        var parsed = LetParser.Parse("=LET(someRange, A1:A10, getMax, MAX(someRange), getMax)");
+
+        Assert.Equal(2, parsed.Bindings.Count);
+        Assert.Equal("someRange", parsed.Bindings[0].Name);
+        Assert.False(parsed.Bindings[0].IsCalculation);
+        Assert.Equal("getMax", parsed.Bindings[1].Name);
+        Assert.True(parsed.Bindings[1].IsCalculation);
+        Assert.Equal("getMax", parsed.Body);
+    }
+}

--- a/addin/lambda-boss.Tests/LetToLambdaBuilderTests.cs
+++ b/addin/lambda-boss.Tests/LetToLambdaBuilderTests.cs
@@ -1,0 +1,109 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+public class LetToLambdaBuilderTests
+{
+    private static string Build(string formula, string lambdaName,
+        params (string name, string paramName, bool keep)[] choices)
+    {
+        var parsed = LetParser.Parse(formula);
+        var inputs = choices.Select(c => new InputChoice(c.name, c.paramName, c.keep)).ToList();
+        return LetToLambdaBuilder.Build(new LambdaGenerationRequest(lambdaName, parsed, inputs));
+    }
+
+    [Fact]
+    public void AllInputsKept_NoInternalLet()
+    {
+        var result = Build("=LET(x, 1, y, 2, SUM(x, y))", "Adder",
+            ("x", "x", true), ("y", "y", true));
+
+        Assert.Equal("=LAMBDA(x, y, SUM(x, y))", result);
+    }
+
+    [Fact]
+    public void RenamedParam_SubstitutesThroughBody()
+    {
+        var result = Build("=LET(x, 1, y, 2, SUM(x, y))", "Adder",
+            ("x", "a", true), ("y", "b", true));
+
+        Assert.Equal("=LAMBDA(a, b, SUM(a, b))", result);
+    }
+
+    [Fact]
+    public void MixedKeepAndCalc_WrapsInLet()
+    {
+        var result = Build("=LET(someRange, A1:A10, getMax, MAX(someRange), getMax)", "MyMax",
+            ("someRange", "someRange", true));
+
+        Assert.Equal("=LAMBDA(someRange, LET(getMax, MAX(someRange), getMax))", result);
+    }
+
+    [Fact]
+    public void RenamedInput_RenamesInsideInternalBindingRhs()
+    {
+        var result = Build("=LET(a, A1:A10, b, MAX(a), b)", "MaxLambda",
+            ("a", "myRange", true));
+
+        Assert.Equal("=LAMBDA(myRange, LET(b, MAX(myRange), b))", result);
+    }
+
+    [Fact]
+    public void RemovedInput_StaysAsInternalBinding()
+    {
+        var result = Build("=LET(x, 1, y, 2, x + y)", "Test",
+            ("x", "x", false), ("y", "y", true));
+
+        Assert.Equal("=LAMBDA(y, LET(x, 1, x + y))", result);
+    }
+
+    [Fact]
+    public void NoInputsKept_LambdaHasNoParams()
+    {
+        var result = Build("=LET(x, 1, y, 2, x + y)", "Zero",
+            ("x", "x", false), ("y", "y", false));
+
+        Assert.Equal("=LAMBDA(LET(x, 1, y, 2, x + y))", result);
+    }
+
+    [Fact]
+    public void StringLiteralContent_NotRenamed()
+    {
+        var result = Build("=LET(x, 1, CONCAT(\"x is \", x))", "WithString",
+            ("x", "value", true));
+
+        Assert.Equal("=LAMBDA(value, CONCAT(\"x is \", value))", result);
+    }
+
+    [Fact]
+    public void DuplicateParamName_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            Build("=LET(x, 1, y, 2, x + y)", "Dup",
+                ("x", "a", true), ("y", "a", true)));
+    }
+
+    [Fact]
+    public void ParamNameCollidesWithInternalBinding_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            Build("=LET(x, 1, y, MAX(x), y)", "Bad",
+                ("x", "y", true)));
+    }
+
+    [Fact]
+    public void EmptyParamName_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            Build("=LET(x, 1, x)", "Bad",
+                ("x", "", true)));
+    }
+
+    [Fact]
+    public void CalculationBindingOnly_NoInputs()
+    {
+        var result = Build("=LET(m, MAX(A1:A10), m + 1)", "MaxPlus1");
+
+        Assert.Equal("=LAMBDA(LET(m, MAX(A1:A10), m + 1))", result);
+    }
+}

--- a/addin/lambda-boss/Commands/ConvertLetToLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/ConvertLetToLambdaCommand.cs
@@ -1,0 +1,121 @@
+using System.Windows;
+using System.Windows.Interop;
+
+using ExcelDna.Integration;
+
+using LambdaBoss.UI;
+
+using Taglo.Excel.Common;
+
+namespace LambdaBoss.Commands;
+
+/// <summary>
+///     Ribbon handler: converts the active cell's =LET(...) formula into a
+///     workbook-scoped LAMBDA registered in the Name Manager.
+/// </summary>
+public static class ConvertLetToLambdaCommand
+{
+    public static void Run()
+    {
+        try
+        {
+            dynamic app = ExcelDnaUtil.Application;
+            dynamic workbook = app.ActiveWorkbook;
+            if (workbook == null)
+            {
+                ShowError("No active workbook.");
+                return;
+            }
+
+            dynamic activeCell = app.ActiveCell;
+            string? formula = activeCell?.Formula as string;
+
+            if (!LetParser.IsLetFormula(formula))
+            {
+                ShowError("Active cell does not contain a =LET(...) formula.");
+                return;
+            }
+
+            ParsedLet parsed;
+            try
+            {
+                parsed = LetParser.Parse(formula!);
+            }
+            catch (FormatException ex)
+            {
+                ShowError($"Could not parse LET formula: {ex.Message}");
+                return;
+            }
+
+            var existingNames = GetExistingNames(workbook);
+            var excelHwnd = new IntPtr(app.Hwnd);
+
+            ShowLambdaPopupCommand.InvokeOnWindowThread(dispatcher =>
+            {
+                LambdaGenerationRequest? result = null;
+
+                dispatcher.Invoke(() =>
+                {
+                    var window = new LetToLambdaWindow(
+                        parsed,
+                        name => existingNames.Contains(name));
+
+                    var wpfHwnd = new WindowInteropHelper(window).EnsureHandle();
+                    WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
+
+                    if (window.ShowDialog() == true)
+                        result = window.Result;
+                });
+
+                if (result == null) return;
+
+                try
+                {
+                    var generatedFormula = LetToLambdaBuilder.Build(result);
+                    LambdaLoader.InjectLambda(result.LambdaName, generatedFormula);
+                    Logger.Info($"ConvertLetToLambda: Created '{result.LambdaName}'");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("ConvertLetToLambda/Build", ex);
+                    ShowError($"Failed to generate LAMBDA: {ex.Message}");
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("ConvertLetToLambda", ex);
+            ShowError($"Unexpected error: {ex.Message}");
+        }
+    }
+
+    private static HashSet<string> GetExistingNames(dynamic workbook)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            foreach (dynamic n in workbook.Names)
+            {
+                try { names.Add((string)n.Name); }
+                catch { /* skip unreadable */ }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("GetExistingNames", ex);
+        }
+        return names;
+    }
+
+    private static void ShowError(string message)
+    {
+        try
+        {
+            MessageBox.Show(message, "Lambda Boss", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch
+        {
+            Logger.Info($"ShowError: {message}");
+        }
+    }
+}

--- a/addin/lambda-boss/Commands/ShowLambdaPopupCommand.cs
+++ b/addin/lambda-boss/Commands/ShowLambdaPopupCommand.cs
@@ -152,6 +152,17 @@ public static class ShowLambdaPopupCommand
         }
     }
 
+    /// <summary>
+    ///     Ensures the WPF STA thread is running and invokes <paramref name="action"/>
+    ///     with its Dispatcher. Used by commands that need to show their own windows.
+    /// </summary>
+    public static void InvokeOnWindowThread(Action<Dispatcher> action)
+    {
+        EnsureWindowThread();
+        if (_windowDispatcher != null)
+            action(_windowDispatcher);
+    }
+
     private static void EnsureWindowThread()
     {
         if (_windowThread != null && _windowThread.IsAlive)

--- a/addin/lambda-boss/ExcelNameValidator.cs
+++ b/addin/lambda-boss/ExcelNameValidator.cs
@@ -1,0 +1,52 @@
+using System.Text.RegularExpressions;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     Syntactic validation of workbook-scoped defined names. Does not check
+///     for collisions — that requires the live Name Manager.
+/// </summary>
+public static class ExcelNameValidator
+{
+    private static readonly Regex CellRefPattern = new(
+        @"^[A-Za-z]{1,3}[0-9]+$|^R[0-9]+C[0-9]+$",
+        RegexOptions.IgnoreCase);
+
+    private static readonly HashSet<string> Reserved = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "C", "c", "R", "r", "TRUE", "FALSE",
+    };
+
+    public static ValidationResult Validate(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return ValidationResult.Invalid("Name is required.");
+
+        if (name!.Length > 255)
+            return ValidationResult.Invalid("Name is too long (max 255 characters).");
+
+        var first = name[0];
+        if (!char.IsLetter(first) && first != '_' && first != '\\')
+            return ValidationResult.Invalid("Name must start with a letter, underscore, or backslash.");
+
+        foreach (var c in name)
+        {
+            if (!char.IsLetterOrDigit(c) && c != '_' && c != '.' && c != '\\' && c != '?')
+                return ValidationResult.Invalid($"Invalid character '{c}' in name.");
+        }
+
+        if (Reserved.Contains(name))
+            return ValidationResult.Invalid($"'{name}' is reserved by Excel.");
+
+        if (CellRefPattern.IsMatch(name))
+            return ValidationResult.Invalid($"'{name}' looks like a cell reference.");
+
+        return ValidationResult.Valid();
+    }
+}
+
+public record ValidationResult(bool IsValid, string? Error)
+{
+    public static ValidationResult Valid() => new(true, null);
+    public static ValidationResult Invalid(string error) => new(false, error);
+}

--- a/addin/lambda-boss/ExcelNameValidator.cs
+++ b/addin/lambda-boss/ExcelNameValidator.cs
@@ -14,7 +14,12 @@ public static class ExcelNameValidator
 
     private static readonly HashSet<string> Reserved = new(StringComparer.OrdinalIgnoreCase)
     {
-        "C", "c", "R", "r", "TRUE", "FALSE",
+        "C",
+        "c",
+        "R",
+        "r",
+        "TRUE",
+        "FALSE",
     };
 
     public static ValidationResult Validate(string? name)
@@ -22,7 +27,7 @@ public static class ExcelNameValidator
         if (string.IsNullOrWhiteSpace(name))
             return ValidationResult.Invalid("Name is required.");
 
-        if (name!.Length > 255)
+        if (name.Length > 255)
             return ValidationResult.Invalid("Name is too long (max 255 characters).");
 
         var first = name[0];
@@ -30,10 +35,8 @@ public static class ExcelNameValidator
             return ValidationResult.Invalid("Name must start with a letter, underscore, or backslash.");
 
         foreach (var c in name)
-        {
             if (!char.IsLetterOrDigit(c) && c != '_' && c != '.' && c != '\\' && c != '?')
                 return ValidationResult.Invalid($"Invalid character '{c}' in name.");
-        }
 
         if (Reserved.Contains(name))
             return ValidationResult.Invalid($"'{name}' is reserved by Excel.");
@@ -47,6 +50,13 @@ public static class ExcelNameValidator
 
 public record ValidationResult(bool IsValid, string? Error)
 {
-    public static ValidationResult Valid() => new(true, null);
-    public static ValidationResult Invalid(string error) => new(false, error);
+    public static ValidationResult Valid()
+    {
+        return new ValidationResult(true, null);
+    }
+
+    public static ValidationResult Invalid(string error)
+    {
+        return new ValidationResult(false, error);
+    }
 }

--- a/addin/lambda-boss/LetParser.cs
+++ b/addin/lambda-boss/LetParser.cs
@@ -1,0 +1,215 @@
+using System.Text.RegularExpressions;
+
+namespace LambdaBoss;
+
+public record LetBinding(string Name, string RhsText, bool IsCalculation);
+
+public record ParsedLet(IReadOnlyList<LetBinding> Bindings, string Body);
+
+/// <summary>
+///     Parses an Excel <c>=LET(name1, expr1, ..., body)</c> formula into its
+///     bindings and final body expression. RHS text is classified as either a
+///     pure value (literal/reference/bare name) or a calculation (contains a
+///     function call or operator).
+/// </summary>
+public static class LetParser
+{
+    private static readonly Regex LetPrefix = new(
+        @"^=\s*LET\s*\(",
+        RegexOptions.IgnoreCase);
+
+    private static readonly Regex IdentifierPattern = new(
+        @"^[A-Za-z_][A-Za-z0-9_.]*$");
+
+    public static bool IsLetFormula(string? formula)
+    {
+        if (string.IsNullOrEmpty(formula))
+            return false;
+        return LetPrefix.IsMatch(formula!);
+    }
+
+    public static ParsedLet Parse(string formula)
+    {
+        if (formula is null)
+            throw new ArgumentNullException(nameof(formula));
+
+        var match = LetPrefix.Match(formula);
+        if (!match.Success)
+            throw new FormatException("Formula must start with '=LET('.");
+
+        var openParen = match.Index + match.Length - 1;
+        var closeParen = FindMatchingClose(formula, openParen);
+        if (closeParen < 0)
+            throw new FormatException("Unbalanced parentheses in LET formula.");
+
+        var inner = formula[(openParen + 1)..closeParen];
+        var args = SplitTopLevelCommas(inner);
+
+        if (args.Count < 3 || args.Count % 2 == 0)
+            throw new FormatException(
+                "LET must have an odd number of arguments (pairs of name/value plus a final body).");
+
+        var bindings = new List<LetBinding>();
+        for (var i = 0; i < args.Count - 1; i += 2)
+        {
+            var name = args[i].Trim();
+            var rhs = args[i + 1].Trim();
+            if (!IdentifierPattern.IsMatch(name))
+                throw new FormatException($"Invalid LET binding name: '{name}'.");
+            bindings.Add(new LetBinding(name, rhs, IsCalculation(rhs)));
+        }
+
+        var body = args[^1].Trim();
+        return new ParsedLet(bindings, body);
+    }
+
+    /// <summary>
+    ///     An RHS is a calculation if it contains (at top level, outside strings
+    ///     and parens) any operator, an identifier immediately followed by '(',
+    ///     or whitespace between two operand tokens (intersection operator).
+    ///     Unary minus / plus on a single literal does not count.
+    /// </summary>
+    internal static bool IsCalculation(string rhs)
+    {
+        if (string.IsNullOrWhiteSpace(rhs))
+            return false;
+
+        // Strip a single leading unary + or -.
+        var s = rhs.TrimStart();
+        if (s.Length > 0 && (s[0] == '-' || s[0] == '+'))
+            s = s[1..].TrimStart();
+
+        var i = 0;
+        var len = s.Length;
+        var afterOperand = false;
+
+        while (i < len)
+        {
+            var c = s[i];
+
+            if (char.IsWhiteSpace(c))
+            {
+                var j = i;
+                while (j < len && char.IsWhiteSpace(s[j])) j++;
+                if (afterOperand && j < len && !IsOperatorChar(s[j]) && s[j] != ')' && s[j] != ',')
+                    return true;
+                i = j;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                i = SkipString(s, i);
+                afterOperand = true;
+                continue;
+            }
+
+            if (c == '(')
+                return true;
+
+            if (IsOperatorChar(c))
+                return true;
+
+            var start = i;
+            while (i < len)
+            {
+                var ch = s[i];
+                if (char.IsWhiteSpace(ch) || IsOperatorChar(ch) || ch == '(' || ch == '"' || ch == ',' || ch == ')')
+                    break;
+                if (ch == '\'')
+                {
+                    i++;
+                    while (i < len && s[i] != '\'') i++;
+                    if (i < len) i++;
+                    continue;
+                }
+                i++;
+            }
+            var token = s[start..i];
+
+            if (i < len && s[i] == '(' && IsIdentifierStart(token))
+                return true;
+
+            afterOperand = true;
+        }
+
+        return false;
+    }
+
+    private static bool IsIdentifierStart(string token) =>
+        token.Length > 0 && (char.IsLetter(token[0]) || token[0] == '_');
+
+    private static bool IsOperatorChar(char c) =>
+        c is '+' or '-' or '*' or '/' or '^' or '&' or '=' or '<' or '>' or '%';
+
+    private static int SkipString(string text, int openQuoteIndex)
+    {
+        var i = openQuoteIndex + 1;
+        while (i < text.Length)
+        {
+            if (text[i] == '"')
+            {
+                if (i + 1 < text.Length && text[i + 1] == '"')
+                {
+                    i += 2;
+                    continue;
+                }
+                return i + 1;
+            }
+            i++;
+        }
+        return text.Length;
+    }
+
+    internal static int FindMatchingClose(string text, int openParenIndex)
+    {
+        var depth = 0;
+        var i = openParenIndex;
+        while (i < text.Length)
+        {
+            var c = text[i];
+            if (c == '"')
+            {
+                i = SkipString(text, i);
+                continue;
+            }
+            if (c == '(') depth++;
+            else if (c == ')')
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+            i++;
+        }
+        return -1;
+    }
+
+    internal static List<string> SplitTopLevelCommas(string text)
+    {
+        var parts = new List<string>();
+        var depth = 0;
+        var start = 0;
+        var i = 0;
+        while (i < text.Length)
+        {
+            var c = text[i];
+            if (c == '"')
+            {
+                i = SkipString(text, i);
+                continue;
+            }
+            if (c == '(' || c == '{' || c == '[')
+                depth++;
+            else if (c == ')' || c == '}' || c == ']')
+                depth--;
+            else if (c == ',' && depth == 0)
+            {
+                parts.Add(text[start..i]);
+                start = i + 1;
+            }
+            i++;
+        }
+        parts.Add(text[start..]);
+        return parts;
+    }
+}

--- a/addin/lambda-boss/LetParser.cs
+++ b/addin/lambda-boss/LetParser.cs
@@ -25,7 +25,7 @@ public static class LetParser
     {
         if (string.IsNullOrEmpty(formula))
             return false;
-        return LetPrefix.IsMatch(formula!);
+        return LetPrefix.IsMatch(formula);
     }
 
     public static ParsedLet Parse(string formula)
@@ -46,8 +46,10 @@ public static class LetParser
         var args = SplitTopLevelCommas(inner);
 
         if (args.Count < 3 || args.Count % 2 == 0)
+        {
             throw new FormatException(
                 "LET must have an odd number of arguments (pairs of name/value plus a final body).");
+        }
 
         var bindings = new List<LetBinding>();
         for (var i = 0; i < args.Count - 1; i += 2)
@@ -123,8 +125,10 @@ public static class LetParser
                     if (i < len) i++;
                     continue;
                 }
+
                 i++;
             }
+
             var token = s[start..i];
 
             if (i < len && s[i] == '(' && IsIdentifierStart(token))
@@ -136,11 +140,15 @@ public static class LetParser
         return false;
     }
 
-    private static bool IsIdentifierStart(string token) =>
-        token.Length > 0 && (char.IsLetter(token[0]) || token[0] == '_');
+    private static bool IsIdentifierStart(string token)
+    {
+        return token.Length > 0 && (char.IsLetter(token[0]) || token[0] == '_');
+    }
 
-    private static bool IsOperatorChar(char c) =>
-        c is '+' or '-' or '*' or '/' or '^' or '&' or '=' or '<' or '>' or '%';
+    private static bool IsOperatorChar(char c)
+    {
+        return c is '+' or '-' or '*' or '/' or '^' or '&' or '=' or '<' or '>' or '%';
+    }
 
     private static int SkipString(string text, int openQuoteIndex)
     {
@@ -154,10 +162,13 @@ public static class LetParser
                     i += 2;
                     continue;
                 }
+
                 return i + 1;
             }
+
             i++;
         }
+
         return text.Length;
     }
 
@@ -173,14 +184,17 @@ public static class LetParser
                 i = SkipString(text, i);
                 continue;
             }
+
             if (c == '(') depth++;
             else if (c == ')')
             {
                 depth--;
                 if (depth == 0) return i;
             }
+
             i++;
         }
+
         return -1;
     }
 
@@ -198,6 +212,7 @@ public static class LetParser
                 i = SkipString(text, i);
                 continue;
             }
+
             if (c == '(' || c == '{' || c == '[')
                 depth++;
             else if (c == ')' || c == '}' || c == ']')
@@ -207,8 +222,10 @@ public static class LetParser
                 parts.Add(text[start..i]);
                 start = i + 1;
             }
+
             i++;
         }
+
         parts.Add(text[start..]);
         return parts;
     }

--- a/addin/lambda-boss/LetToLambdaBuilder.cs
+++ b/addin/lambda-boss/LetToLambdaBuilder.cs
@@ -1,0 +1,161 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     User's decision for a single LET binding whose RHS is a value.
+/// </summary>
+public record InputChoice(string OriginalBindingName, string ParamName, bool Keep);
+
+public record LambdaGenerationRequest(
+    string LambdaName,
+    ParsedLet ParsedLet,
+    IReadOnlyList<InputChoice> Inputs);
+
+public static class LetToLambdaBuilder
+{
+    public static string Build(LambdaGenerationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var parsed = request.ParsedLet;
+
+        var choicesByName = request.Inputs.ToDictionary(
+            c => c.OriginalBindingName, c => c, StringComparer.OrdinalIgnoreCase);
+
+        // Validate each value-binding has a matching choice.
+        foreach (var b in parsed.Bindings.Where(b => !b.IsCalculation))
+        {
+            if (!choicesByName.ContainsKey(b.Name))
+                throw new InvalidOperationException(
+                    $"No input choice provided for binding '{b.Name}'.");
+        }
+
+        var kept = parsed.Bindings
+            .Where(b => !b.IsCalculation && choicesByName[b.Name].Keep)
+            .Select(b => (Binding: b, Choice: choicesByName[b.Name]))
+            .ToList();
+
+        // Validate param names: non-empty, unique, no collision with non-kept binding names.
+        var paramNames = kept.Select(k => k.Choice.ParamName).ToList();
+        if (paramNames.Any(string.IsNullOrWhiteSpace))
+            throw new InvalidOperationException("Parameter names must be non-empty.");
+        var dup = paramNames
+            .GroupBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(g => g.Count() > 1);
+        if (dup != null)
+            throw new InvalidOperationException($"Duplicate parameter name: '{dup.Key}'.");
+
+        var internalBindingNames = parsed.Bindings
+            .Where(b => b.IsCalculation
+                || (choicesByName.TryGetValue(b.Name, out var c) && !c.Keep))
+            .Select(b => b.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in paramNames)
+            if (internalBindingNames.Contains(p))
+                throw new InvalidOperationException(
+                    $"Parameter name '{p}' collides with a retained LET binding name.");
+
+        // Build rename map for kept inputs where chosen name differs from original.
+        var renames = kept
+            .Where(k => !string.Equals(k.Binding.Name, k.Choice.ParamName, StringComparison.Ordinal))
+            .ToDictionary(k => k.Binding.Name, k => k.Choice.ParamName,
+                StringComparer.OrdinalIgnoreCase);
+
+        // Internal bindings preserve source order; their RHS text has renames applied.
+        var keptNames = kept.Select(k => k.Binding.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var internalBindings = parsed.Bindings
+            .Where(b => !keptNames.Contains(b.Name))
+            .Select(b => new LetBinding(b.Name, ApplyRenames(b.RhsText, renames), b.IsCalculation))
+            .ToList();
+
+        var body = ApplyRenames(parsed.Body, renames);
+
+        var sb = new StringBuilder();
+        sb.Append("=LAMBDA(");
+        for (var i = 0; i < kept.Count; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append(kept[i].Choice.ParamName);
+        }
+        if (kept.Count > 0)
+            sb.Append(", ");
+
+        if (internalBindings.Count == 0)
+        {
+            sb.Append(body);
+        }
+        else
+        {
+            sb.Append("LET(");
+            foreach (var ib in internalBindings)
+            {
+                sb.Append(ib.Name).Append(", ").Append(ib.RhsText).Append(", ");
+            }
+            sb.Append(body).Append(')');
+        }
+
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+    /// <summary>
+    ///     Replaces identifier occurrences of each rename key with its value,
+    ///     skipping string literals. Case-insensitive, word-boundary matched.
+    /// </summary>
+    internal static string ApplyRenames(string text, IReadOnlyDictionary<string, string> renames)
+    {
+        if (renames.Count == 0) return text;
+
+        var pattern = string.Join("|", renames.Keys.Select(Regex.Escape));
+        var regex = new Regex($@"(?<![A-Za-z0-9_.]){pattern}(?![A-Za-z0-9_.])",
+            RegexOptions.IgnoreCase);
+
+        var result = new StringBuilder();
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (text[i] == '"')
+            {
+                var end = SkipString(text, i);
+                result.Append(text, i, end - i);
+                i = end;
+                continue;
+            }
+
+            var nextQuote = text.IndexOf('"', i);
+            var segEnd = nextQuote < 0 ? text.Length : nextQuote;
+            var segment = text[i..segEnd];
+            var rewritten = regex.Replace(segment, m =>
+            {
+                // Find the rename key case-insensitively.
+                var key = renames.Keys.First(k =>
+                    string.Equals(k, m.Value, StringComparison.OrdinalIgnoreCase));
+                return renames[key];
+            });
+            result.Append(rewritten);
+            i = segEnd;
+        }
+        return result.ToString();
+    }
+
+    private static int SkipString(string text, int openQuoteIndex)
+    {
+        var i = openQuoteIndex + 1;
+        while (i < text.Length)
+        {
+            if (text[i] == '"')
+            {
+                if (i + 1 < text.Length && text[i + 1] == '"')
+                {
+                    i += 2;
+                    continue;
+                }
+                return i + 1;
+            }
+            i++;
+        }
+        return text.Length;
+    }
+}

--- a/addin/lambda-boss/RibbonController.cs
+++ b/addin/lambda-boss/RibbonController.cs
@@ -26,6 +26,14 @@ public class RibbonController : ExcelRibbon
                   onAction='OnLoadLibrary'
                   screentip='Open the Lambda library browser (Ctrl+Shift+L)' />
         </group>
+        <group id='GenerateGroup' label='Generate'>
+          <button id='LetToLambdaButton'
+                  label='LET to LAMBDA'
+                  size='large'
+                  imageMso='FunctionWizard'
+                  onAction='OnLetToLambda'
+                  screentip='Convert the active cell&apos;s =LET(...) formula into a workbook-scoped LAMBDA' />
+        </group>
         <group id='ManageGroup' label='Manage'>
           <button id='SettingsButton'
                   label='Settings'
@@ -83,6 +91,11 @@ public class RibbonController : ExcelRibbon
     public void OnRefresh(IRibbonControl control)
     {
         ShowLambdaPopupCommand.RefreshData();
+    }
+
+    public void OnLetToLambda(IRibbonControl control)
+    {
+        ConvertLetToLambdaCommand.Run();
     }
 
     public void OnAbout(IRibbonControl control)

--- a/addin/lambda-boss/UI/LetToLambdaWindow.xaml
+++ b/addin/lambda-boss/UI/LetToLambdaWindow.xaml
@@ -1,0 +1,123 @@
+<Window x:Class="LambdaBoss.UI.LetToLambdaWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Lambda Boss — LET to LAMBDA"
+        Width="560" Height="480"
+        WindowStyle="ToolWindow"
+        ShowInTaskbar="True"
+        Topmost="True"
+        ResizeMode="CanResizeWithGrip"
+        Background="#1e1e1e">
+
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="Lambda name"
+                   FontSize="13"
+                   FontWeight="Bold"
+                   Foreground="#dcdcaa"
+                   Margin="0,0,0,4" />
+
+        <TextBox x:Name="LambdaNameBox"
+                 Grid.Row="1"
+                 Padding="6,4"
+                 FontSize="14"
+                 FontFamily="Consolas"
+                 Background="#2d2d2d"
+                 Foreground="#cccccc"
+                 CaretBrush="#cccccc"
+                 BorderBrush="#3e3e3e"
+                 BorderThickness="1"
+                 TextChanged="LambdaNameBox_TextChanged" />
+
+        <TextBlock x:Name="NameErrorText"
+                   Grid.Row="2"
+                   Margin="0,4,0,0"
+                   Foreground="#e74856"
+                   FontSize="11"
+                   Visibility="Collapsed" />
+
+        <TextBlock Grid.Row="3"
+                   Text="Inputs"
+                   FontSize="13"
+                   FontWeight="Bold"
+                   Foreground="#dcdcaa"
+                   Margin="0,16,0,4" />
+
+        <ScrollViewer Grid.Row="4"
+                      VerticalScrollBarVisibility="Auto"
+                      Background="#252526"
+                      BorderBrush="#3e3e3e"
+                      BorderThickness="1"
+                      Padding="4">
+            <ItemsControl x:Name="InputsList">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <DockPanel Margin="4,3">
+                            <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                            <CheckBox DockPanel.Dock="Left"
+                                      IsChecked="{Binding Keep, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      VerticalAlignment="Center"
+                                      Margin="0,0,8,0"
+                                      ToolTip="Uncheck to hardcode this binding inside the LAMBDA body" />
+                            <TextBlock DockPanel.Dock="Right"
+                                       Text="{Binding RhsPreview}"
+                                       Foreground="#808080"
+                                       FontFamily="Consolas"
+                                       FontSize="12"
+                                       VerticalAlignment="Center"
+                                       Margin="8,0,0,0"
+                                       TextTrimming="CharacterEllipsis"
+                                       ToolTip="{Binding RhsPreview}" />
+                            <TextBox Text="{Binding ParamName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     IsEnabled="{Binding Keep}"
+                                     Padding="4,2"
+                                     FontFamily="Consolas"
+                                     FontSize="13"
+                                     Background="#2d2d2d"
+                                     Foreground="#cccccc"
+                                     CaretBrush="#cccccc"
+                                     BorderBrush="#3e3e3e"
+                                     BorderThickness="1" />
+                            <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
+                        </DockPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+
+        <DockPanel Grid.Row="5" Margin="0,12,0,0">
+            <Button x:Name="CancelButton"
+                    DockPanel.Dock="Right"
+                    Content="Cancel"
+                    Padding="16,4"
+                    Margin="6,0,0,0"
+                    Background="Transparent"
+                    Foreground="#cccccc"
+                    BorderBrush="#3e3e3e"
+                    BorderThickness="1"
+                    Click="CancelButton_Click" />
+            <Button x:Name="SaveButton"
+                    DockPanel.Dock="Right"
+                    Content="Save"
+                    Padding="16,4"
+                    Background="#0e639c"
+                    Foreground="#ffffff"
+                    BorderThickness="0"
+                    IsEnabled="False"
+                    Click="SaveButton_Click" />
+            <TextBlock x:Name="StatusText"
+                       Foreground="#808080"
+                       FontSize="11"
+                       VerticalAlignment="Center" />
+        </DockPanel>
+    </Grid>
+</Window>

--- a/addin/lambda-boss/UI/LetToLambdaWindow.xaml.cs
+++ b/addin/lambda-boss/UI/LetToLambdaWindow.xaml.cs
@@ -1,0 +1,161 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace LambdaBoss.UI;
+
+public class LetInputRow : INotifyPropertyChanged
+{
+    private string _paramName = "";
+    private bool _keep = true;
+
+    public string BindingName { get; set; } = "";
+    public string RhsPreview { get; set; } = "";
+
+    public string ParamName
+    {
+        get => _paramName;
+        set { _paramName = value; OnChanged(); }
+    }
+
+    public bool Keep
+    {
+        get => _keep;
+        set { _keep = value; OnChanged(); }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnChanged([CallerMemberName] string? prop = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+}
+
+public partial class LetToLambdaWindow : Window
+{
+    private readonly ParsedLet _parsed;
+    private readonly Func<string, bool> _nameCollides;
+    private readonly List<LetInputRow> _rows;
+
+    /// <summary>
+    ///     Populated on successful Save. Null if cancelled.
+    /// </summary>
+    public LambdaGenerationRequest? Result { get; private set; }
+
+    public LetToLambdaWindow(ParsedLet parsed, Func<string, bool> nameCollides)
+    {
+        InitializeComponent();
+        _parsed = parsed;
+        _nameCollides = nameCollides;
+
+        _rows = parsed.Bindings
+            .Where(b => !b.IsCalculation)
+            .Select(b => new LetInputRow
+            {
+                BindingName = b.Name,
+                ParamName = b.Name,
+                RhsPreview = b.RhsText,
+                Keep = true,
+            })
+            .ToList();
+
+        foreach (var row in _rows)
+            row.PropertyChanged += (_, _) => UpdateSaveEnabled();
+
+        InputsList.ItemsSource = _rows;
+
+        LambdaNameBox.Focus();
+        UpdateSaveEnabled();
+    }
+
+    private void LambdaNameBox_TextChanged(object sender, TextChangedEventArgs e) =>
+        UpdateSaveEnabled();
+
+    private void UpdateSaveEnabled()
+    {
+        var name = LambdaNameBox.Text?.Trim() ?? "";
+        var validation = ExcelNameValidator.Validate(name);
+
+        if (!validation.IsValid)
+        {
+            ShowNameError(validation.Error!);
+            SaveButton.IsEnabled = false;
+            return;
+        }
+
+        if (_nameCollides(name))
+        {
+            ShowNameError("Name already exists in this workbook.");
+            SaveButton.IsEnabled = false;
+            return;
+        }
+
+        HideNameError();
+
+        // Validate rows: kept rows must have non-empty unique param names
+        // not colliding with any retained LET binding name.
+        var keptRows = _rows.Where(r => r.Keep).ToList();
+        if (keptRows.Any(r => string.IsNullOrWhiteSpace(r.ParamName)))
+        {
+            StatusText.Text = "Every kept input needs a parameter name.";
+            SaveButton.IsEnabled = false;
+            return;
+        }
+
+        var dup = keptRows
+            .GroupBy(r => r.ParamName.Trim(), StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(g => g.Count() > 1);
+        if (dup != null)
+        {
+            StatusText.Text = $"Duplicate parameter name: '{dup.Key}'.";
+            SaveButton.IsEnabled = false;
+            return;
+        }
+
+        var retainedBindingNames = _parsed.Bindings
+            .Where(b => b.IsCalculation || _rows.Any(r => r.BindingName == b.Name && !r.Keep))
+            .Select(b => b.Name)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var collidingParam = keptRows
+            .FirstOrDefault(r => retainedBindingNames.Contains(r.ParamName.Trim()));
+        if (collidingParam != null)
+        {
+            StatusText.Text =
+                $"Parameter '{collidingParam.ParamName}' collides with an internal binding.";
+            SaveButton.IsEnabled = false;
+            return;
+        }
+
+        StatusText.Text = "";
+        SaveButton.IsEnabled = true;
+    }
+
+    private void ShowNameError(string message)
+    {
+        NameErrorText.Text = message;
+        NameErrorText.Visibility = Visibility.Visible;
+    }
+
+    private void HideNameError()
+    {
+        NameErrorText.Text = "";
+        NameErrorText.Visibility = Visibility.Collapsed;
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        var inputs = _rows
+            .Select(r => new InputChoice(r.BindingName, r.ParamName.Trim(), r.Keep))
+            .ToList();
+
+        Result = new LambdaGenerationRequest(LambdaNameBox.Text.Trim(), _parsed, inputs);
+        DialogResult = true;
+        Close();
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        Result = null;
+        DialogResult = false;
+        Close();
+    }
+}

--- a/addin/lambda-boss/UI/LetToLambdaWindow.xaml.cs
+++ b/addin/lambda-boss/UI/LetToLambdaWindow.xaml.cs
@@ -7,8 +7,8 @@ namespace LambdaBoss.UI;
 
 public class LetInputRow : INotifyPropertyChanged
 {
-    private string _paramName = "";
     private bool _keep = true;
+    private string _paramName = "";
 
     public string BindingName { get; set; } = "";
     public string RhsPreview { get; set; } = "";
@@ -16,30 +16,36 @@ public class LetInputRow : INotifyPropertyChanged
     public string ParamName
     {
         get => _paramName;
-        set { _paramName = value; OnChanged(); }
+        set
+        {
+            _paramName = value;
+            OnChanged();
+        }
     }
 
     public bool Keep
     {
         get => _keep;
-        set { _keep = value; OnChanged(); }
+        set
+        {
+            _keep = value;
+            OnChanged();
+        }
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
-    private void OnChanged([CallerMemberName] string? prop = null) =>
+
+    private void OnChanged([CallerMemberName] string? prop = null)
+    {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+    }
 }
 
-public partial class LetToLambdaWindow : Window
+public partial class LetToLambdaWindow
 {
-    private readonly ParsedLet _parsed;
     private readonly Func<string, bool> _nameCollides;
+    private readonly ParsedLet _parsed;
     private readonly List<LetInputRow> _rows;
-
-    /// <summary>
-    ///     Populated on successful Save. Null if cancelled.
-    /// </summary>
-    public LambdaGenerationRequest? Result { get; private set; }
 
     public LetToLambdaWindow(ParsedLet parsed, Func<string, bool> nameCollides)
     {
@@ -54,7 +60,7 @@ public partial class LetToLambdaWindow : Window
                 BindingName = b.Name,
                 ParamName = b.Name,
                 RhsPreview = b.RhsText,
-                Keep = true,
+                Keep = true
             })
             .ToList();
 
@@ -67,12 +73,19 @@ public partial class LetToLambdaWindow : Window
         UpdateSaveEnabled();
     }
 
-    private void LambdaNameBox_TextChanged(object sender, TextChangedEventArgs e) =>
+    /// <summary>
+    ///     Populated on successful Save. Null if cancelled.
+    /// </summary>
+    public LambdaGenerationRequest? Result { get; private set; }
+
+    private void LambdaNameBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
         UpdateSaveEnabled();
+    }
 
     private void UpdateSaveEnabled()
     {
-        var name = LambdaNameBox.Text?.Trim() ?? "";
+        var name = LambdaNameBox.Text.Trim();
         var validation = ExcelNameValidator.Validate(name);
 
         if (!validation.IsValid)

--- a/docs/plans/0002-let-to-lambda.md
+++ b/docs/plans/0002-let-to-lambda.md
@@ -1,0 +1,123 @@
+# Plan: LET → LAMBDA generator (issue #74)
+
+Ribbon button that converts the active cell's `=LET(...)` formula into a workbook-scoped `LAMBDA` via the Name Manager. Source cell is left untouched.
+
+## Input detection rule
+
+Walk the LET's binding pairs. A binding's RHS is either:
+
+- **Value** → becomes a LAMBDA input (default param name = the LET binding name).
+- **Calculation** → stays as an internal binding inside the generated LAMBDA body.
+
+"Calculation" means the RHS, after paren/string-literal-aware tokenization, contains any of:
+
+- A top-level operator: `+ - * / ^ & = < >` (unary minus on a literal does not count).
+- An identifier immediately followed by `(` (a function call).
+- Top-level whitespace between tokens (Excel intersection operator).
+
+Otherwise it's a value: a literal (number/string/bool), a cell ref, a range, a sheet-qualified ref, or a bare identifier (named range or unbound name).
+
+The LET body expression is never scanned for references — we only promote LET bindings.
+
+## Removed inputs
+
+If the user removes a row in the dialog, that LET binding is preserved as a regular internal binding in the generated LAMBDA body (wrapped in a `LET(...)` if needed to hold remaining internals).
+
+## Generated formula shape
+
+Given `=LET(a, A1:A10, b, MAX(a), c, 2, b + c)` where user keeps `a` and `c` as inputs:
+
+```
+=LAMBDA(a, c, LET(b, MAX(a), b + c))
+```
+
+If no internal bindings remain, the LET wrapper is omitted:
+
+```
+=LAMBDA(x, y, SUM(x, y))
+```
+
+If no inputs are kept, the LAMBDA takes zero params.
+
+## Components
+
+### 1. `LetParser` (new, `addin/lambda-boss/LetParser.cs`)
+
+- Validates formula starts with `=LET(` (case-insensitive, no leading whitespace).
+- Reuses paren/string-literal balancing logic from `LambdaParser`.
+- Returns ordered `List<LetBinding> Bindings` + `string Body`.
+- `LetBinding { Name, RhsText, IsCalculation }`.
+
+### 2. `LetToLambdaBuilder` (new, `addin/lambda-boss/LetToLambdaBuilder.cs`)
+
+- Input: parsed LET + user choices (lambda name, per-binding: keep-as-input with chosen param name, or remove).
+- Substitutes renamed params through retained internal bindings and body.
+- Emits the `=LAMBDA(...)` string.
+- Substitution is token-aware (respects strings, skips function-name identifiers followed by `(`).
+
+### 3. `ConvertLetToLambdaCommand` (new, `addin/lambda-boss/Commands/ConvertLetToLambdaCommand.cs`)
+
+- Reads `ExcelDnaUtil.Application.ActiveCell.Formula`.
+- Validates leading `=LET(` — on mismatch, shows Excel message box and aborts.
+- Runs `LetParser`, opens the dialog on the existing STA thread.
+- On Save: calls `LambdaLoader.InjectLambda(name, formula)` with no comment (per spec).
+
+### 4. `LetToLambdaWindow.xaml[.cs]` (new, `addin/lambda-boss/UI/`)
+
+- Hosted on the shared WPF STA thread in `ShowLambdaPopupCommand` (add a second window alongside `_window` / `_settingsWindow`).
+- Lambda name textbox at top, live-validated:
+  - Empty → red hint "Name required".
+  - Invalid Excel name (whitespace, starts with digit, reserved) → red hint.
+  - Collides with an existing workbook name → red hint "Name already exists in this workbook". (No suggestion.)
+  - Valid → Save button enabled.
+- `ItemsControl` of rows, one per LET binding whose RHS is a value:
+  - `[x remove]` button, param-name TextBox (defaults to binding name), label showing original RHS text.
+- Save / Cancel buttons.
+- Centred on Excel via existing `WindowPositioner.CenterOnExcel`.
+
+### 5. Ribbon wiring (modify `RibbonController.cs`)
+
+- New `<group id="GenerateGroup" label="Generate">` on the Lambda Boss tab.
+- One button: `id="LetToLambdaButton" label="LET to LAMBDA"`.
+- Icon: `imageMso="FunctionWizard"` (closest built-in match; swap later if we want custom).
+- Handler `OnLetToLambda` delegates to `ConvertLetToLambdaCommand.Run()`.
+
+## Tests (`addin/lambda-boss.Tests/`)
+
+### `LetParserTests`
+- Single binding, multiple bindings, final body.
+- Nested LETs (outer LET with a LET as a binding RHS → that binding is a calculation).
+- String literals containing `,` and `(`.
+- Rejects non-LET formulas.
+- Classifies RHS correctly: literal, cell ref, range, sheet-qualified ref, named range → value; operators, function calls, intersection → calculation.
+- Unary minus on literal is a value; `-SUM(x)` is a calculation.
+
+### `LetToLambdaBuilderTests`
+- All inputs kept → no internal LET wrapper.
+- Mixed keep/remove → retained internal bindings wrapped in `LET(...)` inside LAMBDA.
+- Renamed param substitutes through body and internal bindings but not inside string literals.
+- Zero kept inputs → `LAMBDA(body)` (no params, no LET wrapper unless internals remain).
+- Rename collision with existing LET binding name → builder throws (UI prevents but guard anyway).
+
+### `ExcelNameValidatorTests` (new small helper)
+- Valid / invalid / reserved names.
+- Uses `workbook.Names` collision check — unit test only covers the pure syntactic validator; collision check is integration-only.
+
+## Out of scope (confirmed)
+
+- Rewriting the source cell.
+- Named-range / cell-ref detection inside the LET body.
+- Worksheet-scoped names.
+- LAMBDA → LET round-trip.
+- Suggesting alternative names on collision (live validation only).
+- Provenance comment on generated names.
+
+## Implementation order
+
+1. `LetParser` + tests.
+2. `LetToLambdaBuilder` + tests.
+3. Excel name validator + tests.
+4. `LetToLambdaWindow` XAML + view model.
+5. `ConvertLetToLambdaCommand` + STA thread hookup in `ShowLambdaPopupCommand`.
+6. Ribbon button.
+7. Manual smoke test in Excel.


### PR DESCRIPTION
Closes #74

## Summary
- New **LET to LAMBDA** ribbon button (new Generate group) converts the active cell's `=LET(...)` formula into a workbook-scoped LAMBDA via the Name Manager.
- WPF confirmation dialog lists each LET binding whose RHS is a pure value (literal / cell ref / range / sheet-qualified ref / bare identifier) with rename + remove controls, plus a live-validated Lambda name field (Excel name rules + collision check against `workbook.Names`).
- Bindings with calculations (function calls or operators) stay as internal LET bindings in the generated LAMBDA body; removed value bindings also stay as internal bindings.
- Source cell's formula is left untouched.

Plan: `docs/plans/0002-let-to-lambda.md`.

## Generated shape
`=LET(a, A1:A10, b, MAX(a), c, 2, b + c)` keeping `a` and `c` as params →
`=LAMBDA(a, c, LET(b, MAX(a), b + c))`.

## Test plan
- [x] Unit tests: 26 new tests across `LetParserTests`, `LetToLambdaBuilderTests`, `ExcelNameValidatorTests`. Full suite: 330/330 passing.
- [x] Manual smoke test in Excel:
  - [x] LET with value-only bindings (all kept) → LAMBDA with no inner LET.
  - [x] Mixed value + calc bindings → LAMBDA wraps inner LET.
  - [x] Rename a param → substitutions flow through body and internal bindings.
  - [x] Remove a value binding → stays as internal binding.
  - [x] Name collision → red hint, Save disabled.
  - [x] Invalid name (cell ref / reserved / bad chars) → red hint, Save disabled.
  - [x] Non-LET active cell → warning message, abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)