### PR TITLE
Gather: cross-sheet refs (PR 3 of 12)

### DIFF
--- a/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
+++ b/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
@@ -127,7 +127,7 @@ public class CellGraphWalkerTests
         // External ref reaches the walker as a CellRef with ExternalWorkbook
         // set. The stub returns null for GetFormula on externals, so it
         // surfaces as a leaf with no precedents of its own.
-        var source = new StubCellSource("Sheet1")
+        var source = new StubCellSource()
             .WithFormula("Sheet1!B1", "=[Other.xlsx]Sheet1!A1+1");
 
         var walked = CellGraphWalker.Walk(source.Ref("Sheet1!B1"), source);
@@ -143,5 +143,8 @@ public class CellGraphWalkerTests
 
 internal static class WalkedCellExtensions
 {
-    public static string Sheet(this WalkedCell cell) => cell.Ref.Sheet;
+    public static string Sheet(this WalkedCell cell)
+    {
+        return cell.Ref.Sheet;
+    }
 }

--- a/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
+++ b/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
@@ -83,4 +83,65 @@ public class CellGraphWalkerTests
         Assert.Single(walked);
         Assert.Null(walked[0].Formula);
     }
+
+    [Fact]
+    public void Walk_CrossSheetPrecedent_WalkedNormally()
+    {
+        // Sheet2!B1 = =Sheet1!A1*2; Sheet1!A1 is a literal on the other
+        // sheet. The walker should reach across, identify A1 as a leaf,
+        // and emit it before B1.
+        var source = new StubCellSource("Sheet2")
+            .WithFormula("Sheet2!B1", "=Sheet1!A1*2");
+
+        var walked = CellGraphWalker.Walk(source.Ref("Sheet2!B1"), source);
+
+        Assert.Equal(2, walked.Count);
+        Assert.Equal("Sheet1", walked[0].Ref.Sheet);
+        Assert.Equal("A1", walked[0].Ref.A1Address);
+        Assert.Null(walked[0].Formula);
+        Assert.Equal("Sheet2", walked[1].Ref.Sheet);
+        Assert.Equal("B1", walked[1].Ref.A1Address);
+    }
+
+    [Fact]
+    public void Walk_CrossSheetStep_PrecedentResolvedOnTargetSheet()
+    {
+        // Sheet2!C1 = =Sheet1!B1+1; Sheet1!B1 = =A1*2 (unqualified A1
+        // refers to Sheet1!A1, NOT Sheet2!A1).
+        var source = new StubCellSource("Sheet2")
+            .WithFormula("Sheet1!B1", "=A1*2")
+            .WithFormula("Sheet2!C1", "=Sheet1!B1+1");
+
+        var walked = CellGraphWalker.Walk(source.Ref("Sheet2!C1"), source);
+
+        var leaf = walked.Single(w => w.Ref.A1Address == "A1");
+        Assert.Equal("Sheet1", leaf.Sheet());
+        var step = walked.Single(w => w.Ref.A1Address == "B1");
+        Assert.Equal("Sheet1", step.Sheet());
+        Assert.Equal("=A1*2", step.Formula);
+    }
+
+    [Fact]
+    public void Walk_ExternalRef_TreatedAsLeaf()
+    {
+        // External ref reaches the walker as a CellRef with ExternalWorkbook
+        // set. The stub returns null for GetFormula on externals, so it
+        // surfaces as a leaf with no precedents of its own.
+        var source = new StubCellSource("Sheet1")
+            .WithFormula("Sheet1!B1", "=[Other.xlsx]Sheet1!A1+1");
+
+        var walked = CellGraphWalker.Walk(source.Ref("Sheet1!B1"), source);
+
+        var external = walked.Single(w => w.Ref.IsExternal);
+        Assert.Equal("Other.xlsx", external.Ref.ExternalWorkbook);
+        Assert.Equal("Sheet1", external.Ref.Sheet);
+        Assert.Equal("A1", external.Ref.A1Address);
+        Assert.Null(external.Formula);
+        Assert.Empty(external.Precedents);
+    }
+}
+
+internal static class WalkedCellExtensions
+{
+    public static string Sheet(this WalkedCell cell) => cell.Ref.Sheet;
 }

--- a/addin/lambda-boss.Tests/CellRefExtractorTests.cs
+++ b/addin/lambda-boss.Tests/CellRefExtractorTests.cs
@@ -57,14 +57,78 @@ public class CellRefExtractorTests
     }
 
     [Fact]
-    public void Extract_SheetQualifiedRef_IsExcluded()
+    public void Extract_SheetQualifiedRef_KeepsSheetName()
     {
-        // Cross-sheet support lands in PR 3; for now sheet-qualified refs
-        // should be skipped so they don't get walked as if same-sheet.
-        var refs = CellRefExtractor.Extract("=Sheet1!A1+B1", Sheet);
+        // PR 3 widens to cross-sheet — Sheet1!A1 surfaces as a CellRef on
+        // Sheet1, while the bare B1 stays on the default sheet.
+        var refs = CellRefExtractor.Extract("=Sheet1!A1+B1", "Sheet2");
+
+        Assert.Equal(2, refs.Count);
+        Assert.Equal("Sheet1", refs[0].Sheet);
+        Assert.Equal("A1", refs[0].A1Address);
+        Assert.False(refs[0].IsExternal);
+        Assert.Equal("Sheet2", refs[1].Sheet);
+        Assert.Equal("B1", refs[1].A1Address);
+    }
+
+    [Fact]
+    public void Extract_QuotedSheetRef_StripsQuotesAndUnescapes()
+    {
+        var refs = CellRefExtractor.Extract("='My Sheet'!A1+'It''s Mine'!B2", Sheet);
+
+        Assert.Equal(2, refs.Count);
+        Assert.Equal("My Sheet", refs[0].Sheet);
+        Assert.Equal("A1", refs[0].A1Address);
+        Assert.Equal("It's Mine", refs[1].Sheet);
+        Assert.Equal("B2", refs[1].A1Address);
+    }
+
+    [Fact]
+    public void Extract_ExternalWorkbookRef_KeepsWorkbookTag()
+    {
+        var refs = CellRefExtractor.Extract("=[Other.xlsx]Sheet1!A1+B1", "Sheet2");
+
+        Assert.Equal(2, refs.Count);
+        Assert.True(refs[0].IsExternal);
+        Assert.Equal("Other.xlsx", refs[0].ExternalWorkbook);
+        Assert.Equal("Sheet1", refs[0].Sheet);
+        Assert.Equal("A1", refs[0].A1Address);
+        Assert.False(refs[1].IsExternal);
+        Assert.Equal("Sheet2", refs[1].Sheet);
+    }
+
+    [Fact]
+    public void Extract_QuotedExternalRef_HandlesSpacesInSheetName()
+    {
+        var refs = CellRefExtractor.Extract("='[Other.xlsx]My Sheet'!A1", Sheet);
 
         Assert.Single(refs);
-        Assert.Equal("B1", refs[0].A1Address);
+        Assert.True(refs[0].IsExternal);
+        Assert.Equal("Other.xlsx", refs[0].ExternalWorkbook);
+        Assert.Equal("My Sheet", refs[0].Sheet);
+        Assert.Equal("A1", refs[0].A1Address);
+    }
+
+    [Fact]
+    public void Extract_QuotedExternalRefWithPath_StillCapturesWorkbook()
+    {
+        // Closed-workbook form Excel writes when the source file isn't open.
+        var refs = CellRefExtractor.Extract(@"='C:\path\to\[Other.xlsx]Sheet1'!A1", Sheet);
+
+        Assert.Single(refs);
+        Assert.True(refs[0].IsExternal);
+        Assert.Equal("Other.xlsx", refs[0].ExternalWorkbook);
+        Assert.Equal("Sheet1", refs[0].Sheet);
+    }
+
+    [Fact]
+    public void Extract_DollarAnchorsOnSheetQualifiedRef_AreStripped()
+    {
+        var refs = CellRefExtractor.Extract("=Sheet1!$A$1", "Sheet2");
+
+        Assert.Single(refs);
+        Assert.Equal("Sheet1", refs[0].Sheet);
+        Assert.Equal("A1", refs[0].A1Address);
     }
 
     [Fact]
