### PR TITLE
Gather: range promotion (PR 4 of 12)

### DIFF
--- a/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
+++ b/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
@@ -139,6 +139,50 @@ public class CellGraphWalkerTests
         Assert.Null(external.Formula);
         Assert.Empty(external.Precedents);
     }
+
+    [Fact]
+    public void Walk_RangePrecedent_DoesNotRecurseIntoRangeCells()
+    {
+        // PR 4: A1, A2, A3 each have a formula but only the range
+        // references them. The walker must NOT include A1/A2/A3 as walked
+        // cells (they're not directly referenced) — the range precedent is
+        // an opaque leaf for the engine to promote.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=RAND()")
+            .WithFormula("A2", "=RAND()")
+            .WithFormula("A3", "=RAND()")
+            .WithFormula("B1", "=SUM(A1:A3)");
+
+        var walked = CellGraphWalker.Walk(source.Ref("B1"), source);
+
+        Assert.Single(walked);
+        Assert.Equal("B1", walked[0].Ref.A1Address);
+
+        var precedents = walked[0].Precedents;
+        Assert.Single(precedents);
+        Assert.True(precedents[0].IsRange);
+        Assert.Equal("A1", precedents[0].Start.A1Address);
+        Assert.Equal("A3", precedents[0].End!.A1Address);
+    }
+
+    [Fact]
+    public void Walk_RangeAndIndividualCell_IndividualCellWalkedSeparately()
+    {
+        // PR 4 acceptance: =SUM(A1:A3) + A4 — A4 is an individual ref and
+        // must be walked, while the range stays opaque.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=SUM(A1:A3) + A4");
+
+        var walked = CellGraphWalker.Walk(source.Ref("B1"), source);
+        var addresses = walked.Select(w => w.Ref.A1Address).OrderBy(a => a).ToList();
+
+        Assert.Equal(new[] { "A4", "B1" }, addresses);
+
+        var b1 = walked.Single(w => w.Ref.A1Address == "B1");
+        Assert.Equal(2, b1.Precedents.Count);
+        Assert.Contains(b1.Precedents, p => p.IsRange && p.A1Address == "A1:A3");
+        Assert.Contains(b1.Precedents, p => !p.IsRange && p.Start.A1Address == "A4");
+    }
 }
 
 internal static class WalkedCellExtensions

--- a/addin/lambda-boss.Tests/CellRefExtractorTests.cs
+++ b/addin/lambda-boss.Tests/CellRefExtractorTests.cs
@@ -58,7 +58,7 @@ public class CellRefExtractorTests
         Assert.Equal("A1", refs[0].Start.A1Address);
         Assert.Equal("A3", refs[0].End!.A1Address);
         Assert.Equal(Sheet, refs[0].Start.Sheet);
-        Assert.Equal(Sheet, refs[0].End.Sheet);
+        Assert.Equal(Sheet, refs[0].End!.Sheet);
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class CellRefExtractorTests
         Assert.Equal("Sheet1", refs[0].Start.Sheet);
         Assert.Equal("Sheet1", refs[0].End!.Sheet);
         Assert.Equal("A1", refs[0].Start.A1Address);
-        Assert.Equal("A3", refs[0].End.A1Address);
+        Assert.Equal("A3", refs[0].End!.A1Address);
     }
 
     [Fact]
@@ -230,7 +230,7 @@ public class CellRefExtractorTests
         var lookup = new Dictionary<FormulaRef, string>
         {
             [new FormulaRef(new CellRef(Sheet, 1, 1))] = "numbers",
-            [new FormulaRef(new CellRef(Sheet, 2, 1))] = "step_1",
+            [new FormulaRef(new CellRef(Sheet, 2, 1))] = "step_1"
         };
 
         var rewritten = CellRefExtractor.Rewrite("=A1*2+B1", Sheet, lookup);
