### PR TITLE
Fix possible null reference assignment in ConvertCellValues

### DIFF
--- a/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
+++ b/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
@@ -146,7 +146,7 @@ public class LambdaHarnessTests
             {
                 var row = (List<object>)outer[r];
                 for (int c = 0; c < colCount; c++)
-                    arr[r, c] = ConvertScalar(row[c]);
+                    arr[r, c] = ConvertScalar(row[c]) ?? "";
             }
             return arr;
         }


### PR DESCRIPTION
## Summary
- ReSharper flagged a possible null reference assignment at [LambdaHarnessTests.cs:149](addin/lambda-boss.AddinTests/LambdaHarnessTests.cs:149).
- `ConvertScalar` returns `object?` (it can pass through a null `value`), but `arr` is `object[,]` — non-nullable element type.
- Coalesced the result with `?? ""` to match the existing pattern already used in the scalar branch on [line 153](addin/lambda-boss.AddinTests/LambdaHarnessTests.cs:153).

## Test plan
- [x] `dotnet build addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj` — succeeds, no new warnings
- [x] Confirm ReSharper warning clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)