### PR TITLE
Gather: naming completeness — sanitizer + cell-left + collisions (PR 2 of 12)

### DIFF
--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -29,19 +29,20 @@ public class GatherEngineTests
         Assert.NotNull(result);
         Assert.Equal("=B2+1", result.OriginalFormula);
 
-        // A2 is an input named "Numbers" (cell-above A1 is "Numbers"),
-        // B2 is a step named step_1 (cell-above B1 is empty).
+        // A2 is an input named "numbers" (cell-above A1 is "Numbers", which
+        // sanitises to lowercase initial); B2 is a step named step_1 (cell-
+        // above B1 is empty, no cell-left either).
         Assert.Equal(2, result.Bindings.Count);
 
         var aRow = result.Bindings.Single(b => b.CellRef.A1Address == "A2");
         Assert.Equal(BindingRole.Input, aRow.Role);
-        Assert.Equal("Numbers", aRow.Name);
+        Assert.Equal("numbers", aRow.Name);
         Assert.Equal("A2", aRow.Rhs);
 
         var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
         Assert.Equal(BindingRole.Step, bRow.Role);
         Assert.Equal("step_1", bRow.Name);
-        Assert.Equal("Numbers*2", bRow.Rhs);
+        Assert.Equal("numbers*2", bRow.Rhs);
 
         // Inputs come before steps.
         var bindings = result.Bindings.ToList();
@@ -50,10 +51,10 @@ public class GatherEngineTests
         // The synthesised LET round-trips through LetParser.
         var parsed = LetParser.Parse(result.SynthesisedLet);
         Assert.Equal(2, parsed.Bindings.Count);
-        Assert.Equal("Numbers", parsed.Bindings[0].Name);
+        Assert.Equal("numbers", parsed.Bindings[0].Name);
         Assert.Equal("A2", parsed.Bindings[0].RhsText);
         Assert.Equal("step_1", parsed.Bindings[1].Name);
-        Assert.Equal("Numbers*2", parsed.Bindings[1].RhsText);
+        Assert.Equal("numbers*2", parsed.Bindings[1].RhsText);
         Assert.Equal("step_1+1", parsed.Body);
     }
 
@@ -94,11 +95,10 @@ public class GatherEngineTests
     }
 
     [Fact]
-    public void Gather_NonIdentifierLabel_FallsBackToStepN()
+    public void Gather_LabelWithSpaces_SanitizedToCamelCase()
     {
-        // Cell-above "Customer ID" has a space so doesn't match the
-        // identifier regex; PR 1 falls through to step_N. Sanitizer
-        // (which would convert "Customer ID" → "customerId") lands in PR 2.
+        // "Customer ID" sanitises to camelCase rather than falling through
+        // to step_N (PR 1 fell through; PR 2 wires the sanitizer in).
         var source = new StubCellSource()
             .WithLabel("A1", "Customer ID")
             .WithFormula("B2", "=A2*2");
@@ -106,7 +106,7 @@ public class GatherEngineTests
         var result = GatherEngine.Gather(source.Ref("B2"), source)!;
 
         Assert.Single(result.Bindings);
-        Assert.Equal("step_1", result.Bindings[0].Name);
+        Assert.Equal("customerId", result.Bindings[0].Name);
     }
 
     [Fact]
@@ -127,11 +127,27 @@ public class GatherEngineTests
     }
 
     [Fact]
