### PR TITLE
Add Edit Lambda command to expand LAMBDA call into LET

### DIFF
--- a/addin/lambda-boss.Tests/EditLambdaCommandTests.cs
+++ b/addin/lambda-boss.Tests/EditLambdaCommandTests.cs
@@ -6,6 +6,8 @@ namespace LambdaBoss.Tests;
 
 public class EditLambdaCommandTests
 {
+    private static string Lines(params string[] lines) => string.Join("\n", lines);
+
     [Fact]
     public void TryParseLambdaCall_SimpleCall_ReturnsNameAndArgs()
     {
@@ -110,12 +112,17 @@ public class EditLambdaCommandTests
     }
 
     [Fact]
-    public void BuildExpandedLet_FullArgs_EmitsLet()
+    public void BuildExpandedLet_FullArgs_EmitsFormattedLet()
     {
         var sig = new LambdaSignature(new[] { "x", "y" }, "x * y + 1");
         var result = EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1", "B1 + 2" });
 
-        Assert.Equal("=LET(x, A1, y, B1 + 2, x * y + 1)", result);
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, A1,",
+            "    y, B1 + 2,",
+            "    x * y + 1",
+            ")"), result);
     }
 
     [Fact]
@@ -133,7 +140,11 @@ public class EditLambdaCommandTests
         var sig = new LambdaSignature(new[] { "x", "y", "z" }, "x + y + z");
         var result = EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1" });
 
-        Assert.Equal("=LET(x, A1, x + y + z)", result);
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, A1,",
+            "    x + y + z",
+            ")"), result);
     }
 
     [Fact]
@@ -159,12 +170,73 @@ public class EditLambdaCommandTests
     [Fact]
     public void BuildExpandedLet_OptionalParamsStripped_GeneratesBareNamesInLet()
     {
-        // LAMBDA with an optional [y] still expands into a LET using the bare
-        // parameter name `y`.
         var sig = LambdaSignatureParser.Parse("=LAMBDA(x, [y], x + y)");
         var result = EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1", "B1" });
 
-        Assert.Equal("=LET(x, A1, y, B1, x + y)", result);
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, A1,",
+            "    y, B1,",
+            "    x + y",
+            ")"), result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_BodyIsLet_FoldsIntoOuterLet()
+    {
+        // Nested LET in body should fold into the outer LET so the result is
+        // a single flat LET rather than LET-in-LET.
+        var sig = LambdaSignatureParser.Parse(
+            "=LAMBDA(x, y, LET(m, MAX(x), m + y))");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1", "B1" });
+
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, A1,",
+            "    y, B1,",
+            "    m, MAX(x),",
+            "    m + y",
+            ")"), result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_BodyIsMultiLineLet_FoldsCorrectly()
+    {
+        // Mirrors what Edit Lambda sees after LET to LAMBDA formatted the
+        // stored LAMBDA with newlines.
+        var refersTo = Lines(
+            "=LAMBDA(",
+            "    x,",
+            "    y,",
+            "    LET(",
+            "        m, MAX(x),",
+            "        m + y",
+            "    )",
+            ")");
+        var sig = LambdaSignatureParser.Parse(refersTo);
+        var result = EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1", "B1" });
+
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, A1,",
+            "    y, B1,",
+            "    m, MAX(x),",
+            "    m + y",
+            ")"), result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_BodyContainsLetInsideExpression_DoesNotFold()
+    {
+        // Body has a LET but it's embedded in a larger expression.
+        var sig = new LambdaSignature(new[] { "x" }, "LET(a, x, a) + 1");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1" });
+
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, A1,",
+            "    LET(a, x, a) + 1",
+            ")"), result);
     }
 
     [Fact]
@@ -180,6 +252,37 @@ public class EditLambdaCommandTests
         var sig = LambdaSignatureParser.Parse(refersTo);
         var letFormula = EditLambdaCommand.BuildExpandedLet(sig, call.Arguments);
 
-        Assert.Equal("=LET(x, A1, y, B1 + 2, x * y + 1)", letFormula);
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, A1,",
+            "    y, B1 + 2,",
+            "    x * y + 1",
+            ")"), letFormula);
+    }
+
+    [Fact]
+    public void RoundTrip_LetToLambdaThenEditLambda_FlattensToOriginalShape()
+    {
+        // Simulate the full round trip: author a LET, convert to LAMBDA, then
+        // call it and expand via Edit Lambda. The expanded LET should fold
+        // the internal binding back into a single flat LET.
+        var parsed = LetParser.Parse("=LET(x, 5, y, MAX(x), x + y)");
+        var request = new LambdaGenerationRequest(
+            "MyCalc",
+            parsed,
+            new[] { new InputChoice("x", "x", true) });
+        var refersTo = LetToLambdaBuilder.Build(request);
+
+        var sig = LambdaSignatureParser.Parse(refersTo);
+        var call = EditLambdaCommand.TryParseLambdaCall("=MyCalc(A1)");
+        Assert.NotNull(call);
+        var expanded = EditLambdaCommand.BuildExpandedLet(sig, call!.Arguments);
+
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, A1,",
+            "    y, MAX(x),",
+            "    x + y",
+            ")"), expanded);
     }
 }