@@ -243,7 +243,7 @@ public class CellRefExtractorTests
     {
         var lookup = new Dictionary<FormulaRef, string>
         {
-            [new FormulaRef(new CellRef(Sheet, 1, 1))] = "numbers",
+            [new FormulaRef(new CellRef(Sheet, 1, 1))] = "numbers"
         };
 
         var rewritten = CellRefExtractor.Rewrite("=A1*Z99", Sheet, lookup);
@@ -256,7 +256,7 @@ public class CellRefExtractorTests
     {
         var lookup = new Dictionary<FormulaRef, string>
         {
-            [new FormulaRef(new CellRef(Sheet, 1, 1))] = "numbers",
+            [new FormulaRef(new CellRef(Sheet, 1, 1))] = "numbers"
         };
 
         var rewritten = CellRefExtractor.Rewrite("=A1&\"A1 unchanged\"", Sheet, lookup);
@@ -270,7 +270,7 @@ public class CellRefExtractorTests
         // The whole `Sheet1!A1` collapses to the binding name, not just A1.
         var lookup = new Dictionary<FormulaRef, string>
         {
-            [new FormulaRef(new CellRef("Sheet1", 1, 1))] = "shared",
+            [new FormulaRef(new CellRef("Sheet1", 1, 1))] = "shared"
         };
 
         var rewritten = CellRefExtractor.Rewrite("=Sheet1!A1*2", "Sheet2", lookup);
@@ -283,7 +283,7 @@ public class CellRefExtractorTests
     {
         var lookup = new Dictionary<FormulaRef, string>
         {
-            [new FormulaRef(new CellRef("My Sheet", 1, 1))] = "mine",
+            [new FormulaRef(new CellRef("My Sheet", 1, 1))] = "mine"
         };
 
         var rewritten = CellRefExtractor.Rewrite("='My Sheet'!A1+1", "Sheet2", lookup);
@@ -296,7 +296,7 @@ public class CellRefExtractorTests
     {
         var lookup = new Dictionary<FormulaRef, string>
         {
-            [new FormulaRef(new CellRef("Sheet1", 1, 1, "Other.xlsx"))] = "outside",
+            [new FormulaRef(new CellRef("Sheet1", 1, 1, "Other.xlsx"))] = "outside"
         };
 
         var rewritten = CellRefExtractor.Rewrite("=[Other.xlsx]Sheet1!A1*2", "Sheet2", lookup);
@@ -310,7 +310,7 @@ public class CellRefExtractorTests
         var lookup = new Dictionary<FormulaRef, string>
         {
             [new FormulaRef(new CellRef("Sheet2", 2, 1))] = "local",
-            [new FormulaRef(new CellRef("Sheet1", 1, 1))] = "shared",
+            [new FormulaRef(new CellRef("Sheet1", 1, 1))] = "shared"
         };
 
         var rewritten = CellRefExtractor.Rewrite("=B1+Sheet1!A1", "Sheet2", lookup);
@@ -325,7 +325,7 @@ public class CellRefExtractorTests
         // name in the rewritten formula.
         var lookup = new Dictionary<FormulaRef, string>
         {
-            [new FormulaRef(new CellRef(Sheet, 1, 1), new CellRef(Sheet, 1, 3))] = "values",
+            [new FormulaRef(new CellRef(Sheet, 1, 1), new CellRef(Sheet, 1, 3))] = "values"
         };
 
         var rewritten = CellRefExtractor.Rewrite("=SUM(A1:A3)", Sheet, lookup);
@@ -342,7 +342,7 @@ public class CellRefExtractorTests
         var lookup = new Dictionary<FormulaRef, string>
         {
             [new FormulaRef(new CellRef(Sheet, 1, 1), new CellRef(Sheet, 1, 3))] = "values",
-            [new FormulaRef(new CellRef(Sheet, 1, 4))] = "extra",
+            [new FormulaRef(new CellRef(Sheet, 1, 4))] = "extra"
         };
 
         var rewritten = CellRefExtractor.Rewrite("=SUM(A1:A3)+A4", Sheet, lookup);
@@ -355,7 +355,7 @@ public class CellRefExtractorTests
     {
         var lookup = new Dictionary<FormulaRef, string>
         {
-            [new FormulaRef(new CellRef("Sheet1", 1, 1), new CellRef("Sheet1", 1, 3))] = "values",
+            [new FormulaRef(new CellRef("Sheet1", 1, 1), new CellRef("Sheet1", 1, 3))] = "values"
         };
 
         var rewritten = CellRefExtractor.Rewrite("=SUM(Sheet1!A1:A3)", "Sheet2", lookup);

--- a/addin/lambda-boss.Tests/CellRefExtractorTests.cs
+++ b/addin/lambda-boss.Tests/CellRefExtractorTests.cs
@@ -47,13 +47,81 @@ public class CellRefExtractorTests
     }
 
     [Fact]
-    public void Extract_RangeRef_ExcludesBothEndpoints()
+    public void Extract_RangeRef_ReturnedAsSingleRangeFormulaRef()
     {
-        // PR 1 doesn't promote ranges; we just need to NOT pick up A1 or
-        // A3 as standalone cells while a range is being parsed elsewhere.
+        // PR 4 promotes ranges to first-class refs. A1:A3 surfaces as one
+        // FormulaRef (Start=A1, End=A3), not two cells.
         var refs = CellRefExtractor.Extract("=SUM(A1:A3)", Sheet);
 
-        Assert.Empty(refs);
+        Assert.Single(refs);
+        Assert.True(refs[0].IsRange);
+        Assert.Equal("A1", refs[0].Start.A1Address);
+        Assert.Equal("A3", refs[0].End!.A1Address);
+        Assert.Equal(Sheet, refs[0].Start.Sheet);
+        Assert.Equal(Sheet, refs[0].End.Sheet);
+    }
+
+    [Fact]
+    public void Extract_RangeRefWithDollarAnchors_StripsAnchors()
+    {
+        var refs = CellRefExtractor.Extract("=SUM($A$1:$A$3)", Sheet);
+
+        Assert.Single(refs);
+        Assert.True(refs[0].IsRange);
+        Assert.Equal("A1", refs[0].Start.A1Address);
+        Assert.Equal("A3", refs[0].End!.A1Address);
+    }
+
+    [Fact]
+    public void Extract_MultiRowRange_BothEndpointsCaptured()
+    {
+        // Two-dimensional range: the End cell carries its own column AND
+        // row — the engine uses both to test cell coverage.
+        var refs = CellRefExtractor.Extract("=SUM(A1:C3)", Sheet);
+
+        Assert.Single(refs);
+        Assert.True(refs[0].IsRange);
+        Assert.Equal("A1", refs[0].Start.A1Address);
+        Assert.Equal("C3", refs[0].End!.A1Address);
+    }
+
+    [Fact]
+    public void Extract_CrossSheetRange_BothEndpointsOnQualifiedSheet()
+    {
+        var refs = CellRefExtractor.Extract("=SUM(Sheet1!A1:A3)", "Sheet2");
+
+        Assert.Single(refs);
+        Assert.True(refs[0].IsRange);
+        Assert.Equal("Sheet1", refs[0].Start.Sheet);
+        Assert.Equal("Sheet1", refs[0].End!.Sheet);
+        Assert.Equal("A1", refs[0].Start.A1Address);
+        Assert.Equal("A3", refs[0].End.A1Address);
+    }
+
+    [Fact]
+    public void Extract_QuotedSheetRange_StripsQuotesOnBothEndpoints()
+    {
+        var refs = CellRefExtractor.Extract("=SUM('My Sheet'!A1:A3)", "Sheet2");
+
+        Assert.Single(refs);
+        Assert.True(refs[0].IsRange);
+        Assert.Equal("My Sheet", refs[0].Start.Sheet);
+        Assert.Equal("My Sheet", refs[0].End!.Sheet);
+    }
+
+    [Fact]
+    public void Extract_RangeAndIndividualCell_BothReturnedSeparately()
+    {
+        // The PR 4 acceptance scenario: =SUM(A1:A3) + A4 must yield two
+        // distinct refs — the range and the individual cell — so the
+        // engine can promote the range while still walking A4.
+        var refs = CellRefExtractor.Extract("=SUM(A1:A3) + A4", Sheet);
+
+        Assert.Equal(2, refs.Count);
+        Assert.True(refs[0].IsRange);
+        Assert.Equal("A1:A3", refs[0].A1Address);
+        Assert.False(refs[1].IsRange);
+        Assert.Equal("A4", refs[1].Start.A1Address);
     }
 
     [Fact]
@@ -159,10 +227,10 @@ public class CellRefExtractorTests
     [Fact]
     public void Rewrite_ReplacesInScopeRefsWithBindingNames()
     {
-        var lookup = new Dictionary<CellRef, string>
+        var lookup = new Dictionary<FormulaRef, string>
         {
-            [new CellRef(Sheet, 1, 1)] = "numbers",
-            [new CellRef(Sheet, 2, 1)] = "step_1",
+            [new FormulaRef(new CellRef(Sheet, 1, 1))] = "numbers",
+            [new FormulaRef(new CellRef(Sheet, 2, 1))] = "step_1",
         };
 
         var rewritten = CellRefExtractor.Rewrite("=A1*2+B1", Sheet, lookup);
@@ -173,9 +241,9 @@ public class CellRefExtractorTests
     [Fact]
     public void Rewrite_LeavesOutOfScopeRefsAlone()
     {
-        var lookup = new Dictionary<CellRef, string>
+        var lookup = new Dictionary<FormulaRef, string>
         {
-            [new CellRef(Sheet, 1, 1)] = "numbers",
+            [new FormulaRef(new CellRef(Sheet, 1, 1))] = "numbers",
         };
 
         var rewritten = CellRefExtractor.Rewrite("=A1*Z99", Sheet, lookup);
@@ -186,9 +254,9 @@ public class CellRefExtractorTests
     [Fact]
     public void Rewrite_PreservesStringLiterals()
     {
-        var lookup = new Dictionary<CellRef, string>
+        var lookup = new Dictionary<FormulaRef, string>
         {
-            [new CellRef(Sheet, 1, 1)] = "numbers",
+            [new FormulaRef(new CellRef(Sheet, 1, 1))] = "numbers",
         };
 
         var rewritten = CellRefExtractor.Rewrite("=A1&\"A1 unchanged\"", Sheet, lookup);
@@ -200,9 +268,9 @@ public class CellRefExtractorTests
     public void Rewrite_SheetQualifiedRef_ReplacesWholeQualifier()
     {
         // The whole `Sheet1!A1` collapses to the binding name, not just A1.
-        var lookup = new Dictionary<CellRef, string>
+        var lookup = new Dictionary<FormulaRef, string>
         {
-            [new CellRef("Sheet1", 1, 1)] = "shared",
+            [new FormulaRef(new CellRef("Sheet1", 1, 1))] = "shared",
         };
 
         var rewritten = CellRefExtractor.Rewrite("=Sheet1!A1*2", "Sheet2", lookup);
@@ -213,9 +281,9 @@ public class CellRefExtractorTests
     [Fact]
     public void Rewrite_QuotedSheetRef_ReplacesWholeQualifier()
     {
-        var lookup = new Dictionary<CellRef, string>
+        var lookup = new Dictionary<FormulaRef, string>
         {
-            [new CellRef("My Sheet", 1, 1)] = "mine",
+            [new FormulaRef(new CellRef("My Sheet", 1, 1))] = "mine",
         };
 
         var rewritten = CellRefExtractor.Rewrite("='My Sheet'!A1+1", "Sheet2", lookup);
@@ -226,9 +294,9 @@ public class CellRefExtractorTests
     [Fact]
     public void Rewrite_ExternalRef_ReplacesWholeQualifier()
     {
-        var lookup = new Dictionary<CellRef, string>
+        var lookup = new Dictionary<FormulaRef, string>
         {
-            [new CellRef("Sheet1", 1, 1, "Other.xlsx")] = "outside",
+            [new FormulaRef(new CellRef("Sheet1", 1, 1, "Other.xlsx"))] = "outside",
         };
 
         var rewritten = CellRefExtractor.Rewrite("=[Other.xlsx]Sheet1!A1*2", "Sheet2", lookup);
@@ -239,15 +307,60 @@ public class CellRefExtractorTests
     [Fact]
     public void Rewrite_BareRefAndCrossSheetRef_BothMatchedSeparately()
     {
-        var lookup = new Dictionary<CellRef, string>
+        var lookup = new Dictionary<FormulaRef, string>
         {
-            [new CellRef("Sheet2", 2, 1)] = "local",
-            [new CellRef("Sheet1", 1, 1)] = "shared",
+            [new FormulaRef(new CellRef("Sheet2", 2, 1))] = "local",
+            [new FormulaRef(new CellRef("Sheet1", 1, 1))] = "shared",
         };
 
         var rewritten = CellRefExtractor.Rewrite("=B1+Sheet1!A1", "Sheet2", lookup);
 
         Assert.Equal("=local+shared", rewritten);
+    }
+
+    [Fact]
+    public void Rewrite_RangeRef_ReplacedByRangeBindingName()
+    {
+        // PR 4: a range key in the lookup collapses A1:A3 to one binding
+        // name in the rewritten formula.
+        var lookup = new Dictionary<FormulaRef, string>
+        {
+            [new FormulaRef(new CellRef(Sheet, 1, 1), new CellRef(Sheet, 1, 3))] = "values",
+        };
+
+        var rewritten = CellRefExtractor.Rewrite("=SUM(A1:A3)", Sheet, lookup);
+
+        Assert.Equal("=SUM(values)", rewritten);
+    }
+
+    [Fact]
+    public void Rewrite_RangeAndCellBindings_BothApplied()
+    {
+        // Range + standalone cell ref in the same formula. The range
+        // binding takes the whole `A1:A3` token; the standalone `A4`
+        // collapses separately.
+        var lookup = new Dictionary<FormulaRef, string>
+        {
+            [new FormulaRef(new CellRef(Sheet, 1, 1), new CellRef(Sheet, 1, 3))] = "values",
+            [new FormulaRef(new CellRef(Sheet, 1, 4))] = "extra",
+        };
+
+        var rewritten = CellRefExtractor.Rewrite("=SUM(A1:A3)+A4", Sheet, lookup);
+
+        Assert.Equal("=SUM(values)+extra", rewritten);
+    }
+
+    [Fact]
+    public void Rewrite_CrossSheetRange_ReplacesWholeQualifier()
+    {
+        var lookup = new Dictionary<FormulaRef, string>
+        {
+            [new FormulaRef(new CellRef("Sheet1", 1, 1), new CellRef("Sheet1", 1, 3))] = "values",
+        };
+
+        var rewritten = CellRefExtractor.Rewrite("=SUM(Sheet1!A1:A3)", "Sheet2", lookup);
+
+        Assert.Equal("=SUM(values)", rewritten);
     }
 
     [Fact]

--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -34,12 +34,12 @@ public class GatherEngineTests
         // above B1 is empty, no cell-left either).
         Assert.Equal(2, result.Bindings.Count);
 
-        var aRow = result.Bindings.Single(b => b.CellRef.A1Address == "A2");
+        var aRow = result.Bindings.Single(b => b.Source.A1Address == "A2");
         Assert.Equal(BindingRole.Input, aRow.Role);
         Assert.Equal("numbers", aRow.Name);
         Assert.Equal("A2", aRow.Rhs);
 
-        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B2");
         Assert.Equal(BindingRole.Step, bRow.Role);
         Assert.Equal("step_1", bRow.Name);
         Assert.Equal("numbers*2", bRow.Rhs);
@@ -69,7 +69,7 @@ public class GatherEngineTests
 
         Assert.Equal(2, result.Bindings.Count);
         Assert.All(result.Bindings, b => Assert.Equal(BindingRole.Input, b.Role));
-        var addrs = result.Bindings.Select(b => b.CellRef.A1Address).ToList();
+        var addrs = result.Bindings.Select(b => b.Source.A1Address).ToList();
         Assert.Contains("A1", addrs);
         Assert.Contains("B1", addrs);
 
@@ -120,8 +120,8 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("C1"), source)!;
 
-        var aRow = result.Bindings.Single(b => b.CellRef.A1Address == "A1");
-        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B1");
+        var aRow = result.Bindings.Single(b => b.Source.A1Address == "A1");
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B1");
         Assert.Equal("step_1", aRow.Name);
         Assert.Equal("step_2", bRow.Name);
     }
@@ -180,7 +180,7 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("C1"), source)!;
 
-        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B1");
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B1");
         Assert.Equal(BindingRole.Input, bRow.Role);
         Assert.Equal("B1", bRow.Rhs);
     }
@@ -196,7 +196,7 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("C2"), source)!;
 
-        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B2");
         Assert.Equal("numbers", bRow.Name);
     }
 
@@ -211,7 +211,7 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("C2"), source)!;
 
-        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B2");
         Assert.Equal("above", bRow.Name);
     }
 
@@ -227,7 +227,7 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("C2"), source)!;
 
-        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B2");
         Assert.Equal("numbers", bRow.Name);
     }
 
