### PR TITLE
Add specs for LET to LAMBDA authoring improvements

### DIFF
--- a/specs/0001-reorder-lambda-input-params.md
+++ b/specs/0001-reorder-lambda-input-params.md
@@ -1,0 +1,37 @@
+# 0001 — Reorder LAMBDA input parameters
+
+## Problem
+
+When converting a `=LET(...)` formula to a LAMBDA via the "LET to LAMBDA" command, the order of the resulting LAMBDA parameters is fixed to the source order of the LET bindings. Authors often want a different calling convention (for example, required args first, then optional; or ordering by conceptual importance) than the order that happened to be convenient when writing the LET. Today the only workaround is to rewrite the LET formula first, which is friction.
+
+## Proposed Solution
+
+Add up/down reorder controls on each "kept" (checked) input row in the `LetToLambdaWindow`. The order shown in the UI is the order the parameters appear in the generated `=LAMBDA(...)` signature.
+
+Unchecked bindings (those being kept as internal `LET` bindings inside the LAMBDA body) remain in their original source order — they are not reorderable, because their RHS expressions may reference earlier bindings.
+
+## User Stories
+
+- As a model author, I want to reorder the input parameters of the generated LAMBDA, so that the LAMBDA's calling convention matches how I want callers to use it.
+- As a model author, I want the reorder controls to be keyboard-accessible, so that I can work through the dialog without reaching for the mouse.
+
+## Acceptance Criteria
+
+- [ ] Each kept input row in `LetToLambdaWindow` has "move up" and "move down" buttons.
+- [ ] Buttons are disabled at the boundaries (first row's "up" disabled, last row's "down" disabled).
+- [ ] Reordering only moves the row among other kept rows; unchecked rows stay in source order and are not affected.
+- [ ] Unchecking a row removes it from the reorderable set; rechecking it re-inserts it at the end of the kept rows.
+- [ ] The generated `=LAMBDA(...)` signature reflects the UI order of kept rows.
+- [ ] Internal LET bindings (unchecked rows and calculations) still appear in source order in the generated body.
+- [ ] Rename behaviour is unchanged: if a kept row's param name differs from the original binding name, references in the body and other bindings are renamed.
+- [ ] Keyboard access: when a row has focus, Alt+Up / Alt+Down move it (or equivalent — confirmed in plan).
+
+## Out of Scope
+
+- Drag-and-drop reordering. Buttons only for v1.
+- Reordering internal (unchecked) bindings.
+- Persisting a preferred ordering across sessions.
+
+## Open Questions
+
+- None — keyboard shortcut choice (Alt+Up/Down vs Ctrl+Up/Down) to be decided in the plan.