@@ -130,6 +194,60 @@ public class CellRefExtractorTests
         var rewritten = CellRefExtractor.Rewrite("=A1&\"A1 unchanged\"", Sheet, lookup);
 
         Assert.Equal("=numbers&\"A1 unchanged\"", rewritten);
+    }
+
+    [Fact]
+    public void Rewrite_SheetQualifiedRef_ReplacesWholeQualifier()
+    {
+        // The whole `Sheet1!A1` collapses to the binding name, not just A1.
+        var lookup = new Dictionary<CellRef, string>
+        {
+            [new CellRef("Sheet1", 1, 1)] = "shared",
+        };
+
+        var rewritten = CellRefExtractor.Rewrite("=Sheet1!A1*2", "Sheet2", lookup);
+
+        Assert.Equal("=shared*2", rewritten);
+    }
+
+    [Fact]
+    public void Rewrite_QuotedSheetRef_ReplacesWholeQualifier()
+    {
+        var lookup = new Dictionary<CellRef, string>
+        {
+            [new CellRef("My Sheet", 1, 1)] = "mine",
+        };
+
+        var rewritten = CellRefExtractor.Rewrite("='My Sheet'!A1+1", "Sheet2", lookup);
+
+        Assert.Equal("=mine+1", rewritten);
+    }
+
+    [Fact]
+    public void Rewrite_ExternalRef_ReplacesWholeQualifier()
+    {
+        var lookup = new Dictionary<CellRef, string>
+        {
+            [new CellRef("Sheet1", 1, 1, "Other.xlsx")] = "outside",
+        };
+
+        var rewritten = CellRefExtractor.Rewrite("=[Other.xlsx]Sheet1!A1*2", "Sheet2", lookup);
+
+        Assert.Equal("=outside*2", rewritten);
+    }
+
+    [Fact]
+    public void Rewrite_BareRefAndCrossSheetRef_BothMatchedSeparately()
+    {
+        var lookup = new Dictionary<CellRef, string>
+        {
+            [new CellRef("Sheet2", 2, 1)] = "local",
+            [new CellRef("Sheet1", 1, 1)] = "shared",
+        };
+
+        var rewritten = CellRefExtractor.Rewrite("=B1+Sheet1!A1", "Sheet2", lookup);
+
+        Assert.Equal("=local+shared", rewritten);
     }
 
     [Fact]

--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -288,6 +288,106 @@ public class GatherEngineTests
     }
 
     [Fact]
