### PR TITLE
Test harness: optional setup block for range-reference inputs

### DIFF
--- a/.claude/skills/create-lambda/SKILL.md
+++ b/.claude/skills/create-lambda/SKILL.md
@@ -308,4 +308,22 @@ Tell the user:
 - **GROUPBY errors on a single-row input; skip one-element test cases.** `GROUPBY({"X"}, {"X"}, ROWS,, 0, -2)` returns `#CALC!` / HRESULT `-2146826273` in Excel even after normalising to a column. Drop the single-element test case — it's not a realistic use of a frequency lambda, and there's no clean workaround without branching on `ROWS(arr)=1`.
 - **SEQUENCE orientation matters for INDEX column indexing.** `INDEX(array, , SEQUENCE(n,,n,-1))` produces an nx1 vertical result even when the input array is 1xn horizontal, because `SEQUENCE(n,,n,-1)` is vertical. Use `SEQUENCE(1,n,n,-1)` (horizontal) to preserve the original 1xn orientation.
 - **Avoid LET variable names that look like R1C1 references.** Names ending in `R1`/`C1` (e.g. `gR1`, `gC1`), or short forms like `cR`, `cC`, `topR`, `botR`, `leftC`, `rightC` are rejected by Excel when injecting the lambda via Names.Add — the harness reports "Could not resolve lambda dependencies". Single-letter names `r` / `c` are also risky because they resemble R1C1 row/column references. Use descriptive names like `baseRow`, `endCol`, `ctrRow`, `topRow`, `leftCol`, `winR`, `winC` instead.
-- **Prefer `INDEX(arr, SEQUENCE(...), SEQUENCE(...))` over `OFFSET` for subrange extraction.** `OFFSET` requires a real range reference and errors on array inputs (e.g. `SEQUENCE(10,10)`), which the harness can only pass as array constants — so OFFSET-based lambdas can't be exercised in tests. `INDEX` with SEQUENCE row/col index arrays accepts both real ranges (production) and array constants (tests), returning the same 2D spilled result. Combine with the `IFERROR(MIN(ROW(grid)),1)` base-cell fallback so positional math stays correct for both inputs.
+- **`INDEX(arr, SEQUENCE(...), SEQUENCE(...))` and `OFFSET` are both testable; pick based on required semantics.** Historically the harness could only pass array constants (e.g. `SEQUENCE(10,10)`), which made `OFFSET` untestable — so lambdas were pushed toward `INDEX` with SEQUENCE index arrays. As of issue #85 the harness supports a `setup:` block that pre-populates cells and/or named ranges before the formula runs, so `OFFSET`-based lambdas (and any lambda that must return or consume a *range reference* rather than a spilled array) can now be exercised in tests. Choose `OFFSET` when the caller needs a true range (for data validation sources, conditional-formatting ranges, `SUBTOTAL`, further `OFFSET`, etc.); choose `INDEX` with SEQUENCE when a spilled 2D array is sufficient. Either way, keep the `IFERROR(MIN(ROW(grid)),1)` base-cell fallback so positional math stays correct for both real-range and array-constant inputs.
+- **Test YAML: `setup:` block pre-populates the sheet before the formula runs.** Each test runs on a fresh worksheet. An optional `setup:` block can populate cells and/or define worksheet-scoped names used by the formula args. Shape:
+    ```yaml
+    - name: real range input via named range
+      setup:
+        cells:
+          - address: "C5:G9"
+            values:
+              - [1, 2, 3, 4, 5]
+              - [6, 7, 8, 9, 10]
+              # ...
+        names:
+          - { name: "testGrid", refers_to: "C5:G9" }
+      args: ["=testGrid", "=E7", "=3", "=3"]
+      expected: [[7, 8, 9], [12, 13, 14], [17, 18, 19]]
+    ```
+  - `cells[].values` is a 2D list (`[[...]]`) whose shape matches `address`. Scalars are also accepted for single-cell addresses.
+  - `names[].refers_to`: a bare address (e.g. `C5:G9`) is auto-qualified with the current test sheet name. To write a full formula, prefix with `=`; use `{sheet}` as a placeholder for the sheet name if needed (e.g. `={sheet}!C5:G9`).
+  - Names are sheet-scoped — they live and die with the fresh worksheet, so no cleanup is required.

--- a/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
+++ b/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
@@ -49,7 +49,8 @@ public class LambdaHarnessTests
                     test.Name,
                     test.Args ?? [],
                     test.Expected ?? "",
-                    test.ExpectedType ?? ""
+                    test.ExpectedType ?? "",
+                    test.Setup!
                 ];
         }
     }