--- a/specs/0002-optional-lambda-input-params.md
+++ b/specs/0002-optional-lambda-input-params.md
@@ -1,0 +1,61 @@
+# 0002 — Optional LAMBDA input parameters
+
+## Problem
+
+When a `=LET(...)` formula is converted to a LAMBDA, every kept binding becomes a required parameter on the generated LAMBDA. In practice, many of these bindings have a sensible "current" value (the one just used in the source cell) that the author would like to use as a default when the caller doesn't supply the argument. Today the author has to hand-edit the LAMBDA after generation to wrap the parameter with `IF(ISOMITTED(...), defaultExpr, param)` — tedious, error-prone, and easy to skip.
+
+## Proposed Solution
+
+Add an "Optional" checkbox on each kept input row in the `LetToLambdaWindow`. When a parameter is marked optional:
+
+- It stays declared as a normal LAMBDA parameter (Excel has no optional-parameter syntax — any parameter can be checked with `ISOMITTED`).
+- The generated LAMBDA body wraps each use of the parameter via a LET binding of the form `IF(ISOMITTED(param), defaultExpr, param)`, so downstream references resolve to the default when the caller omits the argument.
+- The **default expression is the RHS text of the original LET binding** — i.e. the formula that produced the value in the current cell. Not the evaluated result.
+
+### Example
+
+Given:
+
+```excel
+=LET(x, 10, y, A1, x + y)
+```
+
+With the author keeping both bindings as inputs, renaming `y` → `offset`, and marking `offset` as optional:
+
+```excel
+=LAMBDA(x, offset, LET(offset, IF(ISOMITTED(offset), A1, offset), x + offset))
+```
+
+If the author also marks `x` as optional:
+
+```excel
+=LAMBDA(x, offset, LET(x, IF(ISOMITTED(x), 10, x), offset, IF(ISOMITTED(offset), A1, offset), x + offset))
+```
+
+The `IF(ISOMITTED(...))` bindings are added as the first bindings in the inner LET, before any internal (unchecked) LET bindings from the original formula. This ensures their rewritten values are visible to anything that references them.
+
+## User Stories
+
+- As a model author, I want to mark a LAMBDA parameter as optional and have its current value preserved as the default, so that callers can omit it and get the same behaviour as the source cell.
+- As a model author, I want optional parameters to work alongside renaming and reordering, so that I can shape the full calling convention in one pass.
+
+## Acceptance Criteria
+
+- [ ] Each kept input row in `LetToLambdaWindow` has an "Optional" checkbox.
+- [ ] The checkbox is disabled (and unchecked) when the row's "Keep" checkbox is unchecked.
+- [ ] When at least one parameter is optional, the generated LAMBDA wraps each optional parameter via a LET binding using `IF(ISOMITTED(param), <original RHS text>, param)`.
+- [ ] Optional-parameter LET bindings appear **before** any internal LET bindings from the original formula, so internal bindings can reference optional parameters without hitting un-defaulted values.
+- [ ] When no parameters are optional, the generated LAMBDA is byte-for-byte identical to today's output.
+- [ ] Default expressions preserve the original RHS text verbatim (including references like `A1`, other names, etc.), subject to existing rename rewrites applied to other kept params referenced inside the RHS.
+- [ ] Optional works correctly in combination with rename and reorder from spec 0001.
+- [ ] Validation: a row cannot be both "optional" and "unchecked" (Keep=false). The UI enforces this by disabling Optional when Keep is off.
+
+## Out of Scope
+
+- Marking internal (unchecked) bindings as optional.
+- Excel's newer named-argument syntax or any formal "optional" declaration beyond `ISOMITTED`.
+- Automatically reordering optional params to the end of the signature. The author controls order via spec 0001; default order is source order.
+
+## Open Questions
+
+- Should the `IF(ISOMITTED(...))` LET binding reuse the parameter name (shadowing the LAMBDA parameter), or use a distinct name like `paramName_`? Reusing the name is cleaner and matches typical hand-written patterns; the plan should confirm it works under Excel's scoping and that renames cascade correctly. Tentative answer: reuse the parameter name.