@@ -244,8 +244,8 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("C1"), source)!;
 
-        var b1 = result.Bindings.Single(b => b.CellRef.A1Address == "B1");
-        var b2 = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        var b1 = result.Bindings.Single(b => b.Source.A1Address == "B1");
+        var b2 = result.Bindings.Single(b => b.Source.A1Address == "B2");
         var names = new[] { b1.Name, b2.Name }.OrderBy(n => n).ToList();
         Assert.Equal(new[] { "sales", "sales_2" }, names);
     }
@@ -264,7 +264,7 @@ public class GatherEngineTests
         var result = GatherEngine.Gather(source.Ref("D1"), source)!;
 
         var names = new[] { "B1", "B2", "B3" }
-            .Select(addr => result.Bindings.Single(b => b.CellRef.A1Address == addr).Name)
+            .Select(addr => result.Bindings.Single(b => b.Source.A1Address == addr).Name)
             .OrderBy(n => n)
             .ToList();
         Assert.Equal(new[] { "x", "x_2", "x_3" }, names);
@@ -281,8 +281,8 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("C1"), source)!;
 
-        var b1 = result.Bindings.Single(b => b.CellRef.A1Address == "B1");
-        var b2 = result.Bindings.Single(b => b.CellRef.A1Address == "B2");
+        var b1 = result.Bindings.Single(b => b.Source.A1Address == "B1");
+        var b2 = result.Bindings.Single(b => b.Source.A1Address == "B2");
         Assert.Equal("step_1", b1.Name);
         Assert.Equal("step_2", b2.Name);
     }
@@ -297,7 +297,7 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("Sheet2!C1"), source)!;
 
-        var aRow = result.Bindings.Single(b => b.CellRef.A1Address == "A1");
+        var aRow = result.Bindings.Single(b => b.Source.A1Address == "A1");
         Assert.Equal(BindingRole.Input, aRow.Role);
         Assert.Equal("Sheet1!A1", aRow.Rhs);
 