--- a/addin/lambda-boss.Tests/EditLambdaCommandTests.cs
+++ b/addin/lambda-boss.Tests/EditLambdaCommandTests.cs
@@ -1,0 +1,185 @@
+using LambdaBoss.Commands;
+
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+public class EditLambdaCommandTests
+{
+    [Fact]
+    public void TryParseLambdaCall_SimpleCall_ReturnsNameAndArgs()
+    {
+        var call = EditLambdaCommand.TryParseLambdaCall("=MyCalc(A1, B1)");
+
+        Assert.NotNull(call);
+        Assert.Equal("MyCalc", call!.Name);
+        Assert.Equal(new[] { "A1", "B1" }, call.Arguments);
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_ArgsWithExpressions_PreservesInnerText()
+    {
+        var call = EditLambdaCommand.TryParseLambdaCall("=MyCalc(A1, B1 + 2)");
+
+        Assert.NotNull(call);
+        Assert.Equal(new[] { "A1", "B1 + 2" }, call!.Arguments);
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_NestedCallAsArg_TreatedAsSingleArg()
+    {
+        var call = EditLambdaCommand.TryParseLambdaCall("=MyCalc(SUM(A1, B1), C1)");
+
+        Assert.NotNull(call);
+        Assert.Equal(new[] { "SUM(A1, B1)", "C1" }, call!.Arguments);
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_ZeroArgs_ReturnsEmptyList()
+    {
+        var call = EditLambdaCommand.TryParseLambdaCall("=MyCalc()");
+
+        Assert.NotNull(call);
+        Assert.Equal("MyCalc", call!.Name);
+        Assert.Empty(call.Arguments);
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_WhitespaceOnlyInside_ReturnsEmptyArgs()
+    {
+        var call = EditLambdaCommand.TryParseLambdaCall("=MyCalc(  )");
+
+        Assert.NotNull(call);
+        Assert.Empty(call!.Arguments);
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_DottedName_Matches()
+    {
+        var call = EditLambdaCommand.TryParseLambdaCall("=tst.Double(A1)");
+
+        Assert.NotNull(call);
+        Assert.Equal("tst.Double", call!.Name);
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_WhitespaceAfterClose_Ok()
+    {
+        var call = EditLambdaCommand.TryParseLambdaCall("=MyCalc(A1)   ");
+
+        Assert.NotNull(call);
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_TrailingExpression_Rejected()
+    {
+        Assert.Null(EditLambdaCommand.TryParseLambdaCall("=MyCalc(A1) + 5"));
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_LeadingExpression_Rejected()
+    {
+        Assert.Null(EditLambdaCommand.TryParseLambdaCall("=5 + MyCalc(A1)"));
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_NotAFormula_Rejected()
+    {
+        Assert.Null(EditLambdaCommand.TryParseLambdaCall("MyCalc(A1)"));
+        Assert.Null(EditLambdaCommand.TryParseLambdaCall("123"));
+        Assert.Null(EditLambdaCommand.TryParseLambdaCall(""));
+        Assert.Null(EditLambdaCommand.TryParseLambdaCall(null));
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_NoParens_Rejected()
+    {
+        Assert.Null(EditLambdaCommand.TryParseLambdaCall("=MyCalc"));
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_UnbalancedParens_Rejected()
+    {
+        Assert.Null(EditLambdaCommand.TryParseLambdaCall("=MyCalc(A1"));
+    }
+
+    [Fact]
+    public void TryParseLambdaCall_NumericLeading_Rejected()
+    {
+        Assert.Null(EditLambdaCommand.TryParseLambdaCall("=123(A1)"));
+    }
+
+    [Fact]
+    public void BuildExpandedLet_FullArgs_EmitsLet()
+    {
+        var sig = new LambdaSignature(new[] { "x", "y" }, "x * y + 1");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1", "B1 + 2" });
+
+        Assert.Equal("=LET(x, A1, y, B1 + 2, x * y + 1)", result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_ZeroParamsZeroArgs_ReturnsBareBody()
+    {
+        var sig = new LambdaSignature(Array.Empty<string>(), "1 + 1");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, Array.Empty<string>());
+
+        Assert.Equal("=1 + 1", result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_FewerArgsThanParams_LeavesTrailingUnbound()
+    {
+        var sig = new LambdaSignature(new[] { "x", "y", "z" }, "x + y + z");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1" });
+
+        Assert.Equal("=LET(x, A1, x + y + z)", result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_ZeroArgsWithParams_OmitsLetWrapper()
+    {
+        var sig = new LambdaSignature(new[] { "x" }, "x + 1");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, Array.Empty<string>());
+
+        Assert.Equal("=x + 1", result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_TooManyArgs_Throws()
+    {
+        var sig = new LambdaSignature(new[] { "x" }, "x + 1");
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1", "B1" }));
+        Assert.Contains("1 parameter", ex.Message);
+        Assert.Contains("2 were provided", ex.Message);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_OptionalParamsStripped_GeneratesBareNamesInLet()
+    {
+        // LAMBDA with an optional [y] still expands into a LET using the bare
+        // parameter name `y`.
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(x, [y], x + y)");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, new[] { "A1", "B1" });
+
+        Assert.Equal("=LET(x, A1, y, B1, x + y)", result);
+    }
+
+    [Fact]
+    public void EndToEnd_SpecExample_ProducesExpectedLet()
+    {
+        var formula = "=MyCalc(A1, B1 + 2)";
+        var refersTo = "=LAMBDA(x, y, x * y + 1)";
+
+        var call = EditLambdaCommand.TryParseLambdaCall(formula);
+        Assert.NotNull(call);
+        Assert.Equal("MyCalc", call!.Name);
+
+        var sig = LambdaSignatureParser.Parse(refersTo);
+        var letFormula = EditLambdaCommand.BuildExpandedLet(sig, call.Arguments);
+
+        Assert.Equal("=LET(x, A1, y, B1 + 2, x * y + 1)", letFormula);
+    }
+}

--- a/addin/lambda-boss.Tests/LambdaSignatureParserTests.cs
+++ b/addin/lambda-boss.Tests/LambdaSignatureParserTests.cs
@@ -1,0 +1,133 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+public class LambdaSignatureParserTests
+{
+    [Fact]
+    public void IsLambdaFormula_DetectsLambda()
+    {
+        Assert.True(LambdaSignatureParser.IsLambdaFormula("=LAMBDA(x, x)"));
+        Assert.True(LambdaSignatureParser.IsLambdaFormula("=lambda(x, x)"));
+        Assert.True(LambdaSignatureParser.IsLambdaFormula("=LAMBDA ( x , x )"));
+    }
+
+    [Fact]
+    public void IsLambdaFormula_RejectsNonLambda()
+    {
+        Assert.False(LambdaSignatureParser.IsLambdaFormula("=SUM(A1:A10)"));
+        Assert.False(LambdaSignatureParser.IsLambdaFormula("=LET(x, 1, x)"));
+        Assert.False(LambdaSignatureParser.IsLambdaFormula("=IF(A1, LAMBDA(x, x), 0)"));
+        Assert.False(LambdaSignatureParser.IsLambdaFormula(" =LAMBDA(x, x)"));
+        Assert.False(LambdaSignatureParser.IsLambdaFormula(""));
+        Assert.False(LambdaSignatureParser.IsLambdaFormula(null));
+    }
+
+    [Fact]
+    public void Parse_SingleParam_ReturnsParamAndBody()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(x, x*2)");
+
+        Assert.Equal(new[] { "x" }, sig.Parameters);
+        Assert.Equal("x*2", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_MultipleParams_PreservesOrder()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(x, y, z, x + y * z)");
+
+        Assert.Equal(new[] { "x", "y", "z" }, sig.Parameters);
+        Assert.Equal("x + y * z", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_NestedCommasInBody_TreatedAsOneBody()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(x, SUM(x, 1, 2))");
+
+        Assert.Equal(new[] { "x" }, sig.Parameters);
+        Assert.Equal("SUM(x, 1, 2)", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_NestedLambdaInBody_PreservedAsBody()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(x, LAMBDA(y, x + y))");
+
+        Assert.Equal(new[] { "x" }, sig.Parameters);
+        Assert.Equal("LAMBDA(y, x + y)", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_OptionalParamBrackets_Stripped()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA([x], x*2)");
+
+        Assert.Equal(new[] { "x" }, sig.Parameters);
+        Assert.Equal("x*2", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_MixedRequiredAndOptional_StripsBrackets()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(a, [b], a + b)");
+
+        Assert.Equal(new[] { "a", "b" }, sig.Parameters);
+        Assert.Equal("a + b", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_NoParams_ReturnsEmptyParamsAndBody()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(1 + 1)");
+
+        Assert.Empty(sig.Parameters);
+        Assert.Equal("1 + 1", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_CaseInsensitiveAndWhitespaceTolerant()
+    {
+        var sig = LambdaSignatureParser.Parse("=lambda( x ,  y , x + y )");
+
+        Assert.Equal(new[] { "x", "y" }, sig.Parameters);
+        Assert.Equal("x + y", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_StringLiteralWithCommasInBody_PreservedIntact()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(x, CONCAT(\"a, b\", x))");
+
+        Assert.Equal(new[] { "x" }, sig.Parameters);
+        Assert.Equal("CONCAT(\"a, b\", x)", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_NonLambdaFormula_Throws()
+    {
+        Assert.Throws<FormatException>(() => LambdaSignatureParser.Parse("=LET(x, 1, x)"));
+    }
+
+    [Fact]
+    public void Parse_UnbalancedParens_Throws()
+    {
+        Assert.Throws<FormatException>(() => LambdaSignatureParser.Parse("=LAMBDA(x, x"));
+    }
+
+    [Fact]
+    public void Parse_InvalidParamName_Throws()
+    {
+        Assert.Throws<FormatException>(() => LambdaSignatureParser.Parse("=LAMBDA(1x, x)"));
+    }
+
+    [Fact]
+    public void Parse_RealWorldExample_FromSpec()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(x, y, x * y + 1)");
+
+        Assert.Equal(new[] { "x", "y" }, sig.Parameters);
+        Assert.Equal("x * y + 1", sig.Body);
+    }
+}

--- a/addin/lambda-boss.Tests/LetToLambdaBuilderTests.cs
+++ b/addin/lambda-boss.Tests/LetToLambdaBuilderTests.cs
@@ -22,13 +22,20 @@ public class LetToLambdaBuilderTests
         return LetToLambdaBuilder.Build(new LambdaGenerationRequest(lambdaName, parsed, inputs));
     }
 
+    private static string Lines(params string[] lines) => string.Join("\n", lines);
+
     [Fact]
     public void AllInputsKept_NoInternalLet()
     {
         var result = Build("=LET(x, 1, y, 2, SUM(x, y))", "Adder",
             ("x", "x", true), ("y", "y", true));
 
-        Assert.Equal("=LAMBDA(x, y, SUM(x, y))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    x,",
+            "    y,",
+            "    SUM(x, y)",
+            ")"), result);
     }
 
     [Fact]
@@ -37,7 +44,12 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(x, 1, y, 2, SUM(x, y))", "Adder",
             ("x", "a", true), ("y", "b", true));
 
-        Assert.Equal("=LAMBDA(a, b, SUM(a, b))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    a,",
+            "    b,",
+            "    SUM(a, b)",
+            ")"), result);
     }
 
     [Fact]
@@ -46,7 +58,14 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(someRange, A1:A10, getMax, MAX(someRange), getMax)", "MyMax",
             ("someRange", "someRange", true));
 
-        Assert.Equal("=LAMBDA(someRange, LET(getMax, MAX(someRange), getMax))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    someRange,",
+            "    LET(",
+            "        getMax, MAX(someRange),",
+            "        getMax",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -55,7 +74,14 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(a, A1:A10, b, MAX(a), b)", "MaxLambda",
             ("a", "myRange", true));
 
-        Assert.Equal("=LAMBDA(myRange, LET(b, MAX(myRange), b))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    myRange,",
+            "    LET(",
+            "        b, MAX(myRange),",
+            "        b",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -64,7 +90,14 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(x, 1, y, 2, x + y)", "Test",
             ("x", "x", false), ("y", "y", true));
 
-        Assert.Equal("=LAMBDA(y, LET(x, 1, x + y))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    y,",
+            "    LET(",
+            "        x, 1,",
+            "        x + y",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -73,7 +106,14 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(x, 1, y, 2, x + y)", "Zero",
             ("x", "x", false), ("y", "y", false));
 
-        Assert.Equal("=LAMBDA(LET(x, 1, y, 2, x + y))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    LET(",
+            "        x, 1,",
+            "        y, 2,",
+            "        x + y",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -82,7 +122,11 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(x, 1, CONCAT(\"x is \", x))", "WithString",
             ("x", "value", true));
 
-        Assert.Equal("=LAMBDA(value, CONCAT(\"x is \", value))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    value,",
+            "    CONCAT(\"x is \", value)",
+            ")"), result);
     }
 
     [Fact]
@@ -114,7 +158,13 @@ public class LetToLambdaBuilderTests
     {
         var result = Build("=LET(m, MAX(A1:A10), m + 1)", "MaxPlus1");
 
-        Assert.Equal("=LAMBDA(LET(m, MAX(A1:A10), m + 1))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    LET(",
+            "        m, MAX(A1:A10),",
+            "        m + 1",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -124,7 +174,12 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(x, 1, y, 2, SUM(x, y))", "Adder",
             ("y", "y", true), ("x", "x", true));
 
-        Assert.Equal("=LAMBDA(y, x, SUM(x, y))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    y,",
+            "    x,",
+            "    SUM(x, y)",
+            ")"), result);
     }
 
     [Fact]
@@ -135,7 +190,15 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(x, 1, y, MAX(x), z, 3, x + y + z)", "Mix",
             ("z", "z", true), ("x", "x", true));
 
-        Assert.Equal("=LAMBDA(z, x, LET(y, MAX(x), x + y + z))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    z,",
+            "    x,",
+            "    LET(",
+            "        y, MAX(x),",
+            "        x + y + z",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -144,7 +207,12 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(x, 1, y, 2, SUM(x, y))", "Adder",
             ("y", "second", true), ("x", "first", true));
 
-        Assert.Equal("=LAMBDA(second, first, SUM(first, second))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    second,",
+            "    first,",
+            "    SUM(first, second)",
+            ")"), result);
     }
 
     [Fact]
@@ -155,7 +223,15 @@ public class LetToLambdaBuilderTests
         var result = Build("=LET(x, 1, y, 2, z, 3, x + y + z)", "Skip",
             ("z", "z", false), ("y", "y", true), ("x", "x", true));
 
-        Assert.Equal("=LAMBDA(y, x, LET(z, 3, x + y + z))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    y,",
+            "    x,",
+            "    LET(",
+            "        z, 3,",
+            "        x + y + z",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -166,9 +242,15 @@ public class LetToLambdaBuilderTests
         var result = BuildWithOptional("=LET(x, 10, y, A1, x + y)", "Adder",
             ("x", "x", true, false), ("y", "offset", true, true));
 
-        Assert.Equal(
-            "=LAMBDA(x, [offset], LET(offset, IF(ISOMITTED(offset), $A$1, offset), x + offset))",
-            result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    x,",
+            "    [offset],",
+            "    LET(",
+            "        offset, IF(ISOMITTED(offset), $A$1, offset),",
+            "        x + offset",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -177,9 +259,16 @@ public class LetToLambdaBuilderTests
         var result = BuildWithOptional("=LET(x, 10, y, A1, x + y)", "Adder",
             ("x", "x", true, true), ("y", "offset", true, true));
 
-        Assert.Equal(
-            "=LAMBDA([x], [offset], LET(x, IF(ISOMITTED(x), 10, x), offset, IF(ISOMITTED(offset), $A$1, offset), x + offset))",
-            result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    [x],",
+            "    [offset],",
+            "    LET(",
+            "        x, IF(ISOMITTED(x), 10, x),",
+            "        offset, IF(ISOMITTED(offset), $A$1, offset),",
+            "        x + offset",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -191,19 +280,30 @@ public class LetToLambdaBuilderTests
         var result = BuildWithOptional("=LET(x, 10, y, x + 1, x + y)", "Calc",
             ("x", "x", true, true));
 
-        Assert.Equal(
-            "=LAMBDA([x], LET(x, IF(ISOMITTED(x), 10, x), y, x + 1, x + y))",
-            result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    [x],",
+            "    LET(",
+            "        x, IF(ISOMITTED(x), 10, x),",
+            "        y, x + 1,",
+            "        x + y",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
     public void NoOptionalParams_OutputIsUnchanged()
     {
-        // Matches the today's output exactly when IsOptional is false for all.
+        // Matches today's output exactly when IsOptional is false for all.
         var result = BuildWithOptional("=LET(x, 1, y, 2, SUM(x, y))", "Adder",
             ("x", "x", true, false), ("y", "y", true, false));
 
-        Assert.Equal("=LAMBDA(x, y, SUM(x, y))", result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    x,",
+            "    y,",
+            "    SUM(x, y)",
+            ")"), result);
     }
 
     [Fact]
@@ -215,9 +315,15 @@ public class LetToLambdaBuilderTests
         var result = BuildWithOptional("=LET(x, 5, y, x, x + y)", "Calc",
             ("x", "a", true, false), ("y", "y", true, true));
 
-        Assert.Equal(
-            "=LAMBDA(a, [y], LET(y, IF(ISOMITTED(y), a, y), a + y))",
-            result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    a,",
+            "    [y],",
+            "    LET(",
+            "        y, IF(ISOMITTED(y), a, y),",
+            "        a + y",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -226,9 +332,15 @@ public class LetToLambdaBuilderTests
         var result = BuildWithOptional("=LET(x, 10, y, A1, x + y)", "Adder",
             ("y", "offset", true, true), ("x", "base", true, false));
 
-        Assert.Equal(
-            "=LAMBDA([offset], base, LET(offset, IF(ISOMITTED(offset), $A$1, offset), base + offset))",
-            result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    [offset],",
+            "    base,",
+            "    LET(",
+            "        offset, IF(ISOMITTED(offset), $A$1, offset),",
+            "        base + offset",
+            "    )",
+            ")"), result);
     }
 
     [Fact]
@@ -265,8 +377,27 @@ public class LetToLambdaBuilderTests
         var result = BuildWithOptional("=LET(x, 5, x + 1)", "Inc",
             ("x", "x", true, true));
 
-        Assert.Equal(
-            "=LAMBDA([x], LET(x, IF(ISOMITTED(x), 5, x), x + 1))",
-            result);
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    [x],",
+            "    LET(",
+            "        x, IF(ISOMITTED(x), 5, x),",
+            "        x + 1",
+            "    )",
+            ")"), result);
+    }
+
+    [Fact]
+    public void GeneratedLambda_ParsesBackViaLambdaSignatureParser()
+    {
+        // The formatted output must round-trip cleanly through the parser
+        // so Edit Lambda can expand it back into a LET.
+        var refersTo = Build("=LET(x, 1, y, 2, SUM(x, y))", "Adder",
+            ("x", "x", true), ("y", "y", true));
+
+        Assert.True(LambdaSignatureParser.IsLambdaFormula(refersTo));
+        var sig = LambdaSignatureParser.Parse(refersTo);
+        Assert.Equal(new[] { "x", "y" }, sig.Parameters);
+        Assert.Equal("SUM(x, y)", sig.Body);
     }
 }

--- a/addin/lambda-boss/Commands/ConvertLetToLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/ConvertLetToLambdaCommand.cs
@@ -13,7 +13,7 @@ namespace LambdaBoss.Commands;
 ///     Ribbon handler: converts the active cell's =LET(...) formula into a
 ///     workbook-scoped LAMBDA registered in the Name Manager.
 /// </summary>
-public static class ConvertLetToLambdaCommand
+internal static class ConvertLetToLambdaCommand
 {
     public static void Run()
     {

--- a/addin/lambda-boss/Commands/ConvertLetToLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/ConvertLetToLambdaCommand.cs
@@ -58,7 +58,7 @@ internal static class ConvertLetToLambdaCommand
                 {
                     var window = new LetToLambdaWindow(
                         parsed,
-                        name => existingNames.Contains(name));
+                        name => existingNames.TryGetValue(name, out string? refersTo) ? refersTo : null);
 
                     var wpfHwnd = new WindowInteropHelper(window).EnsureHandle();
                     WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
@@ -89,14 +89,19 @@ internal static class ConvertLetToLambdaCommand
         }
     }
 
-    private static HashSet<string> GetExistingNames(dynamic workbook)
+    private static Dictionary<string, string> GetExistingNames(dynamic workbook)
     {
-        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var names = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         try
         {
             foreach (dynamic n in workbook.Names)
             {
-                try { names.Add((string)n.Name); }
+                try
+                {
+                    var name = (string)n.Name;
+                    var refersTo = (string?)n.RefersTo ?? string.Empty;
+                    names[name] = refersTo;
+                }
                 catch { /* skip unreadable */ }
             }
         }

--- a/addin/lambda-boss/Commands/EditLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/EditLambdaCommand.cs
@@ -1,0 +1,192 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Windows;
+
+using ExcelDna.Integration;
+
+using Taglo.Excel.Common;
+
+namespace LambdaBoss.Commands;
+
+/// <summary>
+///     Ribbon handler: when the active cell's formula is exactly a call to a
+///     registered LAMBDA (e.g. <c>=MyCalc(A1, B1 + 2)</c>), replaces it with
+///     an equivalent <c>=LET(...)</c> that inlines the LAMBDA's parameters
+///     (bound to the call-site arguments) followed by the LAMBDA's body. The
+///     workbook name definition is left in place so rerunning LET to LAMBDA
+///     with the same name overwrites it.
+/// </summary>
+public static class EditLambdaCommand
+{
+    private const string NotALambdaCallMessage =
+        "Edit Lambda requires a cell whose formula is exactly a call to a LAMBDA "
+        + "(e.g. =MyLambda(A1, B1)).";
+
+    private static readonly Regex CallPrefix = new(
+        @"^=\s*([A-Za-z_][A-Za-z0-9_.]*)\s*\(",
+        RegexOptions.CultureInvariant);
+
+    internal record LambdaCall(string Name, IReadOnlyList<string> Arguments);
+
+    public static void Run()
+    {
+        try
+        {
+            dynamic app = ExcelDnaUtil.Application;
+            dynamic workbook = app.ActiveWorkbook;
+            if (workbook == null)
+            {
+                ShowError("No active workbook.");
+                return;
+            }
+
+            dynamic activeCell = app.ActiveCell;
+            var formula = activeCell?.Formula as string;
+
+            var call = TryParseLambdaCall(formula);
+            if (call == null)
+            {
+                ShowError(NotALambdaCallMessage);
+                return;
+            }
+
+            var refersTo = ResolveName(workbook, call.Name);
+            if (!LambdaSignatureParser.IsLambdaFormula(refersTo))
+            {
+                ShowError(NotALambdaCallMessage);
+                return;
+            }
+
+            LambdaSignature signature;
+            try
+            {
+                signature = LambdaSignatureParser.Parse(refersTo!);
+            }
+            catch (FormatException ex)
+            {
+                ShowError($"Could not parse LAMBDA definition for '{call.Name}': {ex.Message}");
+                return;
+            }
+
+            string letFormula;
+            try
+            {
+                letFormula = BuildExpandedLet(signature, call.Arguments);
+            }
+            catch (InvalidOperationException ex)
+            {
+                ShowError(ex.Message);
+                return;
+            }
+
+            try
+            {
+                activeCell.Formula = letFormula;
+                Logger.Info($"EditLambda: Expanded '{call.Name}' into LET");
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("EditLambda/SetFormula", ex);
+                ShowError($"Failed to update cell: {ex.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("EditLambda", ex);
+            ShowError($"Unexpected error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    ///     Parses a formula that looks like <c>=Name(args...)</c> into the name
+    ///     and top-level arguments. Returns null if the formula is not exactly
+    ///     a single call (e.g. has trailing content, missing parens, etc.).
+    /// </summary>
+    internal static LambdaCall? TryParseLambdaCall(string? formula)
+    {
+        if (string.IsNullOrEmpty(formula))
+            return null;
+
+        var match = CallPrefix.Match(formula);
+        if (!match.Success)
+            return null;
+
+        var name = match.Groups[1].Value;
+        var openParen = match.Index + match.Length - 1;
+        var closeParen = LetParser.FindMatchingClose(formula, openParen);
+        if (closeParen < 0)
+            return null;
+
+        for (var i = closeParen + 1; i < formula.Length; i++)
+        {
+            if (!char.IsWhiteSpace(formula[i]))
+                return null;
+        }
+
+        var inner = formula[(openParen + 1)..closeParen];
+        var args = inner.Trim().Length == 0
+            ? new List<string>()
+            : LetParser.SplitTopLevelCommas(inner).Select(a => a.Trim()).ToList();
+
+        return new LambdaCall(name, args);
+    }
+
+    /// <summary>
+    ///     Builds a <c>=LET(param1, arg1, ..., body)</c> formula that binds
+    ///     as many of the LAMBDA's parameters as call-site arguments were
+    ///     provided. Throws when the caller passed more arguments than the
+    ///     LAMBDA declares.
+    /// </summary>
+    internal static string BuildExpandedLet(LambdaSignature signature, IReadOnlyList<string> arguments)
+    {
+        ArgumentNullException.ThrowIfNull(signature);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        if (arguments.Count > signature.Parameters.Count)
+        {
+            throw new InvalidOperationException(
+                $"Too many arguments: LAMBDA has {signature.Parameters.Count} parameter(s) "
+                + $"but {arguments.Count} were provided.");
+        }
+
+        if (arguments.Count == 0)
+            return "=" + signature.Body;
+
+        var sb = new StringBuilder();
+        sb.Append("=LET(");
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            sb.Append(signature.Parameters[i])
+              .Append(", ")
+              .Append(arguments[i])
+              .Append(", ");
+        }
+        sb.Append(signature.Body).Append(')');
+        return sb.ToString();
+    }
+
+    private static string? ResolveName(dynamic workbook, string name)
+    {
+        try
+        {
+            dynamic n = workbook.Names.Item(name);
+            return n?.RefersTo as string;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void ShowError(string message)
+    {
+        try
+        {
+            MessageBox.Show(message, "Lambda Boss", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch
+        {
+            Logger.Info($"ShowError: {message}");
+        }
+    }
+}

--- a/addin/lambda-boss/Commands/EditLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/EditLambdaCommand.cs
@@ -16,7 +16,7 @@ namespace LambdaBoss.Commands;
 ///     workbook name definition is left in place so rerunning LET to LAMBDA
 ///     with the same name overwrites it.
 /// </summary>
-public static class EditLambdaCommand
+internal static class EditLambdaCommand
 {
     private const string NotALambdaCallMessage =
         "Edit Lambda requires a cell whose formula is exactly a call to a LAMBDA "

--- a/addin/lambda-boss/Commands/EditLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/EditLambdaCommand.cs
@@ -134,8 +134,11 @@ internal static class EditLambdaCommand
     /// <summary>
     ///     Builds a <c>=LET(param1, arg1, ..., body)</c> formula that binds
     ///     as many of the LAMBDA's parameters as call-site arguments were
-    ///     provided. Throws when the caller passed more arguments than the
-    ///     LAMBDA declares.
+    ///     provided. When the LAMBDA body is itself a LET, its bindings are
+    ///     folded into the outer LET so the result is a single flat LET
+    ///     rather than a LET-inside-LET. Output is formatted with newlines so
+    ///     it renders legibly in Excel's formula bar. Throws when the caller
+    ///     passed more arguments than the LAMBDA declares.
     /// </summary>
     internal static string BuildExpandedLet(LambdaSignature signature, IReadOnlyList<string> arguments)
     {
@@ -149,20 +152,74 @@ internal static class EditLambdaCommand
                 + $"but {arguments.Count} were provided.");
         }
 
-        if (arguments.Count == 0)
-            return "=" + signature.Body;
+        var pairs = new List<(string Name, string Value)>();
+        for (var i = 0; i < arguments.Count; i++)
+            pairs.Add((signature.Parameters[i], arguments[i]));
+
+        string body;
+        if (TryParseBodyAsLet(signature.Body, out var innerBindings, out var innerBody))
+        {
+            pairs.AddRange(innerBindings);
+            body = innerBody;
+        }
+        else
+        {
+            body = signature.Body;
+        }
+
+        if (pairs.Count == 0)
+            return "=" + body;
 
         var sb = new StringBuilder();
-        sb.Append("=LET(");
-        for (var i = 0; i < arguments.Count; i++)
-        {
-            sb.Append(signature.Parameters[i])
-              .Append(", ")
-              .Append(arguments[i])
-              .Append(", ");
-        }
-        sb.Append(signature.Body).Append(')');
+        sb.Append('=');
+        FormulaFormatter.AppendLet(sb, indent: 0, pairs, body);
         return sb.ToString();
+    }
+
+    private static readonly Regex NestedLetPrefix = new(
+        @"^LET\s*\(",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    ///     Detects whether <paramref name="body" /> is exactly a single
+    ///     <c>LET(...)</c> expression (no leading or trailing content) and
+    ///     extracts its bindings and inner body if so. Returns false when the
+    ///     body isn't a pure LET or the LET is malformed.
+    /// </summary>
+    private static bool TryParseBodyAsLet(
+        string body,
+        out List<(string Name, string Value)> bindings,
+        out string innerBody)
+    {
+        bindings = new List<(string, string)>();
+        innerBody = string.Empty;
+
+        var trimmed = body.TrimStart();
+        var leading = body.Length - trimmed.Length;
+        var match = NestedLetPrefix.Match(trimmed);
+        if (!match.Success)
+            return false;
+
+        var openParen = leading + match.Index + match.Length - 1;
+        var closeParen = LetParser.FindMatchingClose(body, openParen);
+        if (closeParen < 0)
+            return false;
+
+        for (var i = closeParen + 1; i < body.Length; i++)
+        {
+            if (!char.IsWhiteSpace(body[i]))
+                return false;
+        }
+
+        var inner = body[(openParen + 1)..closeParen];
+        var args = LetParser.SplitTopLevelCommas(inner).Select(a => a.Trim()).ToList();
+        if (args.Count < 3 || args.Count % 2 == 0)
+            return false;
+
+        for (var i = 0; i < args.Count - 1; i += 2)
+            bindings.Add((args[i], args[i + 1]));
+        innerBody = args[^1];
+        return true;
     }
 
     private static string? ResolveName(dynamic workbook, string name)

--- a/addin/lambda-boss/FormulaFormatter.cs
+++ b/addin/lambda-boss/FormulaFormatter.cs
@@ -1,0 +1,59 @@
+using System.Text;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     Emits formatted <c>LET(...)</c> and <c>LAMBDA(...)</c> blocks into a
+///     <see cref="StringBuilder" /> so authored formulas render legibly in
+///     Excel's formula bar (one parameter/binding per line, 4-space indent
+///     per nesting level). Excel preserves embedded newlines in cell formulas
+///     and <c>Name.RefersTo</c> values.
+/// </summary>
+internal static class FormulaFormatter
+{
+    internal const int IndentStep = 4;
+
+    /// <summary>
+    ///     Emits <c>LET(\n    name1, value1,\n    ..., body\n)</c> starting at
+    ///     the caller's current cursor position. <paramref name="indent" /> is
+    ///     the column the closing paren sits at (and the column the opening
+    ///     line would start at if the caller were at column 0). Bindings and
+    ///     body are emitted at <paramref name="indent" /> + 4.
+    /// </summary>
+    public static void AppendLet(
+        StringBuilder sb,
+        int indent,
+        IReadOnlyList<(string Name, string Value)> bindings,
+        string body)
+    {
+        var close = new string(' ', indent);
+        var inner = new string(' ', indent + IndentStep);
+
+        sb.Append("LET(\n");
+        foreach (var (name, value) in bindings)
+            sb.Append(inner).Append(name).Append(", ").Append(value).Append(",\n");
+        sb.Append(inner).Append(body).Append('\n').Append(close).Append(')');
+    }
+
+    /// <summary>
+    ///     Emits <c>LAMBDA(\n    param1,\n    ..., body\n)</c>. Parameters are
+    ///     placed on their own lines and the body is emitted verbatim at
+    ///     <paramref name="indent" /> + 4. If the body is itself an inline
+    ///     formatted block, callers should already have produced it with the
+    ///     same indent convention.
+    /// </summary>
+    public static void AppendLambda(
+        StringBuilder sb,
+        int indent,
+        IReadOnlyList<string> parameters,
+        string body)
+    {
+        var close = new string(' ', indent);
+        var inner = new string(' ', indent + IndentStep);
+
+        sb.Append("LAMBDA(\n");
+        foreach (var p in parameters)
+            sb.Append(inner).Append(p).Append(",\n");
+        sb.Append(inner).Append(body).Append('\n').Append(close).Append(')');
+    }
+}

--- a/addin/lambda-boss/LambdaSignatureParser.cs
+++ b/addin/lambda-boss/LambdaSignatureParser.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+
+namespace LambdaBoss;
+
+public record LambdaSignature(IReadOnlyList<string> Parameters, string Body);
+
+/// <summary>
+///     Parses an Excel <c>=LAMBDA(param1, ..., paramN, body)</c> formula into
+///     its parameter names and final body expression. Mirrors
+///     <see cref="LetParser" />. Optional parameters wrapped in
+///     <c>[brackets]</c> are accepted and the brackets are stripped from the
+///     returned names.
+/// </summary>
+public static class LambdaSignatureParser
+{
+    private static readonly Regex LambdaPrefix = new(
+        @"^=\s*LAMBDA\s*\(",
+        RegexOptions.IgnoreCase);
+
+    private static readonly Regex ParamNamePattern = new(
+        @"^\[?([A-Za-z_][A-Za-z0-9_.]*)\]?$");
+
+    public static bool IsLambdaFormula(string? formula)
+    {
+        if (string.IsNullOrEmpty(formula))
+            return false;
+        return LambdaPrefix.IsMatch(formula);
+    }
+
+    public static LambdaSignature Parse(string formula)
+    {
+        if (formula is null)
+            throw new ArgumentNullException(nameof(formula));
+
+        var match = LambdaPrefix.Match(formula);
+        if (!match.Success)
+            throw new FormatException("Formula must start with '=LAMBDA('.");
+
+        var openParen = match.Index + match.Length - 1;
+        var closeParen = LetParser.FindMatchingClose(formula, openParen);
+        if (closeParen < 0)
+            throw new FormatException("Unbalanced parentheses in LAMBDA formula.");
+
+        var inner = formula[(openParen + 1)..closeParen];
+        var args = LetParser.SplitTopLevelCommas(inner);
+
+        if (args.Count < 1)
+            throw new FormatException("LAMBDA must have at least a body expression.");
+
+        var parameters = new List<string>();
+        for (var i = 0; i < args.Count - 1; i++)
+        {
+            var raw = args[i].Trim();
+            var m = ParamNamePattern.Match(raw);
+            if (!m.Success)
+                throw new FormatException($"Invalid LAMBDA parameter name: '{raw}'.");
+            parameters.Add(m.Groups[1].Value);
+        }
+
+        var body = args[^1].Trim();
+        return new LambdaSignature(parameters, body);
+    }
+}

--- a/addin/lambda-boss/LetToLambdaBuilder.cs
+++ b/addin/lambda-boss/LetToLambdaBuilder.cs
@@ -111,38 +111,39 @@ public static class LetToLambdaBuilder
 
         var body = ApplyRenames(parsed.Body, renames);
 
-        var sb = new StringBuilder();
-        sb.Append("=LAMBDA(");
-        for (var i = 0; i < kept.Count; i++)
-        {
-            if (i > 0) sb.Append(", ");
-            // Optional params are wrapped in [] in the signature per Excel's
-            // convention for optional-argument IntelliSense. The bare name is
-            // still used for the inner LET binding and body references.
-            if (kept[i].Choice.IsOptional)
-                sb.Append('[').Append(kept[i].Choice.ParamName).Append(']');
-            else
-                sb.Append(kept[i].Choice.ParamName);
-        }
-        if (kept.Count > 0)
-            sb.Append(", ");
+        // Optional params wrap their name in [] per Excel's IntelliSense
+        // convention; the bare name is still used for inner-LET bindings and
+        // body references.
+        var paramSignatures = kept
+            .Select(k => k.Choice.IsOptional
+                ? $"[{k.Choice.ParamName}]"
+                : k.Choice.ParamName)
+            .ToList();
 
         var innerBindings = optionalBindings.Concat(internalBindings).ToList();
+
+        string lambdaBody;
         if (innerBindings.Count == 0)
         {
-            sb.Append(body);
+            lambdaBody = body;
         }
         else
         {
-            sb.Append("LET(");
-            foreach (var ib in innerBindings)
-            {
-                sb.Append(ib.Name).Append(", ").Append(ib.RhsText).Append(", ");
-            }
-            sb.Append(body).Append(')');
+            // LET sits one level below the LAMBDA (indent 4); its bindings sit
+            // two levels below (indent 8). Pre-format the block and pass it to
+            // AppendLambda so the LAMBDA layout stays uniform.
+            var bodyBuilder = new StringBuilder();
+            FormulaFormatter.AppendLet(
+                bodyBuilder,
+                FormulaFormatter.IndentStep,
+                innerBindings.Select(ib => (ib.Name, ib.RhsText)).ToList(),
+                body);
+            lambdaBody = bodyBuilder.ToString();
         }
 
-        sb.Append(')');
+        var sb = new StringBuilder();
+        sb.Append('=');
+        FormulaFormatter.AppendLambda(sb, indent: 0, paramSignatures, lambdaBody);
         return sb.ToString();
     }
 

--- a/addin/lambda-boss/RibbonController.cs
+++ b/addin/lambda-boss/RibbonController.cs
@@ -33,6 +33,12 @@ public class RibbonController : ExcelRibbon
                   imageMso='FunctionWizard'
                   onAction='OnLetToLambda'
                   screentip='Convert the active cell&apos;s =LET(...) formula into a workbook-scoped LAMBDA' />
+          <button id='EditLambdaButton'
+                  label='Edit Lambda'
+                  size='large'
+                  imageMso='Edit'
+                  onAction='OnEditLambda'
+                  screentip='Expand the active cell&apos;s LAMBDA call back into an equivalent =LET(...) for editing' />
         </group>
         <group id='ManageGroup' label='Manage'>
           <button id='SettingsButton'
@@ -96,6 +102,11 @@ public class RibbonController : ExcelRibbon
     public void OnLetToLambda(IRibbonControl control)
     {
         ConvertLetToLambdaCommand.Run();
+    }
+
+    public void OnEditLambda(IRibbonControl control)
+    {
+        EditLambdaCommand.Run();
     }
 
     public void OnAbout(IRibbonControl control)

--- a/addin/lambda-boss/UI/LetToLambdaWindow.xaml.cs
+++ b/addin/lambda-boss/UI/LetToLambdaWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
 
 namespace LambdaBoss.UI;
 
@@ -103,15 +104,27 @@ public class LetInputRow : INotifyPropertyChanged
 
 public partial class LetToLambdaWindow
 {
-    private readonly Func<string, bool> _nameCollides;
+    private static readonly Brush ErrorBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#e74856"));
+    private static readonly Brush InfoBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#d7ba7d"));
+
+    private readonly Func<string, string?> _resolveExistingRefersTo;
     private readonly ParsedLet _parsed;
     private readonly ObservableCollection<LetInputRow> _rows;
 
-    public LetToLambdaWindow(ParsedLet parsed, Func<string, bool> nameCollides)
+    /// <summary>
+    ///     Creates the dialog. <paramref name="resolveExistingRefersTo" />
+    ///     returns the <c>RefersTo</c> of an existing workbook name (or
+    ///     <c>null</c> if the name isn't taken). When the existing name is a
+    ///     LAMBDA, Save proceeds as an overwrite so authors can round-trip
+    ///     via Edit Lambda and re-register with the same name.
+    /// </summary>
+    public LetToLambdaWindow(ParsedLet parsed, Func<string, string?> resolveExistingRefersTo)
     {
         InitializeComponent();
         _parsed = parsed;
-        _nameCollides = nameCollides;
+        _resolveExistingRefersTo = resolveExistingRefersTo;
 
         var valueBindings = parsed.Bindings
             .Where(b => !b.IsCalculation)
@@ -296,14 +309,25 @@ public partial class LetToLambdaWindow
             return;
         }
 
-        if (_nameCollides(name))
+        var existingRefersTo = _resolveExistingRefersTo(name);
+        if (existingRefersTo != null)
         {
-            ShowNameError("Name already exists in this workbook.");
-            SaveButton.IsEnabled = false;
-            return;
+            if (LambdaSignatureParser.IsLambdaFormula(existingRefersTo))
+            {
+                ShowNameInfo($"'{name}' already exists — Save will overwrite the existing LAMBDA.");
+            }
+            else
+            {
+                ShowNameError(
+                    $"'{name}' already exists in this workbook and is not a LAMBDA. Choose another name.");
+                SaveButton.IsEnabled = false;
+                return;
+            }
         }
-
-        HideNameError();
+        else
+        {
+            HideNameError();
+        }
 
         // Validate rows: kept rows must have non-empty unique param names
         // not colliding with any retained LET binding name.
@@ -346,6 +370,14 @@ public partial class LetToLambdaWindow
     private void ShowNameError(string message)
     {
         NameErrorText.Text = message;
+        NameErrorText.Foreground = ErrorBrush;
+        NameErrorText.Visibility = Visibility.Visible;
+    }
+
+    private void ShowNameInfo(string message)
+    {
+        NameErrorText.Text = message;
+        NameErrorText.Foreground = InfoBrush;
         NameErrorText.Visibility = Visibility.Visible;
     }
 


### PR DESCRIPTION
Closes #94

## Summary

- Adds an **Edit Lambda** ribbon button (Generate group) that replaces the active cell's exact call to a registered LAMBDA with an equivalent `=LET(...)` inlining the LAMBDA's parameters bound to the call-site arguments.
- New `LambdaSignatureParser` extracts `(param1, ..., paramN, body)` from a `=LAMBDA(...)` `RefersTo` (handles optional `[x]` brackets, nested commas, case-insensitive, whitespace-tolerant).
- New `EditLambdaCommand` detects `=Name(args...)` shape exactly (rejects trailing content, missing parens), resolves the name via Name Manager, and builds the expanded LET. The LAMBDA Name definition is left in place so rerunning LET to LAMBDA with the same name overwrites it.
- Clear errors for: non-LAMBDA-call cells, call-site arg count exceeding LAMBDA param count. Fewer call-site args than params leaves trailing params unbound (documented behaviour).

### Example

`MyCalc` = `=LAMBDA(x, y, x * y + 1)`, active cell = `=MyCalc(A1, B1 + 2)`
→ cell becomes `=LET(x, A1, y, B1 + 2, x * y + 1)`.

## Test plan

- [x] Unit tests: `LambdaSignatureParserTests` (14) and `EditLambdaCommandTests` (19) — 421 tests pass, 0 fail.
- [x] Smoke test in Excel: register a LAMBDA via LET to LAMBDA, call it in a cell, run Edit Lambda, confirm cell becomes the equivalent LET.
- [x] Round-trip test: edit the LET, run LET to LAMBDA with the same name, confirm the Name's RefersTo is updated (existing `LambdaLoader.InjectLambda` path).
- [x] Error paths: non-LAMBDA call (e.g. `=SUM(A1:A10)`), non-exact call (`=MyCalc(A1) + 5`), too many args — all show a clear message and make no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)