+    public void Gather_CrossSheetSink_RhsUsesSheetQualifiedAddress()
+    {
+        // Sheet2!C1 = =Sheet1!A1*2. The Sheet1!A1 binding must keep the
+        // sheet qualifier in its RHS since the LET lives on Sheet2.
+        var source = new StubCellSource("Sheet2")
+            .WithFormula("Sheet2!C1", "=Sheet1!A1*2");
+
+        var result = GatherEngine.Gather(source.Ref("Sheet2!C1"), source)!;
+
+        var aRow = result.Bindings.Single(b => b.CellRef.A1Address == "A1");
+        Assert.Equal(BindingRole.Input, aRow.Role);
+        Assert.Equal("Sheet1!A1", aRow.Rhs);
+
+        // Body refers to the binding name, not the cross-sheet ref.
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Single(parsed.Bindings);
+        Assert.Equal("Sheet1!A1", parsed.Bindings[0].RhsText);
+        Assert.Equal($"{aRow.Name}*2", parsed.Body);
+    }
+
+    [Fact]
+    public void Gather_CrossSheetStep_RewritesRefToBindingName()
+    {
+        // Sheet2!C1 = =Sheet1!B1+1; Sheet1!B1 = =A1*2 (Sheet1's A1).
+        // The step's RHS should rewrite both Sheet1!B1 (in C1) and A1 (in
+        // B1) — the latter uses Sheet1 as default since the formula lives
+        // on Sheet1.
+        var source = new StubCellSource("Sheet2")
+            .WithLabel("Sheet1!A1", "Numbers")
+            .WithFormula("Sheet1!B1", "=A1*2")
+            .WithFormula("Sheet2!C1", "=Sheet1!B1+1");
+
+        var result = GatherEngine.Gather(source.Ref("Sheet2!C1"), source)!;
+
+        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B1");
+        Assert.Equal(BindingRole.Step, bRow.Role);
+        // The step's RHS uses the leaf binding name, not the cross-sheet
+        // form `Sheet1!A1` it had in the source formula.
+        var aRow = result.Bindings.Single(b => b.CellRef.A1Address == "A1");
+        Assert.Equal($"{aRow.Name}*2", bRow.Rhs);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal($"{bRow.Name}+1", parsed.Body);
+    }
+
+    [Fact]
+    public void Gather_QuotedSheetName_PreservedInBindingRhs()
+    {
+        // Sheet name with a space forces quoting in the synthesised LET.
+        var source = new StubCellSource("Sheet2")
+            .WithFormula("Sheet2!B1", "='My Sheet'!A1*2");
+
+        var result = GatherEngine.Gather(source.Ref("Sheet2!B1"), source)!;
+
+        var aRow = result.Bindings.Single(b => b.CellRef.A1Address == "A1");
+        Assert.Equal("My Sheet", aRow.CellRef.Sheet);
+        Assert.Equal("'My Sheet'!A1", aRow.Rhs);
+
+        // Round-trips through LetParser despite the spaced sheet name —
+        // the parser's bracket-aware comma splitter ignores the bang and
+        // single-quote pair inside the RHS.
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal("'My Sheet'!A1", parsed.Bindings[0].RhsText);
+    }
+
+    [Fact]
+    public void Gather_ExternalRef_LeftAsLeafInputWithWorkbookTag()
+    {
+        // External-workbook ref shows up as an input — we never reach into
+        // the other workbook — and its RHS is the workbook-qualified
+        // address, ready to evaluate when Excel rebinds it.
+        var source = new StubCellSource("Sheet1")
+            .WithFormula("Sheet1!B1", "=[Other.xlsx]Sheet1!A1+1");
+
+        var result = GatherEngine.Gather(source.Ref("Sheet1!B1"), source)!;
+
+        var ext = result.Bindings.Single(b => b.CellRef.IsExternal);
+        Assert.Equal(BindingRole.Input, ext.Role);
+        Assert.Equal("[Other.xlsx]Sheet1!A1", ext.Rhs);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        // The body still references the binding name, not the original
+        // external ref text — the external sub-tree is just an input.
+        Assert.Equal($"{ext.Name}+1", parsed.Body);
+    }
+
+    [Fact]
+    public void Gather_QuotedExternalRef_RhsRoundTripsAsQualifiedForm()
+    {
+        // External + spaced sheet → quoted entire qualifier on emit.
+        var source = new StubCellSource("Sheet1")
+            .WithFormula("Sheet1!B1", "='[Other.xlsx]My Sheet'!A1+1");
+
+        var result = GatherEngine.Gather(source.Ref("Sheet1!B1"), source)!;
+
+        var ext = result.Bindings.Single(b => b.CellRef.IsExternal);
+        Assert.Equal("'[Other.xlsx]My Sheet'!A1", ext.Rhs);
+    }
+
+    [Fact]
     public void Gather_NamingMatchesIssueManualTestScenario()
     {
         // From issue 132 acceptance — combines sanitizer, cell-left, and

--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -359,7 +359,7 @@ public class GatherEngineTests
         // External-workbook ref shows up as an input — we never reach into
         // the other workbook — and its RHS is the workbook-qualified
         // address, ready to evaluate when Excel rebinds it.
-        var source = new StubCellSource("Sheet1")
+        var source = new StubCellSource()
             .WithFormula("Sheet1!B1", "=[Other.xlsx]Sheet1!A1+1");
 
         var result = GatherEngine.Gather(source.Ref("Sheet1!B1"), source)!;
@@ -378,7 +378,7 @@ public class GatherEngineTests
     public void Gather_QuotedExternalRef_RhsRoundTripsAsQualifiedForm()
     {
         // External + spaced sheet → quoted entire qualifier on emit.
-        var source = new StubCellSource("Sheet1")
+        var source = new StubCellSource()
             .WithFormula("Sheet1!B1", "='[Other.xlsx]My Sheet'!A1+1");
 
         var result = GatherEngine.Gather(source.Ref("Sheet1!B1"), source)!;
@@ -407,10 +407,10 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("C4"), source)!;
 
-        Assert.Equal("sales",   result.Bindings.Single(b => b.CellRef.A1Address == "B1").Name);
+        Assert.Equal("sales", result.Bindings.Single(b => b.CellRef.A1Address == "B1").Name);
         Assert.Equal("sales_2", result.Bindings.Single(b => b.CellRef.A1Address == "B2").Name);
         Assert.Equal("taxRate", result.Bindings.Single(b => b.CellRef.A1Address == "B3").Name);
-        Assert.Equal("total",   result.Bindings.Single(b => b.CellRef.A1Address == "B4").Name);
+        Assert.Equal("total", result.Bindings.Single(b => b.CellRef.A1Address == "B4").Name);
 
         // Sanity: synthesised LET round-trips and the body uses the step
         // binding name rather than the cell ref.

--- a/addin/lambda-boss.Tests/StubCellSource.cs
+++ b/addin/lambda-boss.Tests/StubCellSource.cs
@@ -1,12 +1,16 @@
 namespace LambdaBoss.Tests;
 
 /// <summary>
-///     In-memory <see cref="ICellSource" /> used by gather tests. Cells
-///     are seeded by A1 address; formulas start with <c>=</c>, labels are
-///     plain text used for the cell-above lookup.
+///     In-memory <see cref="ICellSource" /> used by gather tests. Cells are
+///     seeded by A1 address; formulas start with <c>=</c>, labels are plain
+///     text used for the cell-above and cell-left lookups. Cross-sheet
+///     seeding uses an <c>"Sheet!A1"</c> address; bare addresses default to
+///     the source's sink sheet.
 /// </summary>
 internal sealed class StubCellSource : ICellSource
 {
+    // Keys are normalised to "Sheet!A1" with the sheet name compared
+    // case-insensitively (matches CellRef equality).
     private readonly Dictionary<string, string> _formulas = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _labels = new(StringComparer.OrdinalIgnoreCase);
 
@@ -19,49 +23,81 @@ internal sealed class StubCellSource : ICellSource
 
     public StubCellSource WithFormula(string a1, string formula)
     {
-        _formulas[a1] = formula;
+        _formulas[Qualify(a1)] = formula;
         return this;
     }
 
     public StubCellSource WithLabel(string a1, string label)
     {
-        _labels[a1] = label;
+        _labels[Qualify(a1)] = label;
         return this;
     }
 
     public string? GetFormula(CellRef cell)
     {
-        return _formulas.TryGetValue(cell.A1Address, out var f) ? f : null;
+        if (cell.IsExternal)
+            return null;
+        return _formulas.TryGetValue(Key(cell.Sheet, cell.Column, cell.Row), out var f) ? f : null;
     }
 
     public string? GetCellAboveText(CellRef cell)
     {
-        if (cell.Row <= 1)
+        if (cell.IsExternal || cell.Row <= 1)
             return null;
-        var aboveAddress = $"{CellRef.ColumnLetters(cell.Column)}{cell.Row - 1}";
-        return _labels.TryGetValue(aboveAddress, out var l) ? l : null;
+        return _labels.TryGetValue(Key(cell.Sheet, cell.Column, cell.Row - 1), out var l) ? l : null;
     }
 
     public string? GetCellLeftText(CellRef cell)
     {
-        if (cell.Column <= 1)
+        if (cell.IsExternal || cell.Column <= 1)
             return null;
-        var leftAddress = $"{CellRef.ColumnLetters(cell.Column - 1)}{cell.Row}";
-        return _labels.TryGetValue(leftAddress, out var l) ? l : null;
+        return _labels.TryGetValue(Key(cell.Sheet, cell.Column - 1, cell.Row), out var l) ? l : null;
     }
 
+    /// <summary>
+    ///     Build a CellRef from <c>"A1"</c> (defaults to the sink sheet) or
+    ///     <c>"Sheet!A1"</c>. Quoted sheet names (<c>"'My Sheet'!A1"</c>)
+    ///     are recognised so tests can mirror what the extractor sees.
+    /// </summary>
     public CellRef Ref(string a1)
     {
-        var (col, row) = ParseA1(a1);
-        return new CellRef(SinkSheet, col, row);
+        var (sheet, col, row) = ParseAddress(a1, SinkSheet);
+        return new CellRef(sheet, col, row);
     }
 
-    private static (int Col, int Row) ParseA1(string a1)
+    private string Qualify(string a1)
     {
+        var (sheet, col, row) = ParseAddress(a1, SinkSheet);
+        return Key(sheet, col, row);
+    }
+
+    private static string Key(string sheet, int col, int row) =>
+        $"{sheet}!{CellRef.ColumnLetters(col)}{row}";
+
+    private static (string Sheet, int Col, int Row) ParseAddress(string addr, string defaultSheet)
+    {
+        var bang = addr.IndexOf('!');
+        string sheet;
+        string a1;
+        if (bang >= 0)
+        {
+            sheet = addr[..bang];
+            if (sheet.Length >= 2 && sheet[0] == '\'' && sheet[^1] == '\'')
+                sheet = sheet[1..^1].Replace("''", "'");
+            a1 = addr[(bang + 1)..];
+        }
+        else
+        {
+            sheet = defaultSheet;
+            a1 = addr;
+        }
+
         var i = 0;
-        while (i < a1.Length && char.IsLetter(a1[i])) i++;
-        var col = CellRef.LettersToColumn(a1[..i]);
-        var row = int.Parse(a1[i..]);
-        return (col, row);
+        while (i < a1.Length && (char.IsLetter(a1[i]) || a1[i] == '$')) i++;
+        var letters = a1[..i].Replace("$", "");
+        var rowText = a1[i..].Replace("$", "");
+        var col = CellRef.LettersToColumn(letters);
+        var row = int.Parse(rowText);
+        return (sheet, col, row);
     }
 }

--- a/addin/lambda-boss/CellGraphWalker.cs
+++ b/addin/lambda-boss/CellGraphWalker.cs
@@ -4,9 +4,12 @@ namespace LambdaBoss;
 ///     Walks the precedent graph rooted at a sink cell. Discovery uses
 ///     <see cref="ICellSource" /> for cell-shape lookups and
 ///     <see cref="CellRefExtractor" /> to find precedents inside formulas.
-///     PR 1 scope: single sheet, no ranges, no spills, no cycle handling.
+///     PR 3 widens scope to all sheets in the active workbook: cross-sheet
+///     refs are walked normally; external-workbook refs surface as leaves
+///     because <see cref="ICellSource.GetFormula" /> returns null for them.
 ///     The returned cells are in topological order (precedents before
-///     dependents) with the sink as the final entry.
+///     dependents) with the sink as the final entry. PR 7 layers cycle
+///     detection on top.
 /// </summary>
 internal static class CellGraphWalker
 {
@@ -35,7 +38,11 @@ internal static class CellGraphWalker
             }
             else
             {
-                precedents = CellRefExtractor.Extract(formula, source.SinkSheet);
+                // Unqualified refs in this cell's formula resolve against
+                // its OWN sheet, not the sink's — otherwise crossing into
+                // Sheet1 from a sink on Sheet2 would mis-route Sheet1's
+                // internal `B1` references back to Sheet2.
+                precedents = CellRefExtractor.Extract(formula, cell.Sheet);
             }
 
             byRef[cell] = new WalkedCell(cell, formula, cellAbove, cellLeft, precedents);

--- a/addin/lambda-boss/CellRefExtractor.cs
+++ b/addin/lambda-boss/CellRefExtractor.cs
@@ -3,36 +3,62 @@ using System.Text.RegularExpressions;
 namespace LambdaBoss;
 
 /// <summary>
-///     Pulls A1-style cell references out of a formula string. PR 1 scope:
-///     unqualified single-cell A1 refs (with optional dollar anchors) on the
-///     same sheet as the sink. Range refs (<c>A1:B2</c>), sheet-qualified
-///     refs (<c>Sheet1!A1</c>), and spill refs (<c>A1#</c>) are recognised
-///     only enough to be excluded — they're handled by later PRs. String
-///     literals are skipped wholesale.
+///     Pulls A1-style cell references out of a formula string. PR 3 scope:
+///     bare refs (<c>A1</c> with optional dollar anchors), sheet-qualified
+///     refs in both unquoted (<c>Sheet1!A1</c>) and quoted
+///     (<c>'My Sheet'!A1</c>) forms, and external-workbook refs in the open
+///     (<c>[Wb.xlsx]Sheet1!A1</c>) and quoted (<c>'[Wb.xlsx]My Sheet'!A1</c>,
+///     <c>'C:\path\[Wb.xlsx]Sheet'!A1</c>) forms. Range refs and spill refs
+///     are still recognised only enough to be excluded — they're handled by
+///     PR 4/5. String literals are skipped wholesale.
 /// </summary>
 internal static class CellRefExtractor
 {
+    // The single combined pattern walks each non-string segment looking for
+    // an optional sheet qualifier (in one of four forms) followed by an A1
+    // cell address. The bare alternative is a zero-width assertion that
+    // guards bare-cell matches against being part of a larger token (mid-
+    // identifier, after '!' / ':', etc.) — without it, the regex would also
+    // match the row digits at the tail of a sheet name.
     private static readonly Regex CellRefPattern = new(
-        // Lookbehind: not preceded by an identifier char, '!' (sheet-qualified)
-        // or ':' (range). Lookahead: not followed by an identifier char,
-        // '!' or ':' (range), '(' (function call like LOG10(), where LOG10
-        // matches the letters+digits shape but isn't a cell ref) or '#'
-        // (spill — out of scope for PR 1).
-        @"(?<![A-Za-z0-9_.!:])\$?([A-Za-z]{1,3})\$?([0-9]+)(?![A-Za-z0-9_.!:(#])",
+        @"(?:" +
+            // 'C:\path\[Wb]Sheet'!  or  '[Wb]My Sheet'!  — quoted form
+            @"'(?<wbPath>[^']*)\[(?<wbQ>[^\[\]]+)\](?<sheetWbQ>(?:[^']|'')*)'!" +
+            @"|" +
+            // [Wb]Sheet!  — open external workbook, simple sheet
+            @"\[(?<wb>[^\[\]]+)\](?<sheetWb>[A-Za-z_][A-Za-z0-9_.]*)!" +
+            @"|" +
+            // 'Sheet'!  — quoted in-workbook sheet name
+            @"'(?<sheetQ>(?:[^']|'')+)'!" +
+            @"|" +
+            // Sheet!  — unquoted in-workbook sheet name
+            @"(?<![A-Za-z0-9_.!:'\]])(?<sheet>[A-Za-z_][A-Za-z0-9_.]*)!" +
+            @"|" +
+            // bare A1 — same lookbehind guard as before, plus '/']' to
+            // reject bare matches immediately after a closed external tag.
+            @"(?<![A-Za-z0-9_.!:'\]])" +
+        @")" +
+        @"\$?(?<col>[A-Za-z]{1,3})\$?(?<row>[0-9]+)" +
+        // Trailing guards: not a longer identifier, not a sheet qualifier
+        // ('!' for the next ref's sheet name), not a range tail (':') or a
+        // function-call tail ('('), not a spill marker ('#' — PR 5).
+        @"(?![A-Za-z0-9_.!:(#])",
         RegexOptions.CultureInvariant);
 
     /// <summary>
-    ///     Returns the unique single-cell A1-style refs found in
-    ///     <paramref name="formula" />, all qualified with
-    ///     <paramref name="sinkSheet" />. Order is the order of first
-    ///     appearance.
+    ///     Returns the unique cell refs found in <paramref name="formula" />
+    ///     in order of first appearance. Unqualified refs use
+    ///     <paramref name="defaultSheet" /> as the host sheet (the formula's
+    ///     own sheet, NOT the sink's sheet — the walker recurses into other
+    ///     sheets). Sheet-qualified refs use the qualifier as written;
+    ///     external-workbook refs carry the workbook name through.
     /// </summary>
-    public static IReadOnlyList<CellRef> Extract(string formula, string sinkSheet)
+    public static IReadOnlyList<CellRef> Extract(string formula, string defaultSheet)
     {
         if (string.IsNullOrEmpty(formula))
             return Array.Empty<CellRef>();
 
-        var seen = new HashSet<(int Col, int Row)>();
+        var seen = new HashSet<CellRef>();
         var refs = new List<CellRef>();
 
         var i = 0;
@@ -45,16 +71,18 @@ internal static class CellRefExtractor
             }
 
             // Find the next quote so we only scan the unquoted segment.
+            // Note: single-quoted sheet names contain '!' / '[' / etc. but
+            // never embedded double-quotes (Excel disallows " in sheet
+            // names), so it's safe to slice on " here.
             var nextQuote = formula.IndexOf('"', i);
             var segEnd = nextQuote < 0 ? formula.Length : nextQuote;
             var segment = formula[i..segEnd];
 
             foreach (Match m in CellRefPattern.Matches(segment))
             {
-                var col = CellRef.LettersToColumn(m.Groups[1].Value);
-                var row = int.Parse(m.Groups[2].Value);
-                if (seen.Add((col, row)))
-                    refs.Add(new CellRef(sinkSheet, col, row));
+                var cellRef = BuildCellRef(m, defaultSheet);
+                if (seen.Add(cellRef))
+                    refs.Add(cellRef);
             }
 
             i = segEnd;
@@ -67,12 +95,12 @@ internal static class CellRefExtractor
     ///     Rewrites every in-scope cell ref in <paramref name="formula" />
     ///     to the binding name supplied by <paramref name="lookup" />. Refs
     ///     not in <paramref name="lookup" /> (out-of-scope, named ranges,
-    ///     LAMBDA names, function names, etc.) are left untouched. String
-    ///     literals are preserved verbatim.
+    ///     LAMBDA names, function names, etc.) are left untouched. The
+    ///     default-sheet rule matches <see cref="Extract" />.
     /// </summary>
     public static string Rewrite(
         string formula,
-        string sinkSheet,
+        string defaultSheet,
         IReadOnlyDictionary<CellRef, string> lookup)
     {
         if (string.IsNullOrEmpty(formula) || lookup.Count == 0)
@@ -95,15 +123,48 @@ internal static class CellRefExtractor
             var segment = formula[i..segEnd];
             var rewritten = CellRefPattern.Replace(segment, m =>
             {
-                var col = CellRef.LettersToColumn(m.Groups[1].Value);
-                var row = int.Parse(m.Groups[2].Value);
-                var key = new CellRef(sinkSheet, col, row);
+                var key = BuildCellRef(m, defaultSheet);
                 return lookup.TryGetValue(key, out var name) ? name : m.Value;
             });
             result.Append(rewritten);
             i = segEnd;
         }
         return result.ToString();
+    }
+
+    private static CellRef BuildCellRef(Match m, string defaultSheet)
+    {
+        var col = CellRef.LettersToColumn(m.Groups["col"].Value);
+        var row = int.Parse(m.Groups["row"].Value);
+
+        if (m.Groups["wbQ"].Success)
+        {
+            // Quoted external form. The workbook name is whatever sat
+            // inside [...]; any path prefix outside the brackets is
+            // discarded for equality, but we don't reconstruct it on
+            // emit — closed-workbook paths get re-resolved by Excel.
+            var wb = m.Groups["wbQ"].Value;
+            var sheet = m.Groups["sheetWbQ"].Value.Replace("''", "'");
+            return new CellRef(sheet, col, row, wb);
+        }
+
+        if (m.Groups["wb"].Success)
+        {
+            return new CellRef(m.Groups["sheetWb"].Value, col, row, m.Groups["wb"].Value);
+        }
+
+        if (m.Groups["sheetQ"].Success)
+        {
+            var sheet = m.Groups["sheetQ"].Value.Replace("''", "'");
+            return new CellRef(sheet, col, row);
+        }
+
+        if (m.Groups["sheet"].Success)
+        {
+            return new CellRef(m.Groups["sheet"].Value, col, row);
+        }
+
+        return new CellRef(defaultSheet, col, row);
     }
 
     private static int SkipString(string text, int openQuoteIndex)

--- a/addin/lambda-boss/Commands/GatherCommand.cs
+++ b/addin/lambda-boss/Commands/GatherCommand.cs
@@ -13,9 +13,9 @@ namespace LambdaBoss.Commands;
 ///     Slash-command handler for <c>/Gather</c>. Reads the active cell,
 ///     synthesises a single <c>=LET(...)</c> formula equivalent to the
 ///     calculation graph rooted there, and on Save writes the LET back to
-///     the sink. PR 1 scope: silent no-op when the active cell has no
-///     formula; chains and branched DAGs of formula cells on the sink's
-///     sheet supported.
+///     the sink. PR 3 scope: cross-sheet precedents are walked normally,
+///     external-workbook refs surface as leaf inputs whose RHS is the
+///     workbook-qualified address.
 /// </summary>
 internal static class GatherCommand
 {
@@ -42,7 +42,7 @@ internal static class GatherCommand
                 return;
 
             var sink = new CellRef(sheetName, sinkColumn, sinkRow);
-            var source = new LiveCellSource(worksheet, sheetName);
+            var source = new LiveCellSource(workbook, sheetName);
 
             GatherResult? result;
             try
@@ -109,17 +109,20 @@ internal static class GatherCommand
     }
 
     /// <summary>
-    ///     Live adapter over a single worksheet. PR 1 reads only from the
-    ///     sink's sheet — cross-sheet support lands in PR 3, where this
-    ///     adapter will need a workbook-scoped variant.
+    ///     Live adapter over the active workbook. Resolves
+    ///     <see cref="CellRef.Sheet" /> case-insensitively against the
+    ///     workbook's worksheets and returns null for external-workbook
+    ///     refs (we never reach into other workbooks) and for refs into
+    ///     sheets that aren't part of this workbook — both classify as
+    ///     leaf inputs upstream.
     /// </summary>
     private sealed class LiveCellSource : ICellSource
     {
-        private readonly dynamic _worksheet;
+        private readonly dynamic _workbook;
 
-        public LiveCellSource(dynamic worksheet, string sinkSheet)
+        public LiveCellSource(dynamic workbook, string sinkSheet)
         {
-            _worksheet = worksheet;
+            _workbook = workbook;
             SinkSheet = sinkSheet;
         }
 
@@ -127,39 +130,49 @@ internal static class GatherCommand
 
         public string? GetFormula(CellRef cell)
         {
+            if (cell.IsExternal)
+                return null;
+            var sheet = TryGetWorksheet(cell.Sheet);
+            if (sheet == null)
+                return null;
             try
             {
-                dynamic range = _worksheet.Cells[cell.Row, cell.Column];
+                dynamic range = sheet.Cells[cell.Row, cell.Column];
                 if ((bool)range.HasFormula)
                     return (string)range.Formula;
                 return null;
             }
             catch (Exception ex)
             {
-                Logger.Error($"Gather/GetFormula({cell.A1Address})", ex);
+                Logger.Error($"Gather/GetFormula({cell.Sheet}!{cell.A1Address})", ex);
                 return null;
             }
         }
 
         public string? GetCellAboveText(CellRef cell)
         {
-            if (cell.Row <= 1)
+            if (cell.IsExternal || cell.Row <= 1)
                 return null;
-            return ReadStringValue(cell.Row - 1, cell.Column, $"GetCellAboveText({cell.A1Address})");
+            return ReadStringValue(cell.Sheet, cell.Row - 1, cell.Column,
+                $"GetCellAboveText({cell.Sheet}!{cell.A1Address})");
         }
 
         public string? GetCellLeftText(CellRef cell)
         {
-            if (cell.Column <= 1)
+            if (cell.IsExternal || cell.Column <= 1)
                 return null;
-            return ReadStringValue(cell.Row, cell.Column - 1, $"GetCellLeftText({cell.A1Address})");
+            return ReadStringValue(cell.Sheet, cell.Row, cell.Column - 1,
+                $"GetCellLeftText({cell.Sheet}!{cell.A1Address})");
         }
 
-        private string? ReadStringValue(int row, int column, string context)
+        private string? ReadStringValue(string sheetName, int row, int column, string context)
         {
+            var sheet = TryGetWorksheet(sheetName);
+            if (sheet == null)
+                return null;
             try
             {
-                dynamic range = _worksheet.Cells[row, column];
+                dynamic range = sheet.Cells[row, column];
                 var value = range.Value2;
                 if (value is string s && !string.IsNullOrEmpty(s))
                     return s;
@@ -168,6 +181,22 @@ internal static class GatherCommand
             catch (Exception ex)
             {
                 Logger.Error($"Gather/{context}", ex);
+                return null;
+            }
+        }
+
+        // The COM Worksheets[name] indexer throws when the name is missing;
+        // catching the exception is the cheapest "does this sheet exist?"
+        // probe. Walking the collection by index is also valid but pays a
+        // round-trip per sheet.
+        private dynamic? TryGetWorksheet(string sheetName)
+        {
+            try
+            {
+                return _workbook.Worksheets[sheetName];
+            }
+            catch
+            {
                 return null;
             }
         }

--- a/addin/lambda-boss/GatherEngine.cs
+++ b/addin/lambda-boss/GatherEngine.cs
@@ -6,10 +6,10 @@ namespace LambdaBoss;
 ///     The top-level Gather entry point. Walks the precedent graph, names
 ///     each cell, classifies it as input or step, rewrites step formulas
 ///     to refer to bindings, and emits a single <c>=LET(...)</c> formula
-///     equivalent to the sink-rooted calculation graph. PR 2 scope: PR 1's
-///     chain/branched DAG support plus full naming completeness — cell-above
-///     fallback to cell-left, sanitization via <see cref="LetNameSanitizer" />,
-///     and final-collision suffixing.
+///     equivalent to the sink-rooted calculation graph. PR 3 widens scope
+///     to cross-sheet and external-workbook refs: cross-sheet inputs render
+///     their RHS as a sheet-qualified address; external refs render their
+///     workbook tag and never recurse.
 /// </summary>
 public static class GatherEngine
 {
@@ -46,11 +46,17 @@ public static class GatherEngine
             string rhs;
             if (role == BindingRole.Input)
             {
-                rhs = cell.Ref.A1Address;
+                // Bare A1 for in-sheet refs, sheet-qualified otherwise,
+                // workbook-qualified for externals — DisplayAddress handles
+                // the quoting rules so the RHS round-trips cleanly.
+                rhs = cell.Ref.DisplayAddress(source.SinkSheet);
             }
             else
             {
-                rhs = CellRefExtractor.Rewrite(StripLeadingEquals(cell.Formula!), source.SinkSheet, nameByRef);
+                // The step's formula was extracted using its own sheet as
+                // the default; the rewrite needs that same default so refs
+                // resolve to the same CellRef keys the walker built.
+                rhs = CellRefExtractor.Rewrite(StripLeadingEquals(cell.Formula!), cell.Ref.Sheet, nameByRef);
             }
 
             var row = new BindingRow(cell.Ref, role, name, rhs);
@@ -129,6 +135,9 @@ public static class GatherEngine
 
     private static BindingRole ClassifyRole(WalkedCell cell, HashSet<CellRef> inScope)
     {
+        // External refs and missing-sheet refs surface here as null-formula
+        // cells (the source can't reach them) and so naturally classify as
+        // input — exactly what we want.
         if (cell.Formula == null)
             return BindingRole.Input;
         // A formula cell whose precedents are all out of scope (none of the

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -17,6 +17,15 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
     /// <summary>True for refs into an external workbook.</summary>
     public bool IsExternal => ExternalWorkbook != null;
 
+    public bool Equals(CellRef? other)
+    {
+        return other is not null
+               && string.Equals(Sheet, other.Sheet, StringComparison.OrdinalIgnoreCase)
+               && Column == other.Column
+               && Row == other.Row
+               && string.Equals(ExternalWorkbook, other.ExternalWorkbook, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     ///     The form to emit as a LET binding RHS when the LET lives on
     ///     <paramref name="hostSheet" />. In-sheet refs render bare;
@@ -27,7 +36,6 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
     {
         if (IsExternal)
         {
-            var sheetPart = SheetPartForQualifiedRef(Sheet);
             var wb = ExternalWorkbook!;
             // If either the workbook or sheet needs quoting, the entire
             // qualifier goes inside one set of single quotes around
@@ -36,6 +44,7 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
                 return $"'[{wb}]{EscapeQuotes(Sheet)}'!{A1Address}";
             return $"[{wb}]{Sheet}!{A1Address}";
         }
+
         if (string.Equals(Sheet, hostSheet, StringComparison.OrdinalIgnoreCase))
             return A1Address;
         if (NeedsQuotes(Sheet))
@@ -43,14 +52,10 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
         return $"{Sheet}!{A1Address}";
     }
 
-    public override string ToString() => A1Address;
-
-    public bool Equals(CellRef? other) =>
-        other is not null
-        && string.Equals(Sheet, other.Sheet, StringComparison.OrdinalIgnoreCase)
-        && Column == other.Column
-        && Row == other.Row
-        && string.Equals(ExternalWorkbook, other.ExternalWorkbook, StringComparison.OrdinalIgnoreCase);
+    public override string ToString()
+    {
+        return A1Address;
+    }
 
     public override int GetHashCode()
     {
@@ -74,6 +79,7 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
             letters = (char)('A' + n % 26) + letters;
             n /= 26;
         }
+
         return letters;
     }
 
@@ -86,8 +92,9 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
         {
             if (!char.IsLetter(c))
                 throw new ArgumentException($"Invalid column letter: '{c}'.", nameof(letters));
-            col = col * 26 + (char.ToUpperInvariant(c) - 'A' + 1);
+            col = col * 26 + (char.ToUpperInvariant(c) - 'A') + 1;
         }
+
         return col;
     }
 
@@ -106,17 +113,15 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
         if (char.IsDigit(name[0]))
             return true;
         foreach (var c in name)
-        {
             if (!char.IsLetterOrDigit(c) && c != '_' && c != '.')
                 return true;
-        }
         return false;
     }
 
-    private static string EscapeQuotes(string name) => name.Replace("'", "''");
-
-    private static string SheetPartForQualifiedRef(string sheet) =>
-        NeedsQuotes(sheet) ? EscapeQuotes(sheet) : sheet;
+    private static string EscapeQuotes(string name)
+    {
+        return name.Replace("'", "''");
+    }
 }
 
 /// <summary>
@@ -148,7 +153,7 @@ public sealed record BindingRow(
 public enum BindingRole
 {
     Input,
-    Step,
+    Step
 }
 
 /// <summary>

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -1,18 +1,66 @@
 namespace LambdaBoss;
 
 /// <summary>
-///     A workbook cell address. PR 1 uses single-sheet refs only; the
-///     <see cref="Sheet" /> field is always the sink's sheet name in this
-///     slice but is included so cross-sheet support can land in PR 3 without
-///     changing the type shape. <see cref="Column" /> and <see cref="Row" />
-///     are 1-based to match Excel's COM addressing.
+///     A workbook cell address. PR 3 adds cross-sheet and external-workbook
+///     support: <see cref="Sheet" /> identifies the worksheet (any sheet in
+///     the active workbook for in-scope refs); <see cref="ExternalWorkbook" />
+///     is non-null for refs into another open or closed workbook (treated as
+///     leaves by the walker). Equality is case-insensitive on
+///     <see cref="Sheet" /> and <see cref="ExternalWorkbook" /> to match
+///     Excel's own name resolution.
 /// </summary>
-public sealed record CellRef(string Sheet, int Column, int Row)
+public sealed record CellRef(string Sheet, int Column, int Row, string? ExternalWorkbook = null)
 {
     /// <summary>The unqualified A1-style address, e.g. <c>A1</c>, <c>BC27</c>.</summary>
     public string A1Address => $"{ColumnLetters(Column)}{Row}";
 
+    /// <summary>True for refs into an external workbook.</summary>
+    public bool IsExternal => ExternalWorkbook != null;
+
+    /// <summary>
+    ///     The form to emit as a LET binding RHS when the LET lives on
+    ///     <paramref name="hostSheet" />. In-sheet refs render bare;
+    ///     cross-sheet refs are sheet-qualified and quoted only if the sheet
+    ///     name needs quoting; external refs always include the workbook tag.
+    /// </summary>
+    public string DisplayAddress(string hostSheet)
+    {
+        if (IsExternal)
+        {
+            var sheetPart = SheetPartForQualifiedRef(Sheet);
+            var wb = ExternalWorkbook!;
+            // If either the workbook or sheet needs quoting, the entire
+            // qualifier goes inside one set of single quotes around
+            // [Wb]Sheet, with embedded quotes doubled.
+            if (NeedsQuotes(Sheet) || NeedsQuotes(wb))
+                return $"'[{wb}]{EscapeQuotes(Sheet)}'!{A1Address}";
+            return $"[{wb}]{Sheet}!{A1Address}";
+        }
+        if (string.Equals(Sheet, hostSheet, StringComparison.OrdinalIgnoreCase))
+            return A1Address;
+        if (NeedsQuotes(Sheet))
+            return $"'{EscapeQuotes(Sheet)}'!{A1Address}";
+        return $"{Sheet}!{A1Address}";
+    }
+
     public override string ToString() => A1Address;
+
+    public bool Equals(CellRef? other) =>
+        other is not null
+        && string.Equals(Sheet, other.Sheet, StringComparison.OrdinalIgnoreCase)
+        && Column == other.Column
+        && Row == other.Row
+        && string.Equals(ExternalWorkbook, other.ExternalWorkbook, StringComparison.OrdinalIgnoreCase);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Sheet, StringComparer.OrdinalIgnoreCase);
+        hash.Add(Column);
+        hash.Add(Row);
+        hash.Add(ExternalWorkbook, StringComparer.OrdinalIgnoreCase);
+        return hash.ToHashCode();
+    }
 
     internal static string ColumnLetters(int column)
     {
@@ -42,15 +90,43 @@ public sealed record CellRef(string Sheet, int Column, int Row)
         }
         return col;
     }
+
+    /// <summary>
+    ///     Excel allows unquoted sheet/workbook qualifiers when they look
+    ///     like an identifier (letters/digits/underscore/dot, not starting
+    ///     with a digit). The dot exemption matters for workbook names with
+    ///     extensions (<c>Other.xlsx</c>) and for sheet names like
+    ///     <c>Data.v2</c> that authors sometimes write — we'd be otherwise
+    ///     adding noise quotes around perfectly valid bare qualifiers.
+    /// </summary>
+    private static bool NeedsQuotes(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return true;
+        if (char.IsDigit(name[0]))
+            return true;
+        foreach (var c in name)
+        {
+            if (!char.IsLetterOrDigit(c) && c != '_' && c != '.')
+                return true;
+        }
+        return false;
+    }
+
+    private static string EscapeQuotes(string name) => name.Replace("'", "''");
+
+    private static string SheetPartForQualifiedRef(string sheet) =>
+        NeedsQuotes(sheet) ? EscapeQuotes(sheet) : sheet;
 }
 
 /// <summary>
 ///     A cell discovered by <see cref="CellGraphWalker" />. The
-///     <see cref="Formula" /> is null when the cell holds a literal value
-///     (treated as a leaf input). <see cref="CellAboveText" /> and
+///     <see cref="Formula" /> is null when the cell holds a literal value or
+///     is unreachable (external workbook ref, missing sheet) — both treated
+///     as leaf inputs. <see cref="CellAboveText" /> and
 ///     <see cref="CellLeftText" /> are the text of the cells directly above
-///     and to the left (checked in that order during binding-name derivation),
-///     null when the neighbour is out of range, empty, or non-string.
+///     and to the left on the cell's own sheet, null when out of range,
+///     empty, or non-string.
 /// </summary>
 public sealed record WalkedCell(
     CellRef Ref,
@@ -88,31 +164,42 @@ public sealed record GatherResult(
 /// <summary>
 ///     COM-free abstraction over the active workbook used by
 ///     <see cref="CellGraphWalker" />. The live adapter implements this
-///     against <c>Range</c> on the macro thread; tests stub it with an
+///     against the <c>Workbook</c> COM object; tests stub it with an
 ///     in-memory dictionary so the engine is exercisable without Excel.
+///     PR 3 widens the contract to span all sheets in the workbook —
+///     implementations resolve <see cref="CellRef.Sheet" /> case-insensitively
+///     against the workbook's worksheets and return null for external refs
+///     and refs into sheets that don't exist.
 /// </summary>
 public interface ICellSource
 {
-    /// <summary>The sheet the sink lives on; PR 1 walks within it only.</summary>
+    /// <summary>
+    ///     The sheet the sink lives on. Used as the default sheet for
+    ///     unqualified refs in the sink's own formula and for the binding
+    ///     RHS rendering rule (in-sheet refs stay bare).
+    /// </summary>
     string SinkSheet { get; }
 
     /// <summary>
     ///     Returns the cell's formula text starting with <c>=</c>, or null
-    ///     when the cell is empty or holds a literal value.
+    ///     when the cell is empty, holds a literal value, lives on a sheet
+    ///     not in the active workbook, or is an external-workbook ref.
     /// </summary>
     string? GetFormula(CellRef cell);
 
     /// <summary>
     ///     Returns the displayed text of the cell directly above
-    ///     <paramref name="cell" />, or null if that cell is empty,
-    ///     non-string, or <paramref name="cell" /> is in row 1.
+    ///     <paramref name="cell" /> on its own sheet, or null if the
+    ///     neighbour is out of range, empty, non-string, the cell is in row
+    ///     1, or the cell is unreachable.
     /// </summary>
     string? GetCellAboveText(CellRef cell);
 
     /// <summary>
     ///     Returns the displayed text of the cell directly to the left of
-    ///     <paramref name="cell" />, or null if that cell is empty,
-    ///     non-string, or <paramref name="cell" /> is in column 1.
+    ///     <paramref name="cell" /> on its own sheet, or null if the
+    ///     neighbour is out of range, empty, non-string, the cell is in
+    ///     column 1, or the cell is unreachable.
     /// </summary>
     string? GetCellLeftText(CellRef cell);
 }


### PR DESCRIPTION
PR 3 of 12 in spec 0005. Targets the spec branch `claude/lambda-from-formulas-wsF4Q`; do not merge to `main`.

## Summary

- `CellRefExtractor` now parses sheet-qualified refs (`Sheet1!A1`, `'My Sheet'!A1`) and external-workbook refs (`[Other.xlsx]Sheet1!A1`, `'[Other.xlsx]My Sheet'!A1`, closed-workbook `'C:\path\[…]Sheet'!A1`) alongside bare cells.
- `CellRef` carries `ExternalWorkbook` and a `DisplayAddress(hostSheet)` helper that emits the right qualifier shape per host. Equality is case-insensitive on sheet/workbook to match Excel's name resolution.
- `CellGraphWalker` extracts each cell's precedents using *its own* sheet as the default, so a Sheet1 step's bare `B1` correctly resolves to `Sheet1!B1` when reached from a Sheet2 sink.
- `GatherEngine` renders input RHS via `DisplayAddress` (bare for in-sheet, sheet-qualified for cross-sheet, workbook-qualified for external) and rewrites step formulas using each step's own sheet as the default.
- `LiveCellSource` is rebuilt to span the active workbook: `Workbook.Worksheets[name]` looks up each ref's sheet, and external/missing-sheet refs return null formulas (surfacing as leaves upstream).

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` clean
- [x] `dotnet test addin/lambda-boss.Tests` — 515 passed
- [x] Manual smoke (per issue body): Sheet1!A1=42; Sheet2!B1=`=Sheet1!A1*2`; Sheet2!C1=`=B1+1`; run `/Gather` on Sheet2!C1; confirm preview shows `Sheet1!A1` rewritten to a binding name in B1's RHS; Save; confirm Sheet2!C1 evaluates to 85.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)