@@ -322,11 +322,11 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("Sheet2!C1"), source)!;
 
-        var bRow = result.Bindings.Single(b => b.CellRef.A1Address == "B1");
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B1");
         Assert.Equal(BindingRole.Step, bRow.Role);
         // The step's RHS uses the leaf binding name, not the cross-sheet
         // form `Sheet1!A1` it had in the source formula.
-        var aRow = result.Bindings.Single(b => b.CellRef.A1Address == "A1");
+        var aRow = result.Bindings.Single(b => b.Source.A1Address == "A1");
         Assert.Equal($"{aRow.Name}*2", bRow.Rhs);
 
         var parsed = LetParser.Parse(result.SynthesisedLet);
@@ -342,8 +342,8 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("Sheet2!B1"), source)!;
 
-        var aRow = result.Bindings.Single(b => b.CellRef.A1Address == "A1");
-        Assert.Equal("My Sheet", aRow.CellRef.Sheet);
+        var aRow = result.Bindings.Single(b => b.Source.A1Address == "A1");
+        Assert.Equal("My Sheet", aRow.Source.Sheet);
         Assert.Equal("'My Sheet'!A1", aRow.Rhs);
 
         // Round-trips through LetParser despite the spaced sheet name —
@@ -364,7 +364,7 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("Sheet1!B1"), source)!;
 
-        var ext = result.Bindings.Single(b => b.CellRef.IsExternal);
+        var ext = result.Bindings.Single(b => b.Source.IsExternal);
         Assert.Equal(BindingRole.Input, ext.Role);
         Assert.Equal("[Other.xlsx]Sheet1!A1", ext.Rhs);
 
@@ -383,7 +383,7 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("Sheet1!B1"), source)!;
 
-        var ext = result.Bindings.Single(b => b.CellRef.IsExternal);
+        var ext = result.Bindings.Single(b => b.Source.IsExternal);
         Assert.Equal("'[Other.xlsx]My Sheet'!A1", ext.Rhs);
     }
 
@@ -407,14 +407,180 @@ public class GatherEngineTests
 
         var result = GatherEngine.Gather(source.Ref("C4"), source)!;
 
-        Assert.Equal("sales", result.Bindings.Single(b => b.CellRef.A1Address == "B1").Name);
-        Assert.Equal("sales_2", result.Bindings.Single(b => b.CellRef.A1Address == "B2").Name);
-        Assert.Equal("taxRate", result.Bindings.Single(b => b.CellRef.A1Address == "B3").Name);
-        Assert.Equal("total", result.Bindings.Single(b => b.CellRef.A1Address == "B4").Name);
+        Assert.Equal("sales", result.Bindings.Single(b => b.Source.A1Address == "B1").Name);
+        Assert.Equal("sales_2", result.Bindings.Single(b => b.Source.A1Address == "B2").Name);
+        Assert.Equal("taxRate", result.Bindings.Single(b => b.Source.A1Address == "B3").Name);
+        Assert.Equal("total", result.Bindings.Single(b => b.Source.A1Address == "B4").Name);
 
         // Sanity: synthesised LET round-trips and the body uses the step
         // binding name rather than the cell ref.
         var parsed = LetParser.Parse(result.SynthesisedLet);
         Assert.Equal("total+1", parsed.Body);
+    }
+
+    [Fact]
+    public void Gather_RangeRef_PromotedToSingleInputBinding()
+    {
+        // PR 4 acceptance: =SUM(A1:A3) with A1/A2/A3 having formulas →
+        // range A1:A3 becomes the single binding; A1/A2/A3 are NOT
+        // walked (only the range references them) so they don't appear
+        // as separate bindings.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=RAND()")
+            .WithFormula("A2", "=RAND()")
+            .WithFormula("A3", "=RAND()")
+            .WithFormula("B1", "=SUM(A1:A3)");
+
+        var result = GatherEngine.Gather(source.Ref("B1"), source)!;
+
+        Assert.Single(result.Bindings);
+        var rangeRow = result.Bindings[0];
+        Assert.Equal(BindingRole.Input, rangeRow.Role);
+        Assert.True(rangeRow.Source.IsRange);
+        Assert.Equal("A1:A3", rangeRow.Rhs);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Single(parsed.Bindings);
+        Assert.Equal("A1:A3", parsed.Bindings[0].RhsText);
+        Assert.Equal($"SUM({rangeRow.Name})", parsed.Body);
+    }
+
+    [Fact]
+    public void Gather_RangeAndIndividualCell_BothBecomeBindings()
+    {
+        // PR 4 acceptance: =SUM(A1:A3) + A4 walks A4 separately while
+        // still promoting the range. A4 lands as its own input binding;
+        // the range stays as a single leaf input.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=SUM(A1:A3) + A4");
+
+        var result = GatherEngine.Gather(source.Ref("B1"), source)!;
+
+        Assert.Equal(2, result.Bindings.Count);
+        var rangeRow = result.Bindings.Single(b => b.Source.IsRange);
+        var a4Row = result.Bindings.Single(b => !b.Source.IsRange);
+        Assert.Equal(BindingRole.Input, rangeRow.Role);
+        Assert.Equal("A1:A3", rangeRow.Rhs);
+        Assert.Equal(BindingRole.Input, a4Row.Role);
+        Assert.Equal("A4", a4Row.Source.A1Address);
+        Assert.Equal("A4", a4Row.Rhs);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal(2, parsed.Bindings.Count);
+        // Body refers to the bindings, not the source refs. Whitespace
+        // between operands is preserved by the rewriter.
+        Assert.Equal($"SUM({rangeRow.Name}) + {a4Row.Name}", parsed.Body);
+    }
+
+    [Fact]
+    public void Gather_RangeFullCoverage_DropsEveryCoveredCell()
+    {
+        // Full coverage: A1/A2/A3 are each in-scope (referenced directly
+        // by B1) AND covered by the sink's range. All three drop; B1
+        // loses every precedent and reverts to an input.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1+A2+A3")
+            .WithFormula("C1", "=SUM(A1:A3) + B1");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source)!;
+
+        var addresses = result.Bindings.Select(b => b.Source.A1Address).ToList();
+        Assert.DoesNotContain("A1", addresses);
+        Assert.DoesNotContain("A2", addresses);
+        Assert.DoesNotContain("A3", addresses);
+        Assert.Contains("A1:A3", addresses);
+        Assert.Contains("B1", addresses);
+
+        var b1Row = result.Bindings.Single(b => b.Source.A1Address == "B1");
+        Assert.Equal(BindingRole.Input, b1Row.Role);
+    }
+
+    [Fact]
+    public void Gather_RangePartialCoverage_DropsCoveredCellFromBindings()
+    {
+        // Partial coverage: B1 references A2 directly (so A2 is in-scope),
+        // and the sink references A1:A3 (which covers A2). The covered A2
+        // must drop from the bindings; B1 keeps its place but loses its
+        // only in-scope precedent and reverts to an input.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A2*5")
+            .WithFormula("C1", "=SUM(A1:A3) + B1");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source)!;
+
+        var addresses = result.Bindings.Select(b => b.Source.A1Address).ToList();
+        Assert.DoesNotContain("A2", addresses);
+        Assert.Contains("A1:A3", addresses);
+        Assert.Contains("B1", addresses);
+
+        var rangeRow = result.Bindings.Single(b => b.Source.IsRange);
+        Assert.Equal(BindingRole.Input, rangeRow.Role);
+
+        var b1Row = result.Bindings.Single(b => !b.Source.IsRange);
+        // B1's only precedent (A2) was dropped, so it has no in-scope
+        // precedents and reverts to an input bound to its cell address.
+        Assert.Equal(BindingRole.Input, b1Row.Role);
+        Assert.Equal("B1", b1Row.Rhs);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal($"SUM({rangeRow.Name}) + {b1Row.Name}", parsed.Body);
+    }
+
+    [Fact]
+    public void Gather_MultiRowRange_RecognisedAsSingleBinding()
+    {
+        // Two-dimensional range A1:C3 still promotes to one binding, with
+        // the literal range text in the RHS so Excel evaluates it as the
+        // same array.
+        var source = new StubCellSource()
+            .WithFormula("D1", "=SUM(A1:C3)");
+
+        var result = GatherEngine.Gather(source.Ref("D1"), source)!;
+
+        Assert.Single(result.Bindings);
+        Assert.True(result.Bindings[0].Source.IsRange);
+        Assert.Equal("A1:C3", result.Bindings[0].Rhs);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal("A1:C3", parsed.Bindings[0].RhsText);
+    }
+
+    [Fact]
+    public void Gather_CrossSheetRange_RhsKeepsSheetQualifier()
+    {
+        // Sheet2!B1 = =SUM(Sheet1!A1:A3) — the binding RHS must keep the
+        // sheet qualifier so the LET works when written into Sheet2.
+        var source = new StubCellSource("Sheet2")
+            .WithFormula("Sheet2!B1", "=SUM(Sheet1!A1:A3)");
+
+        var result = GatherEngine.Gather(source.Ref("Sheet2!B1"), source)!;
+
+        Assert.Single(result.Bindings);
+        var rangeRow = result.Bindings[0];
+        Assert.True(rangeRow.Source.IsRange);
+        Assert.Equal("Sheet1", rangeRow.Source.Sheet);
+        Assert.Equal("Sheet1!A1:A3", rangeRow.Rhs);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal("Sheet1!A1:A3", parsed.Bindings[0].RhsText);
+        Assert.Equal($"SUM({rangeRow.Name})", parsed.Body);
+    }
+
+    [Fact]
+    public void Gather_RangeWithLabelAbove_NamedFromHeader()
+    {
+        // The range's label is the cell directly above its top-left
+        // corner — common in real spreadsheets where the header sits one
+        // row above the data.
+        var source = new StubCellSource()
+            .WithLabel("A1", "Numbers")
+            .WithFormula("B1", "=SUM(A2:A4)");
+
+        var result = GatherEngine.Gather(source.Ref("B1"), source)!;
+
+        Assert.Single(result.Bindings);
+        var row = result.Bindings[0];
+        Assert.True(row.Source.IsRange);
+        Assert.Equal("numbers", row.Name);
     }
 }

