### PR TITLE
Absolutize cell refs in excluded LET inputs when Lambdifying

### DIFF
--- a/addin/lambda-boss.Tests/LetToLambdaBuilderTests.cs
+++ b/addin/lambda-boss.Tests/LetToLambdaBuilderTests.cs
@@ -388,6 +388,95 @@ public class LetToLambdaBuilderTests
     }
 
     [Fact]
+    public void ExcludedInput_CellRefsInRhsAreAbsolutized()
+    {
+        // y is excluded, so its RHS is baked into the LAMBDA body. Its cell
+        // ref must be forced absolute for the same reason as optional
+        // defaults: a registered LAMBDA invoked from another cell would
+        // otherwise shift the reference.
+        var result = Build("=LET(x, 1, y, A1, x + y)", "Calc",
+            ("x", "x", true), ("y", "y", false));
+
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    x,",
+            "    LET(",
+            "        y, $A$1,",
+            "        x + y",
+            "    )",
+            ")"), result);
+    }
+
+    [Fact]
+    public void ExcludedInput_RangeRefAbsolutized()
+    {
+        var result = Build("=LET(data, A1:B10, x, 1, SUM(data) + x)", "Calc",
+            ("data", "data", false), ("x", "x", true));
+
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    x,",
+            "    LET(",
+            "        data, $A$1:$B$10,",
+            "        SUM(data) + x",
+            "    )",
+            ")"), result);
+    }
+
+    [Fact]
+    public void CalculationBinding_CellRefsNotAbsolutized()
+    {
+        // Calculation bindings (RHS contains an operator/call that doesn't
+        // resolve to a simple value) are the author's original derived
+        // expressions and are left verbatim, unlike excluded value inputs.
+        var result = Build("=LET(x, 1, m, MAX(A1:A10), x + m)", "Calc",
+            ("x", "x", true));
+
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    x,",
+            "    LET(",
+            "        m, MAX(A1:A10),",
+            "        x + m",
+            "    )",
+            ")"), result);
+    }
+
+    [Fact]
+    public void ExcludedInput_SheetQualifiedRefAbsolutized()
+    {
+        var result = Build("=LET(y, Sheet1!B2, x, 1, x + y)", "Calc",
+            ("y", "y", false), ("x", "x", true));
+
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    x,",
+            "    LET(",
+            "        y, Sheet1!$B$2,",
+            "        x + y",
+            "    )",
+            ")"), result);
+    }
+
+    [Fact]
+    public void ExcludedInput_StringLiteralCellRefNotAbsolutized()
+    {
+        // Tokens inside string literals must not be touched even when the
+        // surrounding RHS is from an excluded input.
+        var result = Build("=LET(msg, \"see A1\", x, 1, msg)", "Calc",
+            ("msg", "msg", false), ("x", "x", true));
+
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    x,",
+            "    LET(",
+            "        msg, \"see A1\",",
+            "        msg",
+            "    )",
+            ")"), result);
+    }
+
+    [Fact]
     public void GeneratedLambda_ParsesBackViaLambdaSignatureParser()
     {
         // The formatted output must round-trip cleanly through the parser

--- a/addin/lambda-boss/LetToLambdaBuilder.cs
+++ b/addin/lambda-boss/LetToLambdaBuilder.cs
@@ -80,12 +80,22 @@ public static class LetToLambdaBuilder
             .ToDictionary(k => k.Binding.Name, k => k.Choice.ParamName,
                 StringComparer.OrdinalIgnoreCase);
 
-        // Internal bindings preserve source order; their RHS text has renames applied.
+        // Internal bindings preserve source order; their RHS text has renames
+        // applied. For excluded inputs (value bindings the user chose not to
+        // keep) the RHS is hardcoded into the LAMBDA body, so cell refs are
+        // forced absolute for the same reason as optional defaults — see the
+        // note on AbsolutizeCellRefs. Calculation bindings are left untouched
+        // to preserve the author's original expression verbatim.
         var keptNames = kept.Select(k => k.Binding.Name)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         var internalBindings = parsed.Bindings
             .Where(b => !keptNames.Contains(b.Name))
-            .Select(b => new LetBinding(b.Name, ApplyRenames(b.RhsText, renames), b.IsCalculation))
+            .Select(b =>
+            {
+                var renamed = ApplyRenames(b.RhsText, renames);
+                var rhs = b.IsCalculation ? renamed : AbsolutizeCellRefs(renamed);
+                return new LetBinding(b.Name, rhs, b.IsCalculation);
+            })
             .ToList();
 
         // Optional bindings wrap each optional kept param with an
@@ -192,8 +202,10 @@ public static class LetToLambdaBuilder
     ///     fully absolute form (e.g. <c>A1</c>, <c>$A1</c>, <c>A$1</c> all
     ///     become <c>$A$1</c>). Ranges like <c>A1:B5</c> and sheet-qualified
     ///     refs like <c>Sheet1!A1</c> are handled; tokens inside string
-    ///     literals are left alone. Used so baked-in default expressions in
-    ///     optional-param LAMBDAs don't shift when the Name is invoked.
+    ///     literals are left alone. Used so baked-in expressions in a
+    ///     registered LAMBDA (optional-param defaults and excluded-input
+    ///     RHS values) don't shift when the Name is invoked from a cell
+    ///     other than the one it was registered against.
     /// </summary>
     internal static string AbsolutizeCellRefs(string text)
     {

--- a/addin/lambda-boss/UI/LetToLambdaWindow.xaml
+++ b/addin/lambda-boss/UI/LetToLambdaWindow.xaml
@@ -138,7 +138,7 @@
                    FontSize="11"
                    TextWrapping="Wrap"
                    Visibility="Collapsed"
-                   Text="Cell references in optional defaults are made absolute (e.g. $A$1) so the LAMBDA resolves them the same regardless of where it's called from." />
+                   Text="Cell references in optional defaults and hardcoded inputs are made absolute (e.g. $A$1) so the LAMBDA resolves them the same regardless of where it's called from." />
 
         <DockPanel Grid.Row="6" Margin="0,12,0,0">
             <Button x:Name="CancelButton"

--- a/addin/lambda-boss/UI/LetToLambdaWindow.xaml.cs
+++ b/addin/lambda-boss/UI/LetToLambdaWindow.xaml.cs
@@ -143,15 +143,15 @@ public partial class LetToLambdaWindow
             RepositionAfterKeepChanged(row);
 
         if (e.PropertyName is nameof(LetInputRow.IsOptional) or nameof(LetInputRow.Keep))
-            UpdateOptionalWarningVisibility();
+            UpdateAbsolutizeWarningVisibility();
 
         UpdateSaveEnabled();
     }
 
-    private void UpdateOptionalWarningVisibility()
+    private void UpdateAbsolutizeWarningVisibility()
     {
-        var anyOptional = _rows.Any(r => r.Keep && r.IsOptional);
-        OptionalWarningText.Visibility = anyOptional ? Visibility.Visible : Visibility.Collapsed;
+        var anyAbsolutized = _rows.Any(r => (r.Keep && r.IsOptional) || !r.Keep);
+        OptionalWarningText.Visibility = anyAbsolutized ? Visibility.Visible : Visibility.Collapsed;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Extends the absolute-cell-ref transform from f50e8af (optional-param defaults) to excluded inputs — value bindings the user unchecks in the LET→LAMBDA dialog, whose RHS gets hardcoded into the inner LET body. Same failure mode: without absolutization, refs shift by the offset between the active cell at `Names.Add` time and the invoking cell, baking in the wrong values.
- Calculation bindings are intentionally left verbatim: they are the author's derived expressions, not inputs the user excluded.
- UI warning below the inputs list now shows whenever any row is optional **or** any row is unchecked; text broadened to mention hardcoded inputs alongside optional defaults.

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` — clean
- [x] `dotnet test addin/lambda-boss.Tests` — all 438 tests pass (5 new tests for the excluded-input path, including range refs, sheet-qualified refs, string-literal protection, and a pin test for calc bindings staying verbatim)
- [x] Smoke test in Excel: build a LET with a cell ref in a binding, uncheck it, save the LAMBDA, then call the resulting Name from a different cell and confirm the excluded binding resolves to the original source value (not a shifted one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)