-    public void Gather_NumericLabel_FallsBackToStepN()
+    public void Gather_LabelStartingWithDigit_PrefixedWithUnderscore()
     {
-        // Label "30" doesn't match the identifier regex (starts with digit).
+        // A leading digit can't begin an Excel name; the sanitizer prefixes
+        // with `_` so the result is still usable.
         var source = new StubCellSource()
             .WithLabel("A1", "30")
+            .WithFormula("B2", "=A2*2");
+
+        var result = GatherEngine.Gather(source.Ref("B2"), source)!;
+
+        Assert.Equal("_30", result.Bindings[0].Name);
+    }
+
+    [Fact]
+    public void Gather_LabelWithOnlyPunctuation_FallsBackToStepN()
+    {
+        // No identifier characters at all — sanitizer returns null, so the
+        // engine falls through to the next naming level (cell-left here is
+        // also empty) and finally to step_N.
+        var source = new StubCellSource()
+            .WithLabel("A1", "!!!")
             .WithFormula("B2", "=A2*2");
 
         var result = GatherEngine.Gather(source.Ref("B2"), source)!;
@@ -167,5 +183,138 @@ public class GatherEngineTests
         var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B1");
         Assert.Equal(BindingRole.Input, bRow.Role);
         Assert.Equal("B1", bRow.Rhs);
+    }
+
+    [Fact]
+    public void Gather_CellLeftLabel_UsedWhenCellAboveEmpty()
+    {
+        // A2 holds the label "Numbers"; B2 is the input (no cell-above text).
+        // The naming chain falls through to cell-left.
+        var source = new StubCellSource()
+            .WithLabel("A2", "Numbers")
+            .WithFormula("C2", "=B2*2");
+
+        var result = GatherEngine.Gather(source.Ref("C2"), source)!;
+
+        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        Assert.Equal("numbers", bRow.Name);
+    }
+
+    [Fact]
+    public void Gather_CellAbovePreferredOverCellLeft()
+    {
+        // Both neighbours have a label; cell-above wins.
+        var source = new StubCellSource()
+            .WithLabel("B1", "Above")
+            .WithLabel("A2", "Left")
+            .WithFormula("C2", "=B2*2");
+
+        var result = GatherEngine.Gather(source.Ref("C2"), source)!;
+
+        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        Assert.Equal("above", bRow.Name);
+    }
+
+    [Fact]
+    public void Gather_CellAbovePunctuationOnly_FallsThroughToCellLeft()
+    {
+        // Cell-above sanitises to null (no identifier chars), so cell-left
+        // gets a turn before step_N.
+        var source = new StubCellSource()
+            .WithLabel("B1", "!!!")
+            .WithLabel("A2", "Numbers")
+            .WithFormula("C2", "=B2*2");
+
+        var result = GatherEngine.Gather(source.Ref("C2"), source)!;
+
+        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        Assert.Equal("numbers", bRow.Name);
+    }
+
+    [Fact]
+    public void Gather_CollidingSanitizedNames_DisambiguatedWithSuffix()
+    {
+        // A1 and A2 both labelled "Sales"; their cells (B1, B2) both want
+        // the binding name `sales`. Topological order picks B1 first, so
+        // B2 gets `sales_2`.
+        var source = new StubCellSource()
+            .WithLabel("A1", "Sales")
+            .WithLabel("A2", "Sales")
+            .WithFormula("C1", "=B1+B2");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source)!;
+
+        var b1 = result.Bindings.Single(b => b.CellRef.A1Address == "B1");
+        var b2 = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        var names = new[] { b1.Name, b2.Name }.OrderBy(n => n).ToList();
+        Assert.Equal(new[] { "sales", "sales_2" }, names);
+    }
+
+    [Fact]
+    public void Gather_ThreeWayCollision_SuffixesIncrement()
+    {
+        // Three cells whose labels all sanitise to `x` should produce
+        // `x`, `x_2`, `x_3` in topological order.
+        var source = new StubCellSource()
+            .WithLabel("A1", "X")
+            .WithLabel("A2", "X")
+            .WithLabel("A3", "X")
+            .WithFormula("D1", "=B1+B2+B3");
+
+        var result = GatherEngine.Gather(source.Ref("D1"), source)!;
+
+        var names = new[] { "B1", "B2", "B3" }
+            .Select(addr => result.Bindings.Single(b => b.CellRef.A1Address == addr).Name)
+            .OrderBy(n => n)
+            .ToList();
+        Assert.Equal(new[] { "x", "x_2", "x_3" }, names);
+    }
+
+    [Fact]
+    public void Gather_FallbackSkipsNamesAlreadyUsedByLabels()
+    {
+        // A label sanitises to "step_1"; the next unlabelled cell that
+        // would otherwise grab `step_1` should skip to `step_2`.
+        var source = new StubCellSource()
+            .WithLabel("A1", "step_1")
+            .WithFormula("C1", "=B1+B2");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source)!;
+
+        var b1 = result.Bindings.Single(b => b.CellRef.A1Address == "B1");
+        var b2 = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        Assert.Equal("step_1", b1.Name);
+        Assert.Equal("step_2", b2.Name);
+    }
+
+    [Fact]
+    public void Gather_NamingMatchesIssueManualTestScenario()
+    {
+        // From issue 132 acceptance — combines sanitizer, cell-left, and
+        // collision suffixing in one walk:
+        //   A1=Sales,    B1=100
+        //   A2=Sales,    B2=200
+        //   A3=Tax Rate, B3=0.1
+        //   A4=Total,    B4=B1*B3 + B2*B3
+        //   C4 = B4+1                       ← sink
+        var source = new StubCellSource()
+            .WithLabel("A1", "Sales")
+            .WithLabel("A2", "Sales")
+            .WithLabel("A3", "Tax Rate")
+            .WithLabel("A4", "Total")
+            .WithFormula("B4", "=B1*B3 + B2*B3")
+            .WithFormula("C4", "=B4+1");
+
+        var result = GatherEngine.Gather(source.Ref("C4"), source)!;
+
+        Assert.Equal("sales",   result.Bindings.Single(b => b.CellRef.A1Address == "B1").Name);
+        Assert.Equal("sales_2", result.Bindings.Single(b => b.CellRef.A1Address == "B2").Name);
+        Assert.Equal("taxRate", result.Bindings.Single(b => b.CellRef.A1Address == "B3").Name);
+        Assert.Equal("total",   result.Bindings.Single(b => b.CellRef.A1Address == "B4").Name);
+
+        // Sanity: synthesised LET round-trips and the body uses the step
+        // binding name rather than the cell ref.
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal("total+1", parsed.Body);
     }
 }

