### PR TITLE
Fix LET-to-Lambda rename matching first letter of longer identifiers

### DIFF
--- a/addin/lambda-boss.Tests/LetToLambdaBuilderTests.cs
+++ b/addin/lambda-boss.Tests/LetToLambdaBuilderTests.cs
@@ -53,6 +53,32 @@ public class LetToLambdaBuilderTests
     }
 
     [Fact]
+    public void RenamedKey_DoesNotMatchInsideLongerIdentifier()
+    {
+        // Regression: when a rename key appears as the first letter of an
+        // identifier in the body (e.g. `a` inside `ABS`), the word-boundary
+        // lookarounds must still guard the match. A previous bug interpolated
+        // the alternation without grouping, so `|` split the regex and the
+        // first alternative was only left-guarded, causing `ABS` → `add_1BS`.
+        var result = Build(
+            "=LET(a, A1, b, B1, c, INDIRECT(a), d, INDIRECT(b), " +
+            "SUM(ABS(ROW(d)-ROW(c))+ABS(COLUMN(d)-COLUMN(c))))",
+            "Distance",
+            ("a", "add_1", true), ("b", "add_2", true));
+
+        Assert.Equal(Lines(
+            "=LAMBDA(",
+            "    add_1,",
+            "    add_2,",
+            "    LET(",
+            "        c, INDIRECT(add_1),",
+            "        d, INDIRECT(add_2),",
+            "        SUM(ABS(ROW(d)-ROW(c))+ABS(COLUMN(d)-COLUMN(c)))",
+            "    )",
+            ")"), result);
+    }
+
+    [Fact]
     public void MixedKeepAndCalc_WrapsInLet()
     {
         var result = Build("=LET(someRange, A1:A10, getMax, MAX(someRange), getMax)", "MyMax",

--- a/addin/lambda-boss/LetToLambdaBuilder.cs
+++ b/addin/lambda-boss/LetToLambdaBuilder.cs
@@ -166,7 +166,11 @@ public static class LetToLambdaBuilder
         if (renames.Count == 0) return text;
 
         var pattern = string.Join("|", renames.Keys.Select(Regex.Escape));
-        var regex = new Regex($@"(?<![A-Za-z0-9_.]){pattern}(?![A-Za-z0-9_.])",
+        // Wrap the alternation in a non-capturing group so the word-boundary
+        // lookarounds apply to every alternative. Without the group, `|` would
+        // split the regex into "(?<!…)key1" and "key2(?!…)", letting a key
+        // match the first letter of a longer identifier (e.g. `a` in `ABS`).
+        var regex = new Regex($@"(?<![A-Za-z0-9_.])(?:{pattern})(?![A-Za-z0-9_.])",
             RegexOptions.IgnoreCase);
 
         var result = new StringBuilder();


### PR DESCRIPTION
Closes #110

## Summary
- `LetToLambdaBuilder.ApplyRenames` interpolated the alternation of rename keys between the word-boundary lookarounds without grouping. With keys `a`, `b` the assembled regex became `(?<!…)a|b(?!…)` — `|` splits it into two alternatives, each with only one side guarded. An `A` preceded by `(` (non-identifier) therefore matched inside `ABS`, so renaming `a` → `add_1` produced `add_1BS`.
- Wrapped the alternation in `(?:…)` so both lookarounds apply to every key.
- Added a regression test using the exact failure shape from the report (`a`/`b` renamed to `add_1`/`add_2` with `ABS` in the body).

## Test plan
- [x] `dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj` — 439/439 pass
- [x] Tim: smoke test in Excel by rerunning the original conversion