### PR TITLE
NTH: return NA() when index resolves to 0 or below

### DIFF
--- a/lambdas/array/NTH.lambda
+++ b/lambdas/array/NTH.lambda
@@ -25,7 +25,7 @@ NTH = LAMBDA(
     //  Procedure
         flat, TOCOL(arr),
         idx, IF(n < 0, ROWS(flat) + n + 1, n),
-        result, @INDEX(flat, idx, 1),
+        result, IF(idx < 1, NA(), @INDEX(flat, idx, 1)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/array/NTH.tests.yaml
+++ b/lambdas/array/NTH.tests.yaml
@@ -27,6 +27,14 @@ tests:
     args: ['={42}', "=1"]
     expected: 42
 
+  - name: index 0 returns NA
+    args: ['={10,20,30,40}', "=0"]
+    expected: -2146826246
+
+  - name: negative index out of range returns NA
+    args: ['={10,20,30,40}', "=-5"]
+    expected: -2146826246
+
   - name: help text
     args: []
     expected_type: array


### PR DESCRIPTION
## Summary
- `INDEX(arr, 0)` returns the whole column in Excel; with the implicit `@` it silently collapses to the first element, so `NTH(arr, 0)` was returning `arr[1]` instead of an error.
- Wrap the `@INDEX` call with `IF(idx < 1, NA(), ...)` so both `n = 0` and oversized negative `n` (e.g. `-5` on a 4-element array) return `#N/A`.
- Adds two harness cases covering both paths.

Closes #115

## Test plan
- [x] `dotnet test addin/lambda-boss.AddinTests` — full lambda harness, 208 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)