--- a/addin/lambda-boss.Tests/LetNameSanitizerTests.cs
+++ b/addin/lambda-boss.Tests/LetNameSanitizerTests.cs
@@ -1,0 +1,70 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+public class LetNameSanitizerTests
+{
+    [Theory]
+    [InlineData("Customer ID", "customerId")]
+    [InlineData("Tax Rate", "taxRate")]
+    [InlineData("Sales", "sales")]
+    [InlineData("Total", "total")]
+    [InlineData("customer", "customer")]
+    [InlineData("customerName", "customerName")]
+    [InlineData("CustomerName", "customerName")]
+    [InlineData("My Name Field", "myNameField")]
+    [InlineData("My ABC Field", "myAbcField")]
+    [InlineData("Customer-ID", "customerId")]
+    [InlineData("Customer_ID", "customer_ID")]
+    public void Sanitize_CommonLabels_ProducesCamelCase(string input, string expected)
+    {
+        Assert.Equal(expected, LetNameSanitizer.Sanitize(input));
+    }
+
+    [Theory]
+    [InlineData("  Customer ID  ", "customerId")]
+    [InlineData("\tSales\n", "sales")]
+    public void Sanitize_TrimsLeadingAndTrailingWhitespace(string input, string expected)
+    {
+        Assert.Equal(expected, LetNameSanitizer.Sanitize(input));
+    }
+
+    [Theory]
+    [InlineData("30", "_30")]
+    [InlineData("42abc", "_42abc")]
+    [InlineData("4", "_4")]
+    public void Sanitize_LeadingDigit_PrefixedWithUnderscore(string input, string expected)
+    {
+        Assert.Equal(expected, LetNameSanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void Sanitize_LeadingUnderscoreThenDigits_NotPrefixed()
+    {
+        Assert.Equal("_42abc", LetNameSanitizer.Sanitize("_42abc"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("!@#")]
+    [InlineData("---")]
+    [InlineData(" \t\n ")]
+    public void Sanitize_NoIdentifierCharacters_ReturnsNull(string? input)
+    {
+        Assert.Null(LetNameSanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void Sanitize_AllUnderscores_KeptAsSingleWord()
+    {
+        Assert.Equal("___", LetNameSanitizer.Sanitize("___"));
+    }
+
+    [Fact]
+    public void Sanitize_MultipleNonIdentifierRuns_TreatedAsSingleSeparator()
+    {
+        Assert.Equal("aBC", LetNameSanitizer.Sanitize("a   ---   B   !!!   C"));
+    }
+}

--- a/addin/lambda-boss.Tests/StubCellSource.cs
+++ b/addin/lambda-boss.Tests/StubCellSource.cs
@@ -42,6 +42,14 @@ internal sealed class StubCellSource : ICellSource
         return _labels.TryGetValue(aboveAddress, out var l) ? l : null;
     }
 
+    public string? GetCellLeftText(CellRef cell)
+    {
+        if (cell.Column <= 1)
+            return null;
+        var leftAddress = $"{CellRef.ColumnLetters(cell.Column - 1)}{cell.Row}";
+        return _labels.TryGetValue(leftAddress, out var l) ? l : null;
+    }
+
     public CellRef Ref(string a1)
     {
         var (col, row) = ParseA1(a1);

--- a/addin/lambda-boss/CellGraphWalker.cs
+++ b/addin/lambda-boss/CellGraphWalker.cs
@@ -26,6 +26,7 @@ internal static class CellGraphWalker
 
             var formula = source.GetFormula(cell);
             var cellAbove = source.GetCellAboveText(cell);
+            var cellLeft = source.GetCellLeftText(cell);
 
             IReadOnlyList<CellRef> precedents;
             if (formula == null)
@@ -37,7 +38,7 @@ internal static class CellGraphWalker
                 precedents = CellRefExtractor.Extract(formula, source.SinkSheet);
             }
 
-            byRef[cell] = new WalkedCell(cell, formula, cellAbove, precedents);
+            byRef[cell] = new WalkedCell(cell, formula, cellAbove, cellLeft, precedents);
 
             foreach (var p in precedents)
             {

--- a/addin/lambda-boss/Commands/GatherCommand.cs
+++ b/addin/lambda-boss/Commands/GatherCommand.cs
@@ -145,9 +145,21 @@ internal static class GatherCommand
         {
             if (cell.Row <= 1)
                 return null;
+            return ReadStringValue(cell.Row - 1, cell.Column, $"GetCellAboveText({cell.A1Address})");
+        }
+
+        public string? GetCellLeftText(CellRef cell)
+        {
+            if (cell.Column <= 1)
+                return null;
+            return ReadStringValue(cell.Row, cell.Column - 1, $"GetCellLeftText({cell.A1Address})");
+        }
+
+        private string? ReadStringValue(int row, int column, string context)
+        {
             try
             {
-                dynamic range = _worksheet.Cells[cell.Row - 1, cell.Column];
+                dynamic range = _worksheet.Cells[row, column];
                 var value = range.Value2;
                 if (value is string s && !string.IsNullOrEmpty(s))
                     return s;
@@ -155,7 +167,7 @@ internal static class GatherCommand
             }
             catch (Exception ex)
             {
-                Logger.Error($"Gather/GetCellAboveText({cell.A1Address})", ex);
+                Logger.Error($"Gather/{context}", ex);
                 return null;
             }
         }

--- a/addin/lambda-boss/GatherEngine.cs
+++ b/addin/lambda-boss/GatherEngine.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace LambdaBoss;
 
@@ -7,16 +6,13 @@ namespace LambdaBoss;
 ///     The top-level Gather entry point. Walks the precedent graph, names
 ///     each cell, classifies it as input or step, rewrites step formulas
 ///     to refer to bindings, and emits a single <c>=LET(...)</c> formula
-///     equivalent to the sink-rooted calculation graph. PR 1 scope: chain
-///     and branched DAGs of formula cells on a single sheet, with no
-///     ranges, spills, nested LETs, or cycle handling.
+///     equivalent to the sink-rooted calculation graph. PR 2 scope: PR 1's
+///     chain/branched DAG support plus full naming completeness — cell-above
+///     fallback to cell-left, sanitization via <see cref="LetNameSanitizer" />,
+///     and final-collision suffixing.
 /// </summary>
 public static class GatherEngine
 {
-    private static readonly Regex IdentifierPattern = new(
-        @"^[A-Za-z_][A-Za-z0-9_.]*$",
-        RegexOptions.CultureInvariant);
-
     /// <summary>
     ///     Runs the gather over <paramref name="sink" />. Returns null if
     ///     the sink has no formula — the caller (slash command) treats this
@@ -37,22 +33,7 @@ public static class GatherEngine
         // Name every cell except the sink. Sink contributes the LET body.
         var nonSink = walked.Where(w => !w.Ref.Equals(sink)).ToList();
 
-        var nameByRef = new Dictionary<CellRef, string>();
-        var fallbackCounter = 0;
-        foreach (var cell in nonSink)
-        {
-            string name;
-            if (cell.CellAboveText != null && IdentifierPattern.IsMatch(cell.CellAboveText))
-            {
-                name = cell.CellAboveText;
-            }
-            else
-            {
-                fallbackCounter++;
-                name = $"step_{fallbackCounter}";
-            }
-            nameByRef[cell.Ref] = name;
-        }
+        var nameByRef = AssignNames(nonSink);
 
         var bindings = new List<BindingRow>();
         var inputs = new List<BindingRow>();
@@ -96,6 +77,54 @@ public static class GatherEngine
             bodyText);
 
         return new GatherResult(sink, sinkFormula, bindings, sb.ToString());
+    }
+
+    /// <summary>
+    ///     Picks a binding name for each cell in topological order. Tries
+    ///     cell-above first, then cell-left, both routed through
+    ///     <see cref="LetNameSanitizer" />. Falls back to <c>step_N</c> only
+    ///     when both neighbours yield nothing usable. Final collisions —
+    ///     two cells producing the same name — are resolved by suffixing
+    ///     <c>_2</c>, <c>_3</c>, … in topological order.
+    /// </summary>
+    private static Dictionary<CellRef, string> AssignNames(IReadOnlyList<WalkedCell> nonSink)
+    {
+        var nameByRef = new Dictionary<CellRef, string>();
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var fallbackCounter = 0;
+
+        foreach (var cell in nonSink)
+        {
+            var baseName = LetNameSanitizer.Sanitize(cell.CellAboveText)
+                           ?? LetNameSanitizer.Sanitize(cell.CellLeftText);
+
+            string finalName;
+            if (baseName == null)
+            {
+                // No usable label — burn through step_N until we find a
+                // number that hasn't already been used by a sanitised label.
+                do
+                {
+                    fallbackCounter++;
+                    finalName = $"step_{fallbackCounter}";
+                } while (used.Contains(finalName));
+            }
+            else
+            {
+                finalName = baseName;
+                var suffix = 2;
+                while (used.Contains(finalName))
+                {
+                    finalName = $"{baseName}_{suffix}";
+                    suffix++;
+                }
+            }
+
+            used.Add(finalName);
+            nameByRef[cell.Ref] = finalName;
+        }
+
+        return nameByRef;
     }
 
     private static BindingRole ClassifyRole(WalkedCell cell, HashSet<CellRef> inScope)

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -47,14 +47,16 @@ public sealed record CellRef(string Sheet, int Column, int Row)
 /// <summary>
 ///     A cell discovered by <see cref="CellGraphWalker" />. The
 ///     <see cref="Formula" /> is null when the cell holds a literal value
-///     (treated as a leaf input). <see cref="CellAboveText" /> is the text
-///     of the cell directly above (used for binding-name derivation), or
-///     null when the cell is in row 1 or the cell above is empty.
+///     (treated as a leaf input). <see cref="CellAboveText" /> and
+///     <see cref="CellLeftText" /> are the text of the cells directly above
+///     and to the left (checked in that order during binding-name derivation),
+///     null when the neighbour is out of range, empty, or non-string.
 /// </summary>
 public sealed record WalkedCell(
     CellRef Ref,
     string? Formula,
     string? CellAboveText,
+    string? CellLeftText,
     IReadOnlyList<CellRef> Precedents);
 
 /// <summary>
@@ -102,8 +104,15 @@ public interface ICellSource
 
     /// <summary>
     ///     Returns the displayed text of the cell directly above
-    ///     <paramref name="cell" />, or null if that cell is empty or
-    ///     <paramref name="cell" /> is in row 1.
+    ///     <paramref name="cell" />, or null if that cell is empty,
+    ///     non-string, or <paramref name="cell" /> is in row 1.
     /// </summary>
     string? GetCellAboveText(CellRef cell);
+
+    /// <summary>
+    ///     Returns the displayed text of the cell directly to the left of
+    ///     <paramref name="cell" />, or null if that cell is empty,
+    ///     non-string, or <paramref name="cell" /> is in column 1.
+    /// </summary>
+    string? GetCellLeftText(CellRef cell);
 }

--- a/addin/lambda-boss/LetNameSanitizer.cs
+++ b/addin/lambda-boss/LetNameSanitizer.cs
@@ -1,0 +1,90 @@
+using System.Text;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     Turns a free-text label (e.g. a cell-above or cell-left value) into a
+///     LET binding name. Splits on runs of non-identifier characters, lowercases
+///     the first word's initial letter, TitleCases subsequent words, and
+///     prefixes with <c>_</c> if the result would start with a digit. Returns
+///     null when the input has no usable identifier characters at all, so the
+///     caller can fall through to the next naming level.
+/// </summary>
+public static class LetNameSanitizer
+{
+    /// <summary>
+    ///     Identifier characters: ASCII letters, digits, and underscore. Runs of
+    ///     anything else delimit "words" for camelCase joining.
+    /// </summary>
+    private static bool IsIdentifierChar(char c)
+    {
+        return c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_';
+    }
+
+    public static string? Sanitize(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return null;
+
+        var trimmed = text.Trim();
+        if (trimmed.Length == 0)
+            return null;
+
+        var words = SplitWords(trimmed);
+        if (words.Count == 0)
+            return null;
+
+        var sb = new StringBuilder();
+        for (var i = 0; i < words.Count; i++)
+        {
+            var w = words[i];
+            if (i == 0)
+            {
+                // First word: lowercase the initial letter and keep the rest
+                // as-is so already-camelCase labels survive intact.
+                if (char.IsLetter(w[0]))
+                    sb.Append(char.ToLowerInvariant(w[0]));
+                else
+                    sb.Append(w[0]);
+                if (w.Length > 1)
+                    sb.Append(w, 1, w.Length - 1);
+            }
+            else
+            {
+                // Subsequent words: TitleCase (uppercase initial letter,
+                // lowercase the rest) so e.g. "Customer ID" → "customerId".
+                if (char.IsLetter(w[0]))
+                    sb.Append(char.ToUpperInvariant(w[0]));
+                else
+                    sb.Append(w[0]);
+                if (w.Length > 1)
+                    sb.Append(w[1..].ToLowerInvariant());
+            }
+        }
+
+        if (sb.Length == 0)
+            return null;
+
+        if (char.IsDigit(sb[0]))
+            sb.Insert(0, '_');
+
+        return sb.ToString();
+    }
+
+    private static List<string> SplitWords(string text)
+    {
+        var words = new List<string>();
+        var i = 0;
+        while (i < text.Length)
+        {
+            while (i < text.Length && !IsIdentifierChar(text[i]))
+                i++;
+            var start = i;
+            while (i < text.Length && IsIdentifierChar(text[i]))
+                i++;
+            if (i > start)
+                words.Add(text[start..i]);
+        }
+        return words;
+    }
+}


### PR DESCRIPTION
Closes #132. Part of #130. Targets the spec branch `claude/lambda-from-formulas-wsF4Q`; PR 1 of 12 is already merged in.

## Summary

- New `LetNameSanitizer` class — splits a label on runs of non-identifier characters, lowercases the first word's initial letter, TitleCases subsequent words, and prefixes with `_` when the result would start with a digit. Returns null when the input has no usable identifier characters.
- `GatherEngine` naming chain: cell-above (sanitised) → cell-left (sanitised) → `step_N`. Final collisions resolved by `_2`/`_3` suffixing in topological order. The `step_N` counter also skips numbers already taken by sanitised labels.
- New `GetCellLeftText` on `ICellSource`; live and stub adapters both implement it.

## Note on the "extract from LetToLambdaBuilder" framing

The spec and issue describe this as extracting an existing sanitizer from `LetToLambdaBuilder` ("pure refactor, no behaviour change"). On inspection there's no sanitizer in that builder today — the LET-to-LAMBDA dialog just validates user-typed names via `ExcelNameValidator`. So `LetNameSanitizer` lands here as a fresh class, used only by `GatherEngine`. `LetToLambdaBuilder` is untouched (so its tests continue to pass trivially). A follow-up could plumb the sanitizer into the LET-to-LAMBDA dialog if you want the same camelCase treatment there — let me know if you'd like an issue spun up for that.

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` — clean (existing CA warnings only).
- [x] `dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj` — 498 passed, 0 failed.
- [x] New `LetNameSanitizerTests` cover: common camelCase shapes, whitespace trim, leading-digit prefixing, all-non-identifier returns null, multiple separator runs collapse.
- [x] New `GatherEngineTests`: cell-left fallback, cell-above preferred over cell-left, punctuation-only above falls through to left, two-way + three-way collision suffixing, fallback skips names already used by labels, full issue-acceptance scenario (`A1=Sales..C4=B4+1`).
- [x] Existing `GatherEngineTests` for "Customer ID" and "30" labels updated to reflect new sanitizer behaviour (`customerId`, `_30`).
- [x] Manual Excel smoke test from issue body — relies on the live `LiveCellSource.GetCellLeftText` which I've added but can't exercise without Excel. The unit tests cover the engine path end-to-end with a stub source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)