### PR TITLE
Add SNAQUENCE lambda

### DIFF
--- a/lambdas/array/SNAQUENCE.lambda
+++ b/lambdas/array/SNAQUENCE.lambda
@@ -1,0 +1,40 @@
+/*  FUNCTION NAME:      SNAQUENCE
+    DESCRIPTION:*//**Generates a 2D array filled with a sequence in a snake (boustrophedon) pattern, alternating direction each row.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-04-30  Tim Jacks   Initial version
+*/
+SNAQUENCE = LAMBDA(
+//  Parameter Declarations
+    [rows],
+    [columns],
+    [start],
+    [step],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →SNAQUENCE(rows, [columns], [start], [step])¶" &
+                "DESCRIPTION:   →Generates a 2D array filled with a sequence in a snake (boustrophedon) pattern, alternating direction each row.¶" &
+                "VERSION:       →Apr 30 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   rows           →(Required) Number of rows in the output array.¶" &
+                "   columns        →(Optional) Number of columns. Default 1.¶" &
+                "   start          →(Optional) First number in the sequence. Default 1.¶" &
+                "   step           →(Optional) Increment between successive numbers. Default 1.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=SNAQUENCE(3, 4)¶" &
+                "Result         →{1,2,3,4;8,7,6,5;9,10,11,12}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(rows),
+        Cols, IF(ISOMITTED(columns), 1, columns),
+        StartVal, IF(ISOMITTED(start), 1, start),
+        StepVal, IF(ISOMITTED(step), 1, step),
+    //  Procedure
+        rowIdx, SEQUENCE(rows),
+        colIdx, SEQUENCE(, Cols),
+        parity, MOD(rowIdx, 2),
+        linear, (rowIdx - 1) * Cols + parity * colIdx + (1 - parity) * (Cols + 1 - colIdx),
+        result, StartVal + (linear - 1) * StepVal,
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/SNAQUENCE.tests.yaml
+++ b/lambdas/array/SNAQUENCE.tests.yaml
@@ -1,0 +1,32 @@
+tests:
+  - name: 3x4 snake grid default start and step
+    args: ["=3", "=4"]
+    expected: [[1, 2, 3, 4], [8, 7, 6, 5], [9, 10, 11, 12]]
+
+  - name: 2x2 simplest snake
+    args: ["=2", "=2"]
+    expected: [[1, 2], [4, 3]]
+
+  - name: single row degenerates to SEQUENCE
+    args: ["=1", "=5"]
+    expected: [[1, 2, 3, 4, 5]]
+
+  - name: single column default columns
+    args: ["=4"]
+    expected: [[1], [2], [3], [4]]
+
+  - name: custom start
+    args: ["=2", "=3", "=10"]
+    expected: [[10, 11, 12], [15, 14, 13]]
+
+  - name: custom start and step
+    args: ["=2", "=3", "=0", "=2"]
+    expected: [[0, 2, 4], [10, 8, 6]]
+
+  - name: negative step counts down
+    args: ["=2", "=3", "=6", "=-1"]
+    expected: [[6, 5, 4], [1, 2, 3]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary
- New `SNAQUENCE` lambda in `lambdas/array/` that fills a 2D array with a numbered sequence in a snake (boustrophedon) pattern — odd rows go left-to-right, even rows go right-to-left.
- Signature mirrors `SEQUENCE`: `SNAQUENCE(rows, [columns], [start], [step])` with defaults `columns=1`, `start=1`, `step=1`.
- Implements the formula from issue #127 with optional start/step parameters added.

Closes #127

## Test plan
- [x] Format validation passes (`LambdaFormatTests`)
- [x] Functional harness tests pass — covers default 3×4 grid, 2×2, single row, single column, custom start, custom start+step, negative step, and help output