--- a/addin/lambda-boss/CellGraphWalker.cs
+++ b/addin/lambda-boss/CellGraphWalker.cs
@@ -4,12 +4,13 @@ namespace LambdaBoss;
 ///     Walks the precedent graph rooted at a sink cell. Discovery uses
 ///     <see cref="ICellSource" /> for cell-shape lookups and
 ///     <see cref="CellRefExtractor" /> to find precedents inside formulas.
-///     PR 3 widens scope to all sheets in the active workbook: cross-sheet
-///     refs are walked normally; external-workbook refs surface as leaves
-///     because <see cref="ICellSource.GetFormula" /> returns null for them.
-///     The returned cells are in topological order (precedents before
-///     dependents) with the sink as the final entry. PR 7 layers cycle
-///     detection on top.
+///     PR 4 introduces range-aware walking: cell precedents recurse as
+///     before, range precedents are recorded on the cell but not expanded
+///     into their constituent cells. The engine post-processes ranges to
+///     promote each unique range to a leaf input and drop walked cells that
+///     fall inside any promoted range. The returned cells are in topological
+///     order (precedents before dependents) with the sink as the final
+///     entry. PR 7 layers cycle detection on top.
 /// </summary>
 internal static class CellGraphWalker
 {
@@ -31,10 +32,10 @@ internal static class CellGraphWalker
             var cellAbove = source.GetCellAboveText(cell);
             var cellLeft = source.GetCellLeftText(cell);
 
-            IReadOnlyList<CellRef> precedents;
+            IReadOnlyList<FormulaRef> precedents;
             if (formula == null)
             {
-                precedents = Array.Empty<CellRef>();
+                precedents = Array.Empty<FormulaRef>();
             }
             else
             {
@@ -49,8 +50,15 @@ internal static class CellGraphWalker
 
             foreach (var p in precedents)
             {
-                if (!byRef.ContainsKey(p))
-                    stack.Push(p);
+                // Range refs aren't expanded into their constituent cells —
+                // they're an opaque "block" precedent that the engine
+                // promotes to a single leaf input. Cells covered by the
+                // range that happen to be reached via OTHER precedents are
+                // walked normally and dropped post-walk.
+                if (p.IsRange)
+                    continue;
+                if (!byRef.ContainsKey(p.Start))
+                    stack.Push(p.Start);
             }
         }
 
@@ -76,7 +84,10 @@ internal static class CellGraphWalker
             if (nextChild < node.Precedents.Count)
             {
                 stack.Push((cell, nextChild + 1));
-                var child = node.Precedents[nextChild];
+                var pre = node.Precedents[nextChild];
+                if (pre.IsRange)
+                    continue;
+                var child = pre.Start;
                 if (!visited.Contains(child) && byRef.ContainsKey(child))
                     stack.Push((child, 0));
             }

--- a/addin/lambda-boss/CellRefExtractor.cs
+++ b/addin/lambda-boss/CellRefExtractor.cs
@@ -3,23 +3,26 @@ using System.Text.RegularExpressions;
 namespace LambdaBoss;
 
 /// <summary>
-///     Pulls A1-style cell references out of a formula string. PR 3 scope:
-///     bare refs (<c>A1</c> with optional dollar anchors), sheet-qualified
-///     refs in both unquoted (<c>Sheet1!A1</c>) and quoted
-///     (<c>'My Sheet'!A1</c>) forms, and external-workbook refs in the open
-///     (<c>[Wb.xlsx]Sheet1!A1</c>) and quoted (<c>'[Wb.xlsx]My Sheet'!A1</c>,
-///     <c>'C:\path\[Wb.xlsx]Sheet'!A1</c>) forms. Range refs and spill refs
-///     are still recognised only enough to be excluded — they're handled by
-///     PR 4/5. String literals are skipped wholesale.
+///     Pulls cell-shaped references out of a formula string. Recognises
+///     single cells (<c>A1</c> with optional dollar anchors), ranges
+///     (<c>A1:A3</c>), and any of those forms with a sheet qualifier —
+///     unquoted (<c>Sheet1!A1</c>), quoted (<c>'My Sheet'!A1</c>), or
+///     external workbook (<c>[Wb.xlsx]Sheet1!A1</c>, <c>'[Wb.xlsx]My Sheet'!A1</c>,
+///     <c>'C:\path\[Wb.xlsx]Sheet'!A1</c>). PR 4 promotes ranges to first-
+///     class refs; spill refs are still recognised only enough to be
+///     excluded — they're handled by PR 5. String literals are skipped
+///     wholesale.
 /// </summary>
 internal static class CellRefExtractor
 {
     // The single combined pattern walks each non-string segment looking for
     // an optional sheet qualifier (in one of four forms) followed by an A1
-    // cell address. The bare alternative is a zero-width assertion that
-    // guards bare-cell matches against being part of a larger token (mid-
-    // identifier, after '!' / ':', etc.) — without it, the regex would also
-    // match the row digits at the tail of a sheet name.
+    // cell address with an optional ":cell" tail to match a range. The
+    // bare alternative is a zero-width assertion that guards bare-cell
+    // matches against being part of a larger token (mid-identifier, after
+    // '!' / ':', etc.) — without it, the regex would also match the row
+    // digits at the tail of a sheet name. The trailing range tail is
+    // greedy by default, so `A1:A3` matches as one ref rather than two.
     private static readonly Regex CellRefPattern = new(
         @"(?:" +
             // 'C:\path\[Wb]Sheet'!  or  '[Wb]My Sheet'!  — quoted form
@@ -39,27 +42,33 @@ internal static class CellRefExtractor
             @"(?<![A-Za-z0-9_.!:'\]])" +
         @")" +
         @"\$?(?<col>[A-Za-z]{1,3})\$?(?<row>[0-9]+)" +
+        // Optional range tail. Excel ranges always share both endpoints'
+        // sheet, so we capture only the cell part on End — the qualifier
+        // from Start is reused when re-emitting.
+        @"(?::\$?(?<col2>[A-Za-z]{1,3})\$?(?<row2>[0-9]+))?" +
         // Trailing guards: not a longer identifier, not a sheet qualifier
-        // ('!' for the next ref's sheet name), not a range tail (':') or a
-        // function-call tail ('('), not a spill marker ('#' — PR 5).
+        // ('!' for the next ref's sheet name), not a further range tail
+        // (':') or a function-call tail ('('), not a spill marker ('#' —
+        // PR 5).
         @"(?![A-Za-z0-9_.!:(#])",
         RegexOptions.CultureInvariant);
 
     /// <summary>
-    ///     Returns the unique cell refs found in <paramref name="formula" />
-    ///     in order of first appearance. Unqualified refs use
+    ///     Returns the unique formula refs found in <paramref name="formula" />
+    ///     in order of first appearance. Single cells and ranges arrive as
+    ///     distinct <see cref="FormulaRef" /> values. Unqualified refs use
     ///     <paramref name="defaultSheet" /> as the host sheet (the formula's
     ///     own sheet, NOT the sink's sheet — the walker recurses into other
     ///     sheets). Sheet-qualified refs use the qualifier as written;
     ///     external-workbook refs carry the workbook name through.
     /// </summary>
-    public static IReadOnlyList<CellRef> Extract(string formula, string defaultSheet)
+    public static IReadOnlyList<FormulaRef> Extract(string formula, string defaultSheet)
     {
         if (string.IsNullOrEmpty(formula))
-            return Array.Empty<CellRef>();
+            return Array.Empty<FormulaRef>();
 
-        var seen = new HashSet<CellRef>();
-        var refs = new List<CellRef>();
+        var seen = new HashSet<FormulaRef>();
+        var refs = new List<FormulaRef>();
 
         var i = 0;
         while (i < formula.Length)
@@ -80,9 +89,9 @@ internal static class CellRefExtractor
 
             foreach (Match m in CellRefPattern.Matches(segment))
             {
-                var cellRef = BuildCellRef(m, defaultSheet);
-                if (seen.Add(cellRef))
-                    refs.Add(cellRef);
+                var formulaRef = BuildFormulaRef(m, defaultSheet);
+                if (seen.Add(formulaRef))
+                    refs.Add(formulaRef);
             }
 
             i = segEnd;
@@ -92,16 +101,19 @@ internal static class CellRefExtractor
     }
 
     /// <summary>
-    ///     Rewrites every in-scope cell ref in <paramref name="formula" />
-    ///     to the binding name supplied by <paramref name="lookup" />. Refs
-    ///     not in <paramref name="lookup" /> (out-of-scope, named ranges,
-    ///     LAMBDA names, function names, etc.) are left untouched. The
-    ///     default-sheet rule matches <see cref="Extract" />.
+    ///     Rewrites every in-scope ref in <paramref name="formula" /> to the
+    ///     binding name supplied by <paramref name="lookup" />. Refs not in
+    ///     <paramref name="lookup" /> (out-of-scope cells, named ranges,
+    ///     LAMBDA names, function names, etc.) are left untouched. Ranges
+    ///     are matched as a single token, so a range present in the lookup
+    ///     collapses to one binding name even when its endpoints alone are
+    ///     also bound elsewhere. The default-sheet rule matches
+    ///     <see cref="Extract" />.
     /// </summary>
     public static string Rewrite(
         string formula,
         string defaultSheet,
-        IReadOnlyDictionary<CellRef, string> lookup)
+        IReadOnlyDictionary<FormulaRef, string> lookup)
     {
         if (string.IsNullOrEmpty(formula) || lookup.Count == 0)
             return formula;
@@ -123,13 +135,27 @@ internal static class CellRefExtractor
             var segment = formula[i..segEnd];
             var rewritten = CellRefPattern.Replace(segment, m =>
             {
-                var key = BuildCellRef(m, defaultSheet);
+                var key = BuildFormulaRef(m, defaultSheet);
                 return lookup.TryGetValue(key, out var name) ? name : m.Value;
             });
             result.Append(rewritten);
             i = segEnd;
         }
         return result.ToString();
+    }
+
+    private static FormulaRef BuildFormulaRef(Match m, string defaultSheet)
+    {
+        var start = BuildCellRef(m, defaultSheet);
+        if (!m.Groups["col2"].Success)
+            return new FormulaRef(start);
+
+        // Range tail: End shares the sheet/workbook of Start (Excel
+        // disallows cross-sheet ranges), so we don't reparse the qualifier.
+        var endCol = CellRef.LettersToColumn(m.Groups["col2"].Value);
+        var endRow = int.Parse(m.Groups["row2"].Value);
+        var end = new CellRef(start.Sheet, endCol, endRow, start.ExternalWorkbook);
+        return new FormulaRef(start, end);
     }
 
     private static CellRef BuildCellRef(Match m, string defaultSheet)