--- a/specs/0003-edit-lambda.md
+++ b/specs/0003-edit-lambda.md
@@ -1,0 +1,73 @@
+# 0003 — Edit Lambda (round-trip LAMBDA to LET)
+
+## Problem
+
+Once a LAMBDA has been registered in the Name Manager (via the LET to LAMBDA command or imported from a library), there is no convenient way to edit it. Authors who want to tweak the implementation must open Name Manager, find the definition, and hand-edit the formula inline — a poor editing experience for anything non-trivial. This blocks the natural authoring loop of "try it, tune it, save it" that authors already get while working in LET form.
+
+## Proposed Solution
+
+Add an "Edit Lambda" ribbon command that performs the inverse of LET to LAMBDA: given a cell whose formula is a single call to a registered LAMBDA, replace the cell's formula with an equivalent `=LET(...)` that inlines the LAMBDA's parameters (bound to the call-site arguments) followed by the LAMBDA's body. The author edits the LET freely, then rounds-trips back to LAMBDA form via the existing "LET to LAMBDA" command — reusing the same name overwrites the prior definition.
+
+### Example
+
+LAMBDA registered as `MyCalc`:
+
+```excel
+=LAMBDA(x, y, x * y + 1)
+```
+
+Active cell:
+
+```excel
+=MyCalc(A1, B1 + 2)
+```
+
+After Edit Lambda, the cell becomes:
+
+```excel
+=LET(x, A1, y, B1 + 2, x * y + 1)
+```
+
+The `MyCalc` name definition is left untouched. The author edits, then runs LET to LAMBDA with the name `MyCalc` again to overwrite.
+
+### Detection rules
+
+The command only triggers when the active cell's formula is **exactly** a single Lambda call:
+
+- Formula starts with `=`, followed by an identifier that resolves to a workbook-scoped name whose `RefersTo` starts with `=LAMBDA(`.
+- Followed by `(args...)` where the closing paren matches the outer open paren and there is no trailing content.
+
+Any other shape (e.g. `=MyCalc(A1) + 5`, `=IF(cond, MyCalc(A1), 0)`, `=LET(...)`, a value literal) triggers a clear error and makes no change. The author can always wrap their expression manually if they want to edit just a nested call.
+
+### Argument count
+
+- If the number of call-site arguments is less than the number of LAMBDA parameters, trailing parameters are bound to `ISOMITTED()` style — for v1 we just leave them unbound, which means the generated LET will have fewer bindings than LAMBDA has params. The resulting LET may fail to evaluate until the author fills them in; that's acceptable feedback.
+- If there are more call-site arguments than LAMBDA parameters, refuse with a clear error.
+
+## User Stories
+
+- As a model author, I want to expand a LAMBDA call back into its LET form in the active cell, so that I can edit the implementation using the same tools I used to author it.
+- As a model author, I want to round-trip by rerunning LET to LAMBDA with the same name, so that my edits overwrite the prior definition without extra steps.
+
+## Acceptance Criteria
+
+- [ ] A new ribbon button, "Edit Lambda", in the Generate group of the Lambda Boss tab.
+- [ ] When the active cell's formula is exactly `=LambdaName(arg1, arg2, ...)` and `LambdaName` is a workbook name whose `RefersTo` starts with `=LAMBDA(`, the command replaces the cell's formula with `=LET(param1, arg1, param2, arg2, ..., body)` where `param1..N` and `body` come from parsing the LAMBDA definition.
+- [ ] Arguments are split at top-level commas only (respecting nested parens, quoted strings, and brackets) — reuse the same splitter used by `LetParser`.
+- [ ] The LAMBDA name definition is **not** modified or deleted.
+- [ ] If the active cell is not exactly a single Lambda call, the command shows a clear error: "Edit Lambda requires a cell whose formula is exactly a call to a LAMBDA (e.g. `=MyLambda(A1, B1)`)."
+- [ ] If the number of call-site arguments exceeds the LAMBDA's parameter count, the command shows a clear error stating the mismatch.
+- [ ] Round-trip: running LET to LAMBDA on the resulting cell with the same name (e.g. `MyCalc`) replaces the existing definition via the `LambdaLoader.InjectLambda` "update existing" path.
+- [ ] A new `LambdaSignatureParser` (or similar) extracts `(param1, ..., paramN, body)` from a `=LAMBDA(...)` `RefersTo` string, mirroring `LetParser`.
+
+## Out of Scope
+
+- Editing LAMBDAs that are inside a larger expression (e.g. `=MyLambda(A1) + 5`).
+- Multi-cell arrays, or cells with dynamic-array spill.
+- Editing a LAMBDA without a call site (e.g. from Name Manager directly, with no reference cell).
+- Preserving comments or provenance when the name is later overwritten — handled by LambdaLoader today and unchanged here.
+- Detecting when the LAMBDA references other LAMBDAs that would also need expanding.
+
+## Open Questions
+
+- When the LAMBDA was originally generated with optional-parameter wrapping (spec 0002), its body will contain `IF(ISOMITTED(...))` bindings. Edit Lambda inlines the body verbatim, so those wrappers remain in the LET. Round-tripping through LET to LAMBDA with the same "Optional" choices should produce an equivalent result, but double-wrapping could occur if the author re-checks "Optional". The plan should confirm behaviour and either document the gotcha or strip the wrappers on detection. Tentative answer: document the gotcha in v1; no automatic stripping.