@@ -57,7 +58,7 @@ public class LambdaHarnessTests
     [Theory]
     [MemberData(nameof(TestCases))]
     public void LambdaTest(string lambdaPath, string testName, List<object> args,
-        object? expected, string expectedType)
+        object? expected, string expectedType, TestSetup? setup)
     {
         var (name, formula) = LambdaParser.ParseFile(lambdaPath);
         EnsureInjected(name, formula);
@@ -69,6 +70,7 @@ public class LambdaHarnessTests
         var ws = _excel.AddWorksheet();
         try
         {
+            ApplySetup(ws, setup);
             var cell = ws.Range["A1"];
             try
             {
@@ -99,6 +101,77 @@ public class LambdaHarnessTests
                 // Ignore cleanup
             }
         }
+    }
+
+    private static void ApplySetup(dynamic ws, TestSetup? setup)
+    {
+        if (setup == null)
+            return;
+
+        if (setup.Cells != null)
+        {
+            foreach (var sc in setup.Cells)
+            {
+                var range = ws.Range[sc.Address];
+                try
+                {
+                    range.Value = ConvertCellValues(sc.Values);
+                }
+                finally
+                {
+                    Marshal.ReleaseComObject(range);
+                }
+            }
+        }
+
+        if (setup.Names != null)
+        {
+            string sheetName = ws.Name;
+            foreach (var sn in setup.Names)
+            {
+                string refersTo = ResolveRefersTo(sn.RefersTo, sheetName);
+                ws.Names.Add(sn.Name, refersTo);
+            }
+        }
+    }
+
+    private static object ConvertCellValues(object? raw)
+    {
+        if (raw is List<object> outer && outer.Count > 0 && outer[0] is List<object>)
+        {
+            int rowCount = outer.Count;
+            int colCount = ((List<object>)outer[0]).Count;
+            var arr = new object[rowCount, colCount];
+            for (int r = 0; r < rowCount; r++)
+            {
+                var row = (List<object>)outer[r];
+                for (int c = 0; c < colCount; c++)
+                    arr[r, c] = ConvertScalar(row[c]);
+            }
+            return arr;
+        }
+        return ConvertScalar(raw) ?? "";
+    }
+
+    private static object? ConvertScalar(object? value)
+    {
+        if (value is string s)
+        {
+            if (long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out var lv))
+                return lv;
+            if (double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var dv))
+                return dv;
+            if (bool.TryParse(s, out var bv))
+                return bv;
+        }
+        return value;
+    }
+
+    private static string ResolveRefersTo(string refersTo, string sheetName)
+    {
+        var quotedSheet = $"'{sheetName}'";
+        var substituted = refersTo.Replace("{sheet}", quotedSheet);
+        return substituted.StartsWith("=") ? substituted : "=" + quotedSheet + "!" + substituted;
     }
 
     private void EnsureInjected(string name, string formula)
@@ -296,4 +369,23 @@ public class TestCase
     public List<object>? Args { get; set; }
     public object? Expected { get; set; }
     public string? ExpectedType { get; set; }
+    public TestSetup? Setup { get; set; }
+}
+
+public class TestSetup
+{
+    public List<SetupCell>? Cells { get; set; }
+    public List<SetupName>? Names { get; set; }
+}
+
+public class SetupCell
+{
+    public string Address { get; set; } = "";
+    public object? Values { get; set; }
+}
+
+public class SetupName
+{
+    public string Name { get; set; } = "";
+    public string RefersTo { get; set; } = "";
 }

--- a/lambdas/maps/GRIDAREA.tests.yaml
+++ b/lambdas/maps/GRIDAREA.tests.yaml
@@ -39,6 +39,36 @@ tests:
     args: ["=SEQUENCE(10,10)", "=E5", "=1"]
     expected: 45
 
+  - name: real range input via named range
+    setup:
+      cells:
+        - address: "C5:G9"
+          values:
+            - [1, 2, 3, 4, 5]
+            - [6, 7, 8, 9, 10]
+            - [11, 12, 13, 14, 15]
+            - [16, 17, 18, 19, 20]
+            - [21, 22, 23, 24, 25]
+      names:
+        - { name: "testGrid", refers_to: "C5:G9" }
+    args: ["=testGrid", "=E7", "=3", "=3"]
+    expected: [[7, 8, 9], [12, 13, 14], [17, 18, 19]]
+
+  - name: real range clamps at top-left edge
+    setup:
+      cells:
+        - address: "C5:G9"
+          values:
+            - [1, 2, 3, 4, 5]
+            - [6, 7, 8, 9, 10]
+            - [11, 12, 13, 14, 15]
+            - [16, 17, 18, 19, 20]
+            - [21, 22, 23, 24, 25]
+      names:
+        - { name: "testGrid", refers_to: "C5:G9" }
+    args: ["=testGrid", "=C5", "=3", "=3"]
+    expected: [[1, 2], [6, 7]]
+
   - name: help text
     args: []
     expected_type: array


### PR DESCRIPTION
## Summary

- Adds an optional `setup:` block to `.tests.yaml` that pre-populates cells and/or defines worksheet-scoped named ranges before the formula runs, so the harness can exercise lambdas that take (or return) a real range reference — e.g. anything `OFFSET`-based, data-validation sources, `SUBTOTAL` with a range.
- Extends `TestCase` with `TestSetup` / `SetupCell` / `SetupName` models; `ApplySetup` writes cell values and registers sheet-scoped names (auto-deleted when the test's worksheet is deleted).
- `refers_to` auto-qualifies a bare address with the current test sheet and supports a `{sheet}` placeholder in formulas.
- Two new `GRIDAREA` tests use the setup block (named range + center cell) to demonstrate the real-range input path. Existing tests (no `setup:`) continue to work unchanged.
- `create-lambda` skill: INDEX-vs-OFFSET note updated to reflect that OFFSET / range-returning lambdas are now testable, and the setup-block shape is documented.

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` — 0 errors
- [x] `dotnet test addin/lambda-boss.Tests` — 438 / 438 passing
- [x] `dotnet test addin/lambda-boss.AddinTests --filter LambdaHarnessTests` — 151 / 151 passing, including the two new setup-block `GRIDAREA` cases
- [x] Spot-check a Lambda authoring flow uses the `setup:` block per updated skill docs

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)