--- a/addin/lambda-boss/GatherEngine.cs
+++ b/addin/lambda-boss/GatherEngine.cs
@@ -4,12 +4,13 @@ namespace LambdaBoss;
 
 /// <summary>
 ///     The top-level Gather entry point. Walks the precedent graph, names
-///     each cell, classifies it as input or step, rewrites step formulas
-///     to refer to bindings, and emits a single <c>=LET(...)</c> formula
-///     equivalent to the sink-rooted calculation graph. PR 3 widens scope
-///     to cross-sheet and external-workbook refs: cross-sheet inputs render
-///     their RHS as a sheet-qualified address; external refs render their
-///     workbook tag and never recurse.
+///     each cell and range, classifies each as input or step, rewrites
+///     step formulas to refer to bindings, and emits a single
+///     <c>=LET(...)</c> formula equivalent to the sink-rooted calculation
+///     graph. PR 4 promotes range refs to single-input bindings: each
+///     unique range encountered while walking becomes one leaf input, and
+///     any walked cell that falls inside a promoted range is dropped from
+///     the bindings list.
 /// </summary>
 public static class GatherEngine
 {
@@ -28,21 +29,65 @@ public static class GatherEngine
             return null;
 
         var walked = CellGraphWalker.Walk(sink, source);
-        var inScope = walked.Select(w => w.Ref).ToHashSet();
 
-        // Name every cell except the sink. Sink contributes the LET body.
-        var nonSink = walked.Where(w => !w.Ref.Equals(sink)).ToList();
+        // Collect unique range refs encountered anywhere in the walk. Order
+        // is by first-encountered; that becomes the binding order for
+        // ranges (which always sort before cell bindings).
+        var ranges = new List<FormulaRef>();
+        var rangeSet = new HashSet<FormulaRef>();
+        foreach (var cell in walked)
+        {
+            foreach (var p in cell.Precedents)
+            {
+                if (p.IsRange && rangeSet.Add(p))
+                    ranges.Add(p);
+            }
+        }
 
-        var nameByRef = AssignNames(nonSink);
+        // Cells covered by any range are dropped from the bindings list,
+        // even if they would otherwise have been steps. The sink itself is
+        // never dropped — it's the LET body, not a binding.
+        var coveredByRange = new HashSet<CellRef>();
+        foreach (var r in ranges)
+        {
+            foreach (var cell in walked)
+            {
+                if (cell.Ref.Equals(sink))
+                    continue;
+                if (r.Covers(cell.Ref))
+                    coveredByRange.Add(cell.Ref);
+            }
+        }
 
+        var nonSink = walked
+            .Where(w => !w.Ref.Equals(sink) && !coveredByRange.Contains(w.Ref))
+            .ToList();
+
+        // Names: ranges first (in encounter order), then cells (in topo
+        // order). This keeps inputs grouped at the top of the LET — ranges
+        // are always inputs — which matches the spec's dialog ordering.
+        var nameByRef = AssignNames(ranges, nonSink, source);
+
+        // Build the in-scope set used to classify each cell as input vs
+        // step. A cell is a step iff at least one of its precedents has a
+        // binding name. Range precedents always have a binding (they're
+        // promoted leaves), so a cell whose only in-scope precedent is a
+        // range becomes a step whose RHS rewrites the range to its name.
         var bindings = new List<BindingRow>();
-        var inputs = new List<BindingRow>();
-        var steps = new List<BindingRow>();
 
+        foreach (var range in ranges)
+        {
+            var name = nameByRef[range];
+            var rhs = range.DisplayAddress(source.SinkSheet);
+            bindings.Add(new BindingRow(range, BindingRole.Input, name, rhs));
+        }
+
+        var stepRows = new List<BindingRow>();
         foreach (var cell in nonSink)
         {
-            var name = nameByRef[cell.Ref];
-            var role = ClassifyRole(cell, inScope);
+            var cellFormulaRef = new FormulaRef(cell.Ref);
+            var name = nameByRef[cellFormulaRef];
+            var role = ClassifyRole(cell, nameByRef);
             string rhs;
             if (role == BindingRole.Input)
             {
@@ -55,21 +100,21 @@ public static class GatherEngine
             {
                 // The step's formula was extracted using its own sheet as
                 // the default; the rewrite needs that same default so refs
-                // resolve to the same CellRef keys the walker built.
+                // resolve to the same FormulaRef keys the walker built.
                 rhs = CellRefExtractor.Rewrite(StripLeadingEquals(cell.Formula!), cell.Ref.Sheet, nameByRef);
             }
 
-            var row = new BindingRow(cell.Ref, role, name, rhs);
+            var row = new BindingRow(cellFormulaRef, role, name, rhs);
             if (role == BindingRole.Input)
-                inputs.Add(row);
+                bindings.Add(row);
             else
-                steps.Add(row);
+                stepRows.Add(row);
         }
 
-        // Inputs first, then steps in topo order — matches the spec's
-        // dialog ordering and gives a natural read for the synthesised LET.
-        bindings.AddRange(inputs);
-        bindings.AddRange(steps);
+        // Range and cell inputs first, then steps in topo order — matches
+        // the spec's dialog ordering and gives a natural read for the
+        // synthesised LET.
+        bindings.AddRange(stepRows);
 
         var bodyText = CellRefExtractor.Rewrite(
             StripLeadingEquals(sinkFormula), source.SinkSheet, nameByRef);
@@ -86,67 +131,99 @@ public static class GatherEngine
     }
 
     /// <summary>
-    ///     Picks a binding name for each cell in topological order. Tries
-    ///     cell-above first, then cell-left, both routed through
-    ///     <see cref="LetNameSanitizer" />. Falls back to <c>step_N</c> only
-    ///     when both neighbours yield nothing usable. Final collisions —
-    ///     two cells producing the same name — are resolved by suffixing
-    ///     <c>_2</c>, <c>_3</c>, … in topological order.
+    ///     Picks a binding name for each range and each non-sink cell.
+    ///     Ranges name first (their topological position is "before any
+    ///     cell that references them"). Each ref tries cell-above first,
+    ///     then cell-left, both routed through <see cref="LetNameSanitizer" />.
+    ///     Falls back to <c>step_N</c> only when both neighbours yield
+    ///     nothing usable. Final collisions — two refs producing the same
+    ///     name — are resolved by suffixing <c>_2</c>, <c>_3</c>, … in
+    ///     binding order.
     /// </summary>
-    private static Dictionary<CellRef, string> AssignNames(IReadOnlyList<WalkedCell> nonSink)
+    private static Dictionary<FormulaRef, string> AssignNames(
+        IReadOnlyList<FormulaRef> ranges,
+        IReadOnlyList<WalkedCell> nonSink,
+        ICellSource source)
     {
-        var nameByRef = new Dictionary<CellRef, string>();
+        var nameByRef = new Dictionary<FormulaRef, string>();
         var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var fallbackCounter = 0;
+
+        foreach (var range in ranges)
+        {
+            // Use the range Start cell's neighbours for the label hint —
+            // ranges typically have a header above their top-left corner.
+            var aboveText = range.IsExternal ? null : SafeAbove(source, range.Start);
+            var leftText = range.IsExternal ? null : SafeLeft(source, range.Start);
+            var baseName = LetNameSanitizer.Sanitize(aboveText)
+                           ?? LetNameSanitizer.Sanitize(leftText);
+            nameByRef[range] = AssignOne(baseName, used, ref fallbackCounter);
+        }
 
         foreach (var cell in nonSink)
         {
             var baseName = LetNameSanitizer.Sanitize(cell.CellAboveText)
                            ?? LetNameSanitizer.Sanitize(cell.CellLeftText);
-
-            string finalName;
-            if (baseName == null)
-            {
-                // No usable label — burn through step_N until we find a
-                // number that hasn't already been used by a sanitised label.
-                do
-                {
-                    fallbackCounter++;
-                    finalName = $"step_{fallbackCounter}";
-                } while (used.Contains(finalName));
-            }
-            else
-            {
-                finalName = baseName;
-                var suffix = 2;
-                while (used.Contains(finalName))
-                {
-                    finalName = $"{baseName}_{suffix}";
-                    suffix++;
-                }
-            }
-
-            used.Add(finalName);
-            nameByRef[cell.Ref] = finalName;
+            nameByRef[new FormulaRef(cell.Ref)] = AssignOne(baseName, used, ref fallbackCounter);
         }
 
         return nameByRef;
     }
 
-    private static BindingRole ClassifyRole(WalkedCell cell, HashSet<CellRef> inScope)
+    private static string AssignOne(string? baseName, HashSet<string> used, ref int fallbackCounter)
+    {
+        string finalName;
+        if (baseName == null)
+        {
+            // No usable label — burn through step_N until we find a
+            // number that hasn't already been used by a sanitised label.
+            do
+            {
+                fallbackCounter++;
+                finalName = $"step_{fallbackCounter}";
+            } while (used.Contains(finalName));
+        }
+        else
+        {
+            finalName = baseName;
+            var suffix = 2;
+            while (used.Contains(finalName))
+            {
+                finalName = $"{baseName}_{suffix}";
+                suffix++;
+            }
+        }
+
+        used.Add(finalName);
+        return finalName;
+    }
+
+    // Range-label probes share the cell-source contract used for cell-
+    // derived names but skip externals (their neighbour cells aren't
+    // reachable via the live workbook).
+    private static string? SafeAbove(ICellSource source, CellRef cell)
+    {
+        return source.GetCellAboveText(cell);
+    }
+
+    private static string? SafeLeft(ICellSource source, CellRef cell)
+    {
+        return source.GetCellLeftText(cell);
+    }
+
+    private static BindingRole ClassifyRole(WalkedCell cell, IReadOnlyDictionary<FormulaRef, string> nameByRef)
     {
         // External refs and missing-sheet refs surface here as null-formula
         // cells (the source can't reach them) and so naturally classify as
         // input — exactly what we want.
         if (cell.Formula == null)
             return BindingRole.Input;
-        // A formula cell whose precedents are all out of scope (none of the
-        // refs in its formula are themselves walked) is treated as an
-        // input — its RHS is the cell ref. That preserves the spec's "the
-        // LET binds the cell, not the formula" default; promotion to step
-        // is a follow-up in PR 11.
-        var hasInScopePrecedent = cell.Precedents.Any(inScope.Contains);
-        return hasInScopePrecedent ? BindingRole.Step : BindingRole.Input;
+        // A formula cell is a step iff at least one precedent has a binding
+        // (cell-binding for in-scope cells, range-binding for promoted
+        // ranges). Cells whose precedents were all dropped (covered by a
+        // range, out of scope, etc.) revert to inputs whose RHS is the
+        // cell address — promotion to step is a follow-up in PR 11.
+        return cell.Precedents.Any(nameByRef.ContainsKey) ? BindingRole.Step : BindingRole.Input;
     }
 
     private static string StripLeadingEquals(string formula)

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -125,27 +125,86 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
 }
 
 /// <summary>
