### PR TITLE
Add GetVarB and GetVarAtB to Loops family

### DIFF
--- a/lambdas/loops/GetVarAtB.lambda
+++ b/lambdas/loops/GetVarAtB.lambda
@@ -1,0 +1,29 @@
+/*  FUNCTION NAME:      GetVarAtB
+    DESCRIPTION:*//**Reads a positional slot and coerces the payload to boolean. Scalar or vertical array.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-04-28  Claude      Initial version
+*/
+GetVarAtB = LAMBDA(
+//  Parameter Declarations
+    [state],
+    [index],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →GetVarAtB(state, index)¶" &
+                "DESCRIPTION:   →Reads a positional slot and coerces the payload to boolean. Scalar or vertical array.¶" &
+                "VERSION:       →Apr 28 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   state          →(Required) State string built with SetState (or any state with names ""1""..""N"").¶" &
+                "   index          →(Required) 1-based slot number.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=GetVarAtB(SetState(TRUE, FALSE, TRUE), 2)¶" &
+                "Result         →FALSE (boolean). Use GetVarAt for raw text or GetVarAtN for numbers.",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(state),
+    //  Procedure
+        result, GetVarB(state, index & ""),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/loops/GetVarAtB.tests.yaml
+++ b/lambdas/loops/GetVarAtB.tests.yaml
@@ -1,0 +1,20 @@
+tests:
+  - name: read TRUE slot
+    args: ['=SetState(TRUE, FALSE, TRUE)', "=1"]
+    expected: True
+
+  - name: read FALSE slot
+    args: ['=SetState(TRUE, FALSE, TRUE)', "=2"]
+    expected: False
+
+  - name: array slot returns boolean vertical array
+    args: ['=SetState(TRUE, {TRUE;FALSE;TRUE})', "=2"]
+    expected: [[True], [False], [True]]
+
+  - name: missing slot returns NA
+    args: ['=SetState(TRUE, FALSE, TRUE)', "=4"]
+    expected: -2146826246
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/loops/GetVarB.lambda
+++ b/lambdas/loops/GetVarB.lambda
@@ -1,0 +1,29 @@
+/*  FUNCTION NAME:      GetVarB
+    DESCRIPTION:*//**Reads a named variable and coerces the payload to boolean. Scalar or vertical array.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-04-28  Claude      Initial version
+*/
+GetVarB = LAMBDA(
+//  Parameter Declarations
+    [state],
+    [name],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →GetVarB(state, name)¶" &
+                "DESCRIPTION:   →Reads a named variable and coerces the payload to boolean. Scalar or vertical array.¶" &
+                "VERSION:       →Apr 28 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   state          →(Required) State string built with NewState/SetVar/SetVars/SetState.¶" &
+                "   name           →(Required) Variable name to read.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=GetVarB(SetVar(NewState(), ""done?"", TRUE), ""done?"")¶" &
+                "Result         →TRUE (boolean). Use GetVar for raw text or GetVarN for numbers.",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(state),
+    //  Procedure
+        result, GetVar(state, name) = "TRUE",
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/loops/GetVarB.tests.yaml
+++ b/lambdas/loops/GetVarB.tests.yaml
@@ -1,0 +1,28 @@
+tests:
+  - name: scalar TRUE round-trip
+    args: ['=SetVar(NewState(), "x", TRUE)', "x"]
+    expected: True
+
+  - name: scalar FALSE round-trip
+    args: ['=SetVar(NewState(), "x", FALSE)', "x"]
+    expected: False
+
+  - name: lowercase "true" coerces to TRUE (Excel = is case-insensitive)
+    args: ['=SetVar(NewState(), "x", "true")', "x"]
+    expected: True
+
+  - name: numeric 1 does not coerce to TRUE
+    args: ['=SetVar(NewState(), "x", 1)', "x"]
+    expected: False
+
+  - name: array of booleans round-trips element-wise
+    args: ['=SetVar(NewState(), "flags", {TRUE;FALSE;TRUE})', "flags"]
+    expected: [[True], [False], [True]]
+
+  - name: missing var returns NA
+    args: ['=SetVar(NewState(), "x", TRUE)', "missing"]
+    expected: -2146826246
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

- `GetVarB(state, name)` and `GetVarAtB(state, index)` — boolean-coercing companions to `GetVarN` / `GetVarAtN`.
- Implemented as `GetVar(state, name) = "TRUE"` (case-insensitive, works element-wise on arrays, propagates `#N/A` for missing vars).
- Closes the gap that booleans round-trip through `SetVar` as the literal text `"TRUE"`/`"FALSE"`, which neither `GetVar` (text) nor `GetVarN` (`--` coercion → `#VALUE!`) made comfortable to consume in a `REDUCE` loop.

## Test plan

- [x] `dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj` — 527 passed.
- [x] `dotnet test addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj` — 213 passed (full lambda harness, including all new GetVarB/GetVarAtB cases).
- [x] Verified by-name in the harness output: scalar TRUE/FALSE round-trip, lowercase `"true"` coerces to `TRUE`, numeric `1` does **not** coerce to `TRUE`, boolean array round-trip, missing var/slot returns `#N/A`, help text spills.

Closes #116