### PR TITLE
Ship GongSolutions.WPF.DragDrop.dll in installer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,12 @@ dotnet test addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj
 - **Never use compound Bash commands** (no `&&`, `;`, or `|` chaining). Use separate Bash tool calls instead — independent calls can run in parallel. Compound commands trigger extra permission prompts.
 - **Never prefix Bash commands with `cd`**. The working directory is already the project root. All commands (`gh`, `git`, `npm`, etc.) work without `cd`.
 
+## Adding NuGet dependencies
+
+Until the publishing process is more sophisticated, any new NuGet package that produces a runtime DLL must be **manually added to `installer/lambda-boss.iss` under `[Files]`** in the same PR that introduces the dependency. Otherwise the installed build will crash at runtime with `FileNotFoundException` the first time the dependency is loaded — the XLL host probes the install directory, not the NuGet cache.
+
+To check what a new package adds to the build, look at `addin/lambda-boss/bin/Release/net6.0-windows/` after a Release build and cross-reference against the `[Files]` list in the `.iss`.
+
 ## Publishing a release
 
 End-to-end release publishing is handled by `scripts/publish-release.ps1`. Run it from a clean `main` branch; it walks through version bump, build, test, code-signing, installer compilation, PR merge, tagging, and draft GitHub Release creation.

--- a/installer/lambda-boss.iss
+++ b/installer/lambda-boss.iss
@@ -43,6 +43,7 @@ Source: "{#BuildOutput}\lambda-boss64.dna"; DestDir: "{app}"; Flags: ignoreversi
 
 ; Core managed assemblies (unpacked per .dna config)
 Source: "{#BuildOutput}\lambda-boss.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#BuildOutput}\GongSolutions.WPF.DragDrop.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#BuildOutput}\Ookii.Dialogs.Wpf.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#BuildOutput}\Taglo.Excel.Common.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#BuildOutput}\YamlDotNet.dll"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
## Summary
- Add `GongSolutions.WPF.DragDrop.dll` to `installer/lambda-boss.iss` under `[Files]` — without this the installed build crashes with `FileNotFoundException` the moment the LET→LAMBDA editor opens.
- Add a `CLAUDE.md` note requiring new NuGet runtime DLLs to be added to the installer in the same PR that introduces them, until publishing gets smarter.

Full audit against `lambda-boss.deps.json` is in the issue — `GongSolutions.WPF.DragDrop.dll` was the only DLL missing.

Closes #107

## Test plan
- [x] `dotnet build addin/lambda-boss.slnx -c Release` succeeds and emits `GongSolutions.WPF.DragDrop.dll` at the path the `.iss` references.
- [x] `dotnet test addin/lambda-boss.Tests` — 438 / 438 pass.
- [x] Tim: on next `scripts/publish-release.ps1` run, confirm installer output contains the DLL and a clean-machine install opens the LET→LAMBDA editor without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)