+///     A reference appearing inside a formula — either a single cell
+///     (<see cref="End" /> null) or a contiguous range (<see cref="End" />
+///     set, on the same sheet as <see cref="Start" />). The walker tracks
+///     range refs without recursing into their constituent cells; the engine
+///     promotes each unique range to a single leaf input and drops walked
+///     cells covered by any promoted range. Equality follows
+///     <see cref="CellRef" />'s case-insensitive sheet rule.
+/// </summary>
+public sealed record FormulaRef(CellRef Start, CellRef? End = null)
+{
+    public bool IsRange => End is not null;
+
+    /// <summary>
+    ///     The convenience accessor most callers want; for ranges it returns
+    ///     <c>Start:End</c> so the value still uniquely identifies the ref.
+    /// </summary>
+    public string A1Address => IsRange ? $"{Start.A1Address}:{End!.A1Address}" : Start.A1Address;
+
+    /// <summary>The host sheet (always shared between Start and End for ranges).</summary>
+    public string Sheet => Start.Sheet;
+
+    public bool IsExternal => Start.IsExternal;
+
+    public string? ExternalWorkbook => Start.ExternalWorkbook;
+
+    /// <summary>
+    ///     True if this range covers <paramref name="cell" /> — used by the
+    ///     engine to drop walked cells that fall inside a promoted range.
+    ///     Always false for single-cell refs.
+    /// </summary>
+    public bool Covers(CellRef cell)
+    {
+        if (!IsRange)
+            return false;
+        if (!string.Equals(Start.Sheet, cell.Sheet, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!string.Equals(Start.ExternalWorkbook, cell.ExternalWorkbook, StringComparison.OrdinalIgnoreCase))
+            return false;
+        return cell.Column >= Start.Column && cell.Column <= End!.Column
+                                           && cell.Row >= Start.Row && cell.Row <= End.Row;
+    }
+
+    /// <summary>
+    ///     The form to emit as a LET binding RHS when the LET lives on
+    ///     <paramref name="hostSheet" />. For ranges, the sheet qualifier is
+    ///     emitted once on Start; the End cell's address is rendered bare.
+    /// </summary>
+    public string DisplayAddress(string hostSheet)
+    {
+        if (!IsRange)
+            return Start.DisplayAddress(hostSheet);
+        return $"{Start.DisplayAddress(hostSheet)}:{End!.A1Address}";
+    }
+}
+
+/// <summary>
 ///     A cell discovered by <see cref="CellGraphWalker" />. The
 ///     <see cref="Formula" /> is null when the cell holds a literal value or
 ///     is unreachable (external workbook ref, missing sheet) — both treated
 ///     as leaf inputs. <see cref="CellAboveText" /> and
 ///     <see cref="CellLeftText" /> are the text of the cells directly above
 ///     and to the left on the cell's own sheet, null when out of range,
-///     empty, or non-string.
+///     empty, or non-string. <see cref="Precedents" /> mixes single-cell and
+///     range refs; the walker only recurses into single-cell precedents.
 /// </summary>
 public sealed record WalkedCell(
     CellRef Ref,
     string? Formula,
     string? CellAboveText,
     string? CellLeftText,
-    IReadOnlyList<CellRef> Precedents);
+    IReadOnlyList<FormulaRef> Precedents);
 
 /// <summary>
 ///     A finalised LET binding row in PR 1's read-only dialog. PR 2 onwards