--- a/specs/0004-slash-commands-in-popup.md
+++ b/specs/0004-slash-commands-in-popup.md
@@ -1,0 +1,63 @@
+# 0004 — Slash commands in the main popup
+
+## Problem
+
+Lambda Boss has several commands — Load Library, LET to LAMBDA, Edit Lambda (spec 0003), Settings — that are currently only reachable via the Excel ribbon. Power users who invoke the main popup with a keyboard shortcut want to reach every Lambda Boss action without leaving the keyboard or dropping into the ribbon. Today the popup only does library browsing and Lambda search.
+
+## Proposed Solution
+
+Extend the main popup (`LambdaPopup`) with a third mode — **Commands** — activated by typing `/` as the first character in the search box. The Commands mode shows a fuzzy-filterable list of Lambda Boss actions. Enter executes the selected command (which usually closes the popup and runs the action on the Excel side).
+
+### Activation and exit
+
+- Typing `/` as the **first** character of the search box switches the popup into Commands mode and starts filtering the command list by whatever follows the `/`.
+- Deleting back to an empty search box or to a non-`/` first character exits Commands mode and returns to the mode that was active before (Library or Search).
+- Tab does not toggle Commands mode (Tab remains the Library ↔ Search toggle).
+- Mode indicators at the top show "Libraries · Search · Commands", with the active mode highlighted.
+
+### v1 commands
+
+| Command name (shown in list) | Action |
+|---|---|
+| `LET to LAMBDA` | Runs `ConvertLetToLambdaCommand.Run()` |
+| `Edit Lambda` | Runs the Edit Lambda command from spec 0003 |
+| `Load Library` | Switches popup to Library mode (does not close) |
+| `Settings` | Runs `ShowLambdaPopupCommand.ShowSettings()` |
+
+Filtering uses the existing `FuzzyMatcher` against the command name.
+
+### Execution semantics
+
+- Commands that operate on a cell (LET to LAMBDA, Edit Lambda) hide the popup first, then execute on Excel's side. Error messages surface via the existing message-box path in those commands.
+- Commands that change popup mode (Load Library) switch mode without closing.
+- Settings opens the settings window on the same STA thread, as today.
+
+## User Stories
+
+- As a keyboard-driven user, I want to trigger any Lambda Boss action from the main popup via `/`-prefixed commands, so that I can stay on the keyboard for my whole workflow.
+- As a new user, I want a discoverable list of available actions by typing `/`, so that I don't have to memorize ribbon locations or shortcuts.
+
+## Acceptance Criteria
+
+- [ ] Typing `/` as the first character of the search box switches the popup into Commands mode and displays the command list.
+- [ ] The command list filters as the author types (`/le` matches `LET to LAMBDA`).
+- [ ] Enter executes the selected command; arrow keys navigate; Escape closes the popup (or exits Commands mode first — confirmed in plan).
+- [ ] Deleting back to empty or a non-`/` first character exits Commands mode and restores the previously active mode.
+- [ ] The mode indicator row shows "Libraries · Search · Commands" with the active mode highlighted.
+- [ ] All four v1 commands work end-to-end from the popup.
+- [ ] `LET to LAMBDA` and `Edit Lambda` close the popup before running.
+- [ ] `Load Library` switches popup mode without closing.
+- [ ] `Settings` opens the settings window and closes the popup.
+- [ ] When the Edit Lambda ribbon button doesn't yet exist (i.e. spec 0003 isn't landed), the `Edit Lambda` slash command is the only way to reach it — or we gate this spec on 0003. The plan should sequence accordingly.
+
+## Out of Scope
+
+- Slash commands accepting arguments (e.g. `/load MyLibrary`). v1 is noun-only.
+- User-customizable command lists or keybindings.
+- Slash commands in other windows (e.g. `LetToLambdaWindow`).
+- Treating `/` inside a query (not first character) as a special character.
+
+## Open Questions
+
+- Should Escape in Commands mode exit back to the previous mode (two-step exit), or close the popup outright (one-step, matching other modes)? Tentative: two-step — Escape exits Commands mode first, then a second Escape closes the popup. Aligns with the popup's prefix-prompt pattern.
+- Ordering: this spec depends on spec 0003 for the `Edit Lambda` command. If 0003 isn't implemented when this is picked up, the `Edit Lambda` entry should be omitted rather than stubbed.


### PR DESCRIPTION
## Summary

- Adds four specs under `specs/` for a set of improvements to the LET to LAMBDA authoring workflow: reorder inputs, optional parameters with ISOMITTED defaults, Edit Lambda round-trip, and slash commands in the main popup.
- Docs-only — no code changes.

## Specs

- `specs/0001-reorder-lambda-input-params.md`
- `specs/0002-optional-lambda-input-params.md`
- `specs/0003-edit-lambda.md`
- `specs/0004-slash-commands-in-popup.md`

## Related issues

Umbrella: #91
Children: #92, #93, #94, #95

## Test plan

- [ ] Read each spec and confirm scope, acceptance criteria, and open questions match intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)