-///     will allow the user to edit <see cref="Name" /> and toggle role.
+///     will allow the user to edit <see cref="Name" /> and toggle role. The
+///     <see cref="Source" /> is a single cell for cell-derived bindings and
+///     a range for range-promoted leaves (PR 4).
 /// </summary>
 public sealed record BindingRow(
-    CellRef CellRef,
+    FormulaRef Source,
     BindingRole Role,
     string Name,
     string Rhs);

--- a/addin/lambda-boss/UI/GatherWindow.xaml.cs
+++ b/addin/lambda-boss/UI/GatherWindow.xaml.cs
@@ -25,7 +25,7 @@ public partial class GatherWindow
         BindingsList.ItemsSource = result.Bindings
             .Select(b => new GatherRowDisplay
             {
-                Address = b.CellRef.A1Address,
+                Address = b.Source.A1Address,
                 Role = b.Role == BindingRole.Input ? "input" : "step",
                 Name = b.Name,
                 Rhs = b.Rhs,


### PR DESCRIPTION
Closes #134. Part of #130.

## Summary

- Each unique range encountered in any walked cell's formula becomes a single leaf-input binding (RHS = the literal range text).
- Walked cells covered by a promoted range drop from the binding list — even if they would otherwise have been steps — so a range that overlaps individual refs collapses cleanly.
- Cells that lose every in-scope precedent to the range drop revert to inputs (their RHS becomes the cell address); promote-to-step is still PR 11.

## Design

Introduces a `FormulaRef` record that unifies single-cell and range references. The walker records range precedents on each `WalkedCell` but never recurses into a range's constituent cells. The engine post-processes ranges: builds one binding per unique range (named from the cell above the top-left corner, then cell-left, then `step_N`), drops covered cells, and rewrites step bodies via the same `CellRefExtractor.Rewrite` path used for single cells.

The regex change is one optional `:cell` tail on the existing pattern; nothing else in the matcher moved. Range endpoints share the Start ref's sheet/workbook qualifier per Excel's single-sheet-range rule.

## Test plan

- [x] Build clean (0 errors).
- [x] All 532 unit tests pass.
- [x] New extractor tests cover bare/dollar-anchored/multi-row/cross-sheet/quoted ranges, and rewrite of mixed range + cell lookups.
- [x] New walker tests cover range-only precedents (no recursion) and range + individual ref (individual cell walked).
- [x] New engine tests cover `=SUM(A1:A3)` (full coverage with all-formula cells), `=SUM(A1:A3) + A4` (range + individual), full coverage drop, partial coverage drop, multi-row range, cross-sheet range, range with header label.

## Manual Excel test

1. A1=`=RAND()`, A2=`=RAND()`, A3=`=RAND()`.
2. B1=`=SUM(A1:A3)` (sink).
3. Run `/Gather` with B1 selected.
4. Confirm dialog has one binding (`A1:A3` → `step_1` or label-derived name); A1/A2/A3 do NOT appear as separate bindings.
5. Save. Confirm B1 contains `=LET(step_1, A1:A3, SUM(step_1))` and evaluates to the same value.