### PR TITLE
Gather: cycle + multi-sink rejection (PR 7 of 12)

### DIFF
--- a/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
+++ b/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
@@ -12,7 +12,7 @@ public class CellGraphWalkerTests
             .WithFormula("B1", "=A1*2")
             .WithFormula("C1", "=B1+1");
 
-        var walked = CellGraphWalker.Walk(source.Ref("C1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("C1"), source).Cells!;
         var order = walked.Select(w => w.Ref.A1Address).ToList();
 
         Assert.Equal(new[] { "A1", "B1", "C1" }, order);
@@ -24,7 +24,7 @@ public class CellGraphWalkerTests
         var source = new StubCellSource()
             .WithFormula("B1", "=A1*2");
 
-        var walked = CellGraphWalker.Walk(source.Ref("B1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("B1"), source).Cells!;
 
         var leaf = walked.Single(w => w.Ref.A1Address == "A1");
         Assert.Null(leaf.Formula);
@@ -38,7 +38,7 @@ public class CellGraphWalkerTests
         var source = new StubCellSource()
             .WithFormula("C1", "=A1+B1");
 
-        var walked = CellGraphWalker.Walk(source.Ref("C1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("C1"), source).Cells!;
         var addresses = walked.Select(w => w.Ref.A1Address).ToHashSet();
 
         Assert.Contains("A1", addresses);
@@ -57,7 +57,7 @@ public class CellGraphWalkerTests
             .WithFormula("C1", "=A1*2")
             .WithFormula("D1", "=B1+C1");
 
-        var walked = CellGraphWalker.Walk(source.Ref("D1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("D1"), source).Cells!;
         var addresses = walked.Select(w => w.Ref.A1Address).ToList();
 
         Assert.Equal(4, addresses.Count);
@@ -78,7 +78,7 @@ public class CellGraphWalkerTests
         // does. Walking a leaf-only sink just returns the sink as a leaf.
         var source = new StubCellSource();
 
-        var walked = CellGraphWalker.Walk(source.Ref("A1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("A1"), source).Cells!;
 
         Assert.Single(walked);
         Assert.Null(walked[0].Formula);
@@ -93,7 +93,7 @@ public class CellGraphWalkerTests
         var source = new StubCellSource("Sheet2")
             .WithFormula("Sheet2!B1", "=Sheet1!A1*2");
 
-        var walked = CellGraphWalker.Walk(source.Ref("Sheet2!B1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("Sheet2!B1"), source).Cells!;
 
         Assert.Equal(2, walked.Count);
         Assert.Equal("Sheet1", walked[0].Ref.Sheet);
@@ -112,7 +112,7 @@ public class CellGraphWalkerTests
             .WithFormula("Sheet1!B1", "=A1*2")
             .WithFormula("Sheet2!C1", "=Sheet1!B1+1");
 
-        var walked = CellGraphWalker.Walk(source.Ref("Sheet2!C1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("Sheet2!C1"), source).Cells!;
 
         var leaf = walked.Single(w => w.Ref.A1Address == "A1");
         Assert.Equal("Sheet1", leaf.Sheet());
@@ -130,7 +130,7 @@ public class CellGraphWalkerTests
         var source = new StubCellSource()
             .WithFormula("Sheet1!B1", "=[Other.xlsx]Sheet1!A1+1");
 
-        var walked = CellGraphWalker.Walk(source.Ref("Sheet1!B1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("Sheet1!B1"), source).Cells!;
 
         var external = walked.Single(w => w.Ref.IsExternal);
         Assert.Equal("Other.xlsx", external.Ref.ExternalWorkbook);
@@ -153,7 +153,7 @@ public class CellGraphWalkerTests
             .WithFormula("A3", "=RAND()")
             .WithFormula("B1", "=SUM(A1:A3)");
 
-        var walked = CellGraphWalker.Walk(source.Ref("B1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("B1"), source).Cells!;
 
         Assert.Single(walked);
         Assert.Equal("B1", walked[0].Ref.A1Address);
@@ -173,7 +173,7 @@ public class CellGraphWalkerTests
         var source = new StubCellSource()
             .WithFormula("B1", "=SUM(A1:A3) + A4");
 
-        var walked = CellGraphWalker.Walk(source.Ref("B1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("B1"), source).Cells!;
         var addresses = walked.Select(w => w.Ref.A1Address).OrderBy(a => a).ToList();
 
         Assert.Equal(new[] { "A4", "B1" }, addresses);
@@ -194,7 +194,7 @@ public class CellGraphWalkerTests
             .WithSpill("A1")
             .WithFormula("B1", "=SUM(A1#)");
 
-        var walked = CellGraphWalker.Walk(source.Ref("B1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("B1"), source).Cells!;
         var addresses = walked.Select(w => w.Ref.A1Address).ToList();
 
         Assert.Equal(new[] { "A1", "B1" }, addresses);
@@ -216,7 +216,7 @@ public class CellGraphWalkerTests
             .WithSpill("B2")
             .WithFormula("C2", "=SUM(B2#)");
 
-        var walked = CellGraphWalker.Walk(source.Ref("C2"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("C2"), source).Cells!;
         var addresses = walked.Select(w => w.Ref.A1Address).ToList();
 
         Assert.Equal(new[] { "A2", "B2", "C2" }, addresses);
@@ -233,9 +233,82 @@ public class CellGraphWalkerTests
         var source = new StubCellSource()
             .WithFormula("B1", "=A1*2");
 
-        var walked = CellGraphWalker.Walk(source.Ref("B1"), source);
+        var walked = CellGraphWalker.Walk(source.Ref("B1"), source).Cells!;
 
         Assert.All(walked, w => Assert.False(w.HasSpill));
+    }
+
+    [Fact]
+    public void Walk_TwoCycle_ReturnsCycleOutcome()
+    {
+        // PR 7: A1 = =B1+1, B1 = =A1+1 — sink A1. The walker discovers
+        // both cells and then surfaces the back-edge during topo sort
+        // instead of spinning forever in the iterative DFS.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=B1+1")
+            .WithFormula("B1", "=A1+1");
+
+        var outcome = CellGraphWalker.Walk(source.Ref("A1"), source);
+
+        Assert.True(outcome.IsCycle);
+        Assert.Null(outcome.Cells);
+        var addresses = outcome.Cycle!.Select(c => c.A1Address).ToHashSet();
+        Assert.Equal(new HashSet<string> { "A1", "B1" }, addresses);
+    }
+
+    [Fact]
+    public void Walk_ThreeCycle_ReturnsAllThreeCellsInOrder()
+    {
+        // A1 → B1 → C1 → A1 — the cycle list reads in path order from
+        // the back-edge target through to the cell that closed the loop.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=B1+1")
+            .WithFormula("B1", "=C1+1")
+            .WithFormula("C1", "=A1+1");
+
+        var outcome = CellGraphWalker.Walk(source.Ref("A1"), source);
+
+        Assert.True(outcome.IsCycle);
+        var addresses = outcome.Cycle!.Select(c => c.A1Address).ToList();
+        Assert.Equal(3, addresses.Count);
+        Assert.Equal(new[] { "A1", "B1", "C1" }, addresses);
+    }
+
+    [Fact]
+    public void Walk_CycleNotIncludingSink_StillDetected()
+    {
+        // Sink C1 → B1 ↔ A1 (the cycle excludes the sink). The walker
+        // still surfaces the cycle because phase-2 DFS walks into it
+        // from C1; nothing about cycle detection requires the sink to
+        // be on the cycle.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=B1+1")
+            .WithFormula("B1", "=A1+1")
+            .WithFormula("C1", "=B1+1");
+
+        var outcome = CellGraphWalker.Walk(source.Ref("C1"), source);
+
+        Assert.True(outcome.IsCycle);
+        var addresses = outcome.Cycle!.Select(c => c.A1Address).ToHashSet();
+        Assert.Contains("A1", addresses);
+        Assert.Contains("B1", addresses);
+        Assert.DoesNotContain("C1", addresses);
+    }
+
+    [Fact]
+    public void Walk_AcyclicGraph_HasNoCycle()
+    {
+        // Regression guard: a normal acyclic walk surfaces Cells, not
+        // a cycle outcome.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var outcome = CellGraphWalker.Walk(source.Ref("C1"), source);
+
+        Assert.False(outcome.IsCycle);
+        Assert.NotNull(outcome.Cells);
+        Assert.Null(outcome.Cycle);
     }
 }
 

--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -1126,4 +1126,213 @@ public class GatherEngineTests
         Assert.NotNull(parsed);
         Assert.NotEmpty(parsed.Bindings);
     }
+
+    [Fact]
+    public void Gather_TwoCycle_ReturnsCycleDiagnostic()
+    {
+        // PR 7 acceptance: A1 ↔ B1 cycle. Engine returns a result with
+        // Diagnostic.Kind = Cycle, an empty bindings list, and an empty
+        // synthesised LET. The diagnostic's Cells list contains both
+        // cycle members so the caller (or future tests) can introspect.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=B1+1")
+            .WithFormula("B1", "=A1+1");
+
+        var result = GatherEngine.Gather(source.Ref("A1"), source);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result!.Diagnostic);
+        Assert.Equal(GatherDiagnosticKind.Cycle, result.Diagnostic!.Kind);
+        Assert.Empty(result.Bindings);
+        Assert.Empty(result.SynthesisedLet);
+        var addresses = result.Diagnostic.Cells.Select(c => c.A1Address).ToHashSet();
+        Assert.Equal(new HashSet<string> { "A1", "B1" }, addresses);
+    }
+
+    [Fact]
+    public void Gather_TwoCycle_DiagnosticMessageNamesBothCells()
+    {
+        // The MessageBox text the user sees must list both cells with
+        // sheet qualifiers so cross-sheet cycles remain unambiguous.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=B1+1")
+            .WithFormula("B1", "=A1+1");
+
+        var result = GatherEngine.Gather(source.Ref("A1"), source)!;
+
+        Assert.NotNull(result.Diagnostic);
+        Assert.Contains("A1", result.Diagnostic!.Message);
+        Assert.Contains("B1", result.Diagnostic.Message);
+        // Closes the cycle path with the back-edge target repeated at
+        // the end so the loop is visible — exact format isn't pinned
+        // here but the arrow separator must be present.
+        Assert.Contains("→", result.Diagnostic.Message);
+    }
+
+    [Fact]
+    public void Gather_ThreeCycle_DiagnosticListsAllThreeCells()
+    {
+        // PR 7 acceptance: 3-cycle. Diagnostic.Cells contains all three
+        // members in path order; the message names each one.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=B1+1")
+            .WithFormula("B1", "=C1+1")
+            .WithFormula("C1", "=A1+1");
+
+        var result = GatherEngine.Gather(source.Ref("A1"), source)!;
+
+        Assert.Equal(GatherDiagnosticKind.Cycle, result.Diagnostic!.Kind);
+        var addresses = result.Diagnostic.Cells.Select(c => c.A1Address).ToList();
+        Assert.Equal(3, addresses.Count);
+        Assert.Contains("A1", addresses);
+        Assert.Contains("B1", addresses);
+        Assert.Contains("C1", addresses);
+    }
+
+    [Fact]
+    public void Gather_CycleReachableFromSink_StillSurfaces()
+    {
+        // The cycle doesn't include the sink itself; engine still
+        // surfaces it because the walker's DFS reaches into it.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=B1+1")
+            .WithFormula("B1", "=A1+1")
+            .WithFormula("C1", "=B1+1");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source)!;
+
+        Assert.Equal(GatherDiagnosticKind.Cycle, result.Diagnostic!.Kind);
+    }
+
+    [Fact]
+    public void Gather_NoCycle_DiagnosticIsNull()
+    {
+        // Regression guard: an acyclic walk produces no diagnostic.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source)!;
+
+        Assert.Null(result.Diagnostic);
+        Assert.NotEmpty(result.Bindings);
+    }
+
+    [Fact]
+    public void Gather_NoFormulaSink_StillReturnsNullEvenWithSelection()
+    {
+        // The silent-no-op contract is preserved when the new selection
+        // overload is called: a non-formula sink still yields null,
+        // never a diagnostic — the slash command treats it as a quiet
+        // close, not an error worth a MessageBox.
+        var source = new StubCellSource();
+
+        var result = GatherEngine.Gather(
+            source.Ref("A1"),
+            new[] { source.Ref("A1"), source.Ref("B1") },
+            source);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Gather_MultiSinkSelection_ReturnsMultipleSinksDiagnostic()
+    {
+        // PR 7 acceptance: A1=10 (literal), B1=A1*2, C1=A1+1 — B1 and
+        // C1 are independent sinks (neither references the other).
+        // Multi-selecting both must refuse with MultipleSinks. The sink
+        // passed in is whichever cell was active at trigger time; the
+        // diagnostic's Cells is empty per the spec ("no list — situation
+        // is obvious to the author").
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=A1+1");
+
+        var result = GatherEngine.Gather(
+            source.Ref("B1"),
+            new[] { source.Ref("B1"), source.Ref("C1") },
+            source);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result!.Diagnostic);
+        Assert.Equal(GatherDiagnosticKind.MultipleSinks, result.Diagnostic!.Kind);
+        Assert.Empty(result.Bindings);
+        Assert.Empty(result.SynthesisedLet);
+        Assert.Empty(result.Diagnostic.Cells);
+    }
+
+    [Fact]
+    public void Gather_MultiSelectionWithDependency_AllowedSingleSink()
+    {
+        // Multi-selection is allowed when one of the selected cells
+        // transitively reaches every other selected cell — there's only
+        // one true sink. Walk proceeds normally; no diagnostic.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var result = GatherEngine.Gather(
+            source.Ref("C1"),
+            new[] { source.Ref("A1"), source.Ref("B1"), source.Ref("C1") },
+            source);
+
+        Assert.NotNull(result);
+        Assert.Null(result!.Diagnostic);
+        Assert.NotEmpty(result.Bindings);
+    }
+
+    [Fact]
+    public void Gather_SingleCellSelection_BypassesMultiSinkCheck()
+    {
+        // PR 7 acceptance: the multi-sink check is skipped when the
+        // selection is a single cell — the spec says "single-cell
+        // selection (always allowed)".
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2");
+
+        var result = GatherEngine.Gather(
+            source.Ref("B1"),
+            new[] { source.Ref("B1") },
+            source);
+
+        Assert.NotNull(result);
+        Assert.Null(result!.Diagnostic);
+    }
+
+    [Fact]
+    public void Gather_ThreeIndependentSinksInSelection_RefusedAsMultiSink()
+    {
+        // Three disconnected sinks (B1, C1, D1 all refer to A1 only)
+        // — three sink candidates, two would already trigger refusal.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=A1+1")
+            .WithFormula("D1", "=A1-1");
+
+        var result = GatherEngine.Gather(
+            source.Ref("B1"),
+            new[] { source.Ref("B1"), source.Ref("C1"), source.Ref("D1") },
+            source);
+
+        Assert.Equal(GatherDiagnosticKind.MultipleSinks, result!.Diagnostic!.Kind);
+    }
+
+    [Fact]
+    public void Gather_CycleWithMultiSelection_CycleDiagnosticWins()
+    {
+        // Cycles are an unconditional refusal regardless of selection
+        // shape — even a multi-sink-shaped selection should surface
+        // the cycle first because it's the more fundamental error and
+        // the multi-sink check itself walks the graph.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=B1+1")
+            .WithFormula("B1", "=A1+1");
+
+        var result = GatherEngine.Gather(
+            source.Ref("A1"),
+            new[] { source.Ref("A1"), source.Ref("B1") },
+            source);
+
+        Assert.Equal(GatherDiagnosticKind.Cycle, result!.Diagnostic!.Kind);
+    }
 }

--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -900,8 +900,7 @@ public class GatherEngineTests
         // ref producing `a` wouldn't get caught).
         Assert.Equal("a_2*3", innerB.Rhs);
 
-        var stepB2 = result.Bindings.Single(
-            b => b.Source.A1Address == "B2" && b.Name != "a_2" && b.Name != "b");
+        var stepB2 = result.Bindings.Single(b => b.Source.A1Address == "B2" && b.Name != "a_2" && b.Name != "b");
         Assert.Equal("b+1", stepB2.Rhs);
 
         var parsed = LetParser.Parse(result.SynthesisedLet);
@@ -1102,8 +1101,7 @@ public class GatherEngineTests
 
         // Outer `doubled` row exists with the cell's preferred name;
         // the inner colliding binding got `doubled_2`.
-        var outerDoubled = result.Bindings.Single(
-            b => b.Source.A1Address == "B2" && b.Name == "doubled");
+        var outerDoubled = result.Bindings.Single(b => b.Source.A1Address == "B2" && b.Name == "doubled");
         Assert.Equal("doubled_2+1", outerDoubled.Rhs);
 
         var innerDoubled2 = result.Bindings.Single(b => b.Name == "doubled_2");
@@ -1141,12 +1139,12 @@ public class GatherEngineTests
         var result = GatherEngine.Gather(source.Ref("A1"), source);
 
         Assert.NotNull(result);
-        Assert.NotNull(result!.Diagnostic);
+        Assert.NotNull(result.Diagnostic);
         Assert.Equal(GatherDiagnosticKind.Cycle, result.Diagnostic!.Kind);
         Assert.Empty(result.Bindings);
         Assert.Empty(result.SynthesisedLet);
         var addresses = result.Diagnostic.Cells.Select(c => c.A1Address).ToHashSet();
-        Assert.Equal(new HashSet<string> { "A1", "B1" }, addresses);
+        Assert.Equal(["A1", "B1"], addresses);
     }
 
     [Fact]
@@ -1254,7 +1252,7 @@ public class GatherEngineTests
             source);
 
         Assert.NotNull(result);
-        Assert.NotNull(result!.Diagnostic);
+        Assert.NotNull(result.Diagnostic);
         Assert.Equal(GatherDiagnosticKind.MultipleSinks, result.Diagnostic!.Kind);
         Assert.Empty(result.Bindings);
         Assert.Empty(result.SynthesisedLet);
@@ -1277,7 +1275,7 @@ public class GatherEngineTests
             source);
 
         Assert.NotNull(result);
-        Assert.Null(result!.Diagnostic);
+        Assert.Null(result.Diagnostic);
         Assert.NotEmpty(result.Bindings);
     }
 
@@ -1296,7 +1294,7 @@ public class GatherEngineTests
             source);
 
         Assert.NotNull(result);
-        Assert.Null(result!.Diagnostic);
+        Assert.Null(result.Diagnostic);
     }
 
     [Fact]

--- a/addin/lambda-boss/CellGraphWalker.cs
+++ b/addin/lambda-boss/CellGraphWalker.cs
@@ -10,11 +10,15 @@ namespace LambdaBoss;
 ///     promote each unique range to a leaf input and drop walked cells that
 ///     fall inside any promoted range. The returned cells are in topological
 ///     order (precedents before dependents) with the sink as the final
-///     entry. PR 7 layers cycle detection on top.
+///     entry. PR 7 adds DFS-coloured cycle detection during the topological
+///     pass — on a back-edge to a grey ancestor the walker returns a
+///     <see cref="WalkOutcome" /> carrying the cycle's cells in path order
+///     so the engine can refuse with a clear diagnostic instead of
+///     spinning forever.
 /// </summary>
 internal static class CellGraphWalker
 {
-    public static IReadOnlyList<WalkedCell> Walk(CellRef sink, ICellSource source)
+    public static WalkOutcome Walk(CellRef sink, ICellSource source)
     {
         ArgumentNullException.ThrowIfNull(source);
 
@@ -63,20 +67,29 @@ internal static class CellGraphWalker
             }
         }
 
-        return TopoSort(sink, byRef);
+        return CycleAwareTopoSort(sink, byRef);
     }
 
     /// <summary>
-    ///     Iterative DFS post-order: precedents emitted before dependents,
-    ///     sink last. PR 1 assumes no cycles, so we don't track grey-state
-    ///     here — that machinery lands in PR 7.
+    ///     Iterative DFS post-order with grey/black colouring. A child
+    ///     already on the DFS path (grey) means a back-edge — i.e. a
+    ///     cycle. The cycle's cells are extracted from the path stack in
+    ///     topological order (the back-edge target first, then each
+    ///     ancestor up to the cell that closed the loop) and surfaced via
+    ///     <see cref="WalkOutcome" />. Discovery (Walk's first phase)
+    ///     terminates fine in the presence of cycles thanks to the
+    ///     <c>byRef.ContainsKey</c> guard, but topo sort would otherwise
+    ///     spin forever pushing back and forth between the cycle's cells.
     /// </summary>
-    private static List<WalkedCell> TopoSort(CellRef sink, Dictionary<CellRef, WalkedCell> byRef)
+    private static WalkOutcome CycleAwareTopoSort(
+        CellRef sink, Dictionary<CellRef, WalkedCell> byRef)
     {
         var ordered = new List<WalkedCell>(byRef.Count);
         var visited = new HashSet<CellRef>();
+        var onPath = new HashSet<CellRef>();
         var stack = new Stack<(CellRef Cell, int NextChild)>();
         stack.Push((sink, 0));
+        onPath.Add(sink);
 
         while (stack.Count > 0)
         {
@@ -89,15 +102,71 @@ internal static class CellGraphWalker
                 if (pre.IsRange)
                     continue;
                 var child = pre.Start;
-                if (!visited.Contains(child) && byRef.ContainsKey(child))
+                if (!byRef.ContainsKey(child))
+                    continue;
+                if (onPath.Contains(child))
+                    return WalkOutcome.WithCycle(ExtractCycle(stack, child));
+                if (!visited.Contains(child))
+                {
                     stack.Push((child, 0));
+                    onPath.Add(child);
+                }
             }
             else if (visited.Add(cell))
             {
+                onPath.Remove(cell);
                 ordered.Add(node);
             }
         }
 
-        return ordered;
+        return WalkOutcome.Success(ordered);
     }
+
+    /// <summary>
+    ///     Builds the cycle's cell list from the DFS path stack at the
+    ///     moment a back-edge is detected. The stack iterates top-to-
+    ///     bottom and at this point holds the current cell at the top
+    ///     followed by each ancestor down to the sink. We collect from
+    ///     top (current cell) until we hit <paramref name="target" /> (the
+    ///     back-edge destination) and reverse so the result reads from
+    ///     <paramref name="target" /> through to the cell that closed the
+    ///     loop.
+    /// </summary>
+    private static List<CellRef> ExtractCycle(
+        Stack<(CellRef Cell, int NextChild)> stack, CellRef target)
+    {
+        var path = new List<CellRef>();
+        foreach (var (c, _) in stack)
+        {
+            path.Add(c);
+            if (c.Equals(target))
+                break;
+        }
+
+        path.Reverse();
+        return path;
+    }
+}
+
+/// <summary>
+///     Result of <see cref="CellGraphWalker.Walk" />: either a topo-ordered
+///     list of cells or a cycle's cell list. Exactly one of
+///     <see cref="Cells" /> and <see cref="Cycle" /> is non-null.
+/// </summary>
+internal readonly struct WalkOutcome
+{
+    private WalkOutcome(IReadOnlyList<WalkedCell>? cells, IReadOnlyList<CellRef>? cycle)
+    {
+        Cells = cells;
+        Cycle = cycle;
+    }
+
+    public IReadOnlyList<WalkedCell>? Cells { get; }
+    public IReadOnlyList<CellRef>? Cycle { get; }
+
+    public bool IsCycle => Cycle != null;
+
+    public static WalkOutcome Success(IReadOnlyList<WalkedCell> cells) => new(cells, null);
+
+    public static WalkOutcome WithCycle(IReadOnlyList<CellRef> cycle) => new(null, cycle);
 }

--- a/addin/lambda-boss/Commands/GatherCommand.cs
+++ b/addin/lambda-boss/Commands/GatherCommand.cs
@@ -10,12 +10,12 @@ using Taglo.Excel.Common;
 namespace LambdaBoss.Commands;
 
 /// <summary>
-///     Slash-command handler for <c>/Gather</c>. Reads the active cell,
-///     synthesises a single <c>=LET(...)</c> formula equivalent to the
-///     calculation graph rooted there, and on Save writes the LET back to
-///     the sink. PR 3 scope: cross-sheet precedents are walked normally,
-///     external-workbook refs surface as leaf inputs whose RHS is the
-///     workbook-qualified address.
+///     Slash-command handler for <c>/Gather</c>. Reads the active cell and
+///     the multi-selection (PR 7), synthesises a single <c>=LET(...)</c>
+///     formula equivalent to the calculation graph rooted at the active
+///     cell, and on Save writes the LET back to the sink. PR 7 also routes
+///     refusals (cycle in the graph, multi-sink selection) into a
+///     <c>MessageBox</c> rather than opening the dialog.
 /// </summary>
 internal static class GatherCommand
 {
@@ -43,11 +43,12 @@ internal static class GatherCommand
 
             var sink = new CellRef(sheetName, sinkColumn, sinkRow);
             var source = new LiveCellSource(workbook, sheetName);
+            var selection = ReadSelection(app, sheetName, sink);
 
             GatherResult? result;
             try
             {
-                result = GatherEngine.Gather(sink, source);
+                result = GatherEngine.Gather(sink, selection, source);
             }
             catch (Exception ex)
             {
@@ -58,6 +59,13 @@ internal static class GatherCommand
 
             if (result == null)
                 return;
+
+            if (result.Diagnostic != null)
+            {
+                Logger.Info($"Gather: refused — {result.Diagnostic.Kind}");
+                ShowError(result.Diagnostic.Message);
+                return;
+            }
 
             var excelHwnd = new IntPtr(app.Hwnd);
 
@@ -109,6 +117,53 @@ internal static class GatherCommand
         catch
         {
             Logger.Info($"ShowError: {message}");
+        }
+    }
+
+    /// <summary>
+    ///     Enumerates every cell in <c>Application.Selection</c> on the
+    ///     active sheet, including each disjoint area when the user has
+    ///     Ctrl-clicked a multi-area range. Falls back to the sink alone
+    ///     if the selection can't be read for any reason — the engine's
+    ///     multi-sink check short-circuits on a single-cell list, so this
+    ///     keeps the command working even when the COM call surface
+    ///     misbehaves. Selections are restricted to the active sheet; we
+    ///     don't currently model multi-sheet selections (which Excel
+    ///     allows via Ctrl-click on a sheet tab) — those would surface as
+    ///     a single-area Selection on the active sheet here, and the
+    ///     multi-sink check operates on that subset.
+    /// </summary>
+    private static List<CellRef> ReadSelection(dynamic app, string sheetName, CellRef sink)
+    {
+        try
+        {
+            dynamic? selection = app.Selection;
+            if (selection == null)
+                return new List<CellRef> { sink };
+
+            var cells = new List<CellRef>();
+            dynamic areas = selection.Areas;
+            int areaCount = (int)areas.Count;
+            for (var a = 1; a <= areaCount; a++)
+            {
+                dynamic area = areas[a];
+                int firstRow = (int)area.Row;
+                int firstCol = (int)area.Column;
+                int rowCount = (int)area.Rows.Count;
+                int colCount = (int)area.Columns.Count;
+                for (var r = 0; r < rowCount; r++)
+                for (var c = 0; c < colCount; c++)
+                    cells.Add(new CellRef(sheetName, firstCol + c, firstRow + r));
+            }
+
+            if (cells.Count == 0)
+                cells.Add(sink);
+            return cells;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Gather/ReadSelection", ex);
+            return new List<CellRef> { sink };
         }
     }
 

--- a/addin/lambda-boss/GatherEngine.cs
+++ b/addin/lambda-boss/GatherEngine.cs
@@ -21,18 +21,52 @@ public static class GatherEngine
     /// <summary>
     ///     Runs the gather over <paramref name="sink" />. Returns null if
     ///     the sink has no formula — the caller (slash command) treats this
-    ///     as a silent no-op rather than an error.
+    ///     as a silent no-op rather than an error. Cycles in the precedent
+    ///     graph (PR 7) surface as a non-null result with
+    ///     <see cref="GatherResult.Diagnostic" /> set; bindings and
+    ///     synthesised LET are empty in that case.
     /// </summary>
     public static GatherResult? Gather(CellRef sink, ICellSource source)
     {
+        return Gather(sink, new[] { sink }, source);
+    }
+
+    /// <summary>
+    ///     Selection-aware overload (PR 7). When
+    ///     <paramref name="selection" /> contains more than one cell, the
+    ///     engine first checks the multi-sink rule: if 2+ selected cells
+    ///     have no in-scope dependent (i.e. aren't transitively referenced
+    ///     by another selected cell), the engine refuses with a
+    ///     <see cref="GatherDiagnosticKind.MultipleSinks" /> diagnostic.
+    ///     Cycle detection runs whether or not the selection is multi-cell;
+    ///     a cycle anywhere in the walked graph surfaces as
+    ///     <see cref="GatherDiagnosticKind.Cycle" />. PR 9 will additionally
+    ///     use the selection to restrict the walk; for PR 7 the selection
+    ///     only feeds the multi-sink check.
+    /// </summary>
+    public static GatherResult? Gather(CellRef sink, IReadOnlyList<CellRef> selection, ICellSource source)
+    {
         ArgumentNullException.ThrowIfNull(sink);
+        ArgumentNullException.ThrowIfNull(selection);
         ArgumentNullException.ThrowIfNull(source);
 
         var sinkFormula = source.GetFormula(sink);
         if (sinkFormula == null)
             return null;
 
-        var walked = CellGraphWalker.Walk(sink, source);
+        // Multi-sink check uses the cycle-aware walker on each selected
+        // cell. If any walk hits a cycle, surface that cycle diagnostic
+        // first — cycles are an unconditional refusal, while multi-sink
+        // is selection-shape dependent.
+        var multiSinkDiagnostic = CheckMultipleSinks(sink, selection, sinkFormula, source);
+        if (multiSinkDiagnostic != null)
+            return multiSinkDiagnostic;
+
+        var outcome = CellGraphWalker.Walk(sink, source);
+        if (outcome.IsCycle)
+            return RefusedWithCycle(sink, sinkFormula, outcome.Cycle!);
+
+        var walked = outcome.Cells!;
 
         // Collect unique range refs encountered anywhere in the walk. Order
         // is by first-encountered; that becomes the binding order for
@@ -224,6 +258,78 @@ public static class GatherEngine
 
         return new GatherResult(sink, sinkFormula, bindings, sb.ToString());
     }
+
+    /// <summary>
+    ///     Multi-sink check (PR 7). For a multi-cell selection, walks each
+    ///     selected cell and marks the others it transitively reaches; the
+    ///     selected cells nobody reached are independent sinks. If 2+
+    ///     remain, the user has accidentally multi-selected disconnected
+    ///     calculations and the engine refuses. Single-cell selection
+    ///     short-circuits — there's only one possible sink. If any sub-walk
+    ///     hits a cycle, the cycle diagnostic wins (cycles are an
+    ///     unconditional refusal regardless of selection shape) — so the
+    ///     author always sees the more fundamental error first.
+    /// </summary>
+    private static GatherResult? CheckMultipleSinks(
+        CellRef sink, IReadOnlyList<CellRef> selection, string sinkFormula, ICellSource source)
+    {
+        if (selection.Count <= 1)
+            return null;
+
+        var selectionSet = new HashSet<CellRef>(selection);
+        var covered = new HashSet<CellRef>();
+        foreach (var cell in selection)
+        {
+            var outcome = CellGraphWalker.Walk(cell, source);
+            if (outcome.IsCycle)
+                return RefusedWithCycle(sink, sinkFormula, outcome.Cycle!);
+
+            foreach (var walked in outcome.Cells!)
+            {
+                if (walked.Ref.Equals(cell))
+                    continue;
+                if (selectionSet.Contains(walked.Ref))
+                    covered.Add(walked.Ref);
+            }
+        }
+
+        var sinkCount = selection.Count(s => !covered.Contains(s));
+        if (sinkCount <= 1)
+            return null;
+
+        var diagnostic = new GatherDiagnostic(
+            GatherDiagnosticKind.MultipleSinks,
+            "The selection contains multiple independent calculations.\n\n" +
+            "To gather, select a single sink cell, or restrict the selection " +
+            "to a single calculation chain.",
+            Array.Empty<CellRef>());
+
+        return new GatherResult(
+            sink, sinkFormula, Array.Empty<BindingRow>(), string.Empty, diagnostic);
+    }
+
+    /// <summary>
+    ///     Builds a refusal result with a cycle diagnostic, formatting the
+    ///     cell list as a closed path (each cell joined by <c>→</c>, with
+    ///     the cycle's first cell repeated at the end so the loop is
+    ///     visible). Sheet names are always included so cross-sheet cycles
+    ///     remain unambiguous in the dialog text.
+    /// </summary>
+    private static GatherResult RefusedWithCycle(
+        CellRef sink, string sinkFormula, IReadOnlyList<CellRef> cycle)
+    {
+        var path = string.Join(" → ", cycle.Select(FormatCell));
+        var closed = $"{path} → {FormatCell(cycle[0])}";
+        var message =
+            "Cell graph contains a circular reference:\n\n" +
+            $"  {closed}\n\n" +
+            "Excel itself flags this as a circular reference. Resolve it before running /Gather.";
+        var diagnostic = new GatherDiagnostic(GatherDiagnosticKind.Cycle, message, cycle);
+        return new GatherResult(
+            sink, sinkFormula, Array.Empty<BindingRow>(), string.Empty, diagnostic);
+    }
+
+    private static string FormatCell(CellRef cell) => $"{cell.Sheet}!{cell.A1Address}";
 
     /// <summary>
     ///     Picks a binding name for each range and each non-sink cell.

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -225,12 +225,40 @@ public enum BindingRole
 /// <summary>
 ///     The output of <see cref="GatherEngine" />: enough state to render
 ///     the dialog and write the synthesised LET back to the sink on Save.
+///     <see cref="Diagnostic" /> is non-null when the engine refused (PR 7+ —
+///     cycle in the precedent graph or multi-sink selection); in that case
+///     <see cref="Bindings" /> is empty and <see cref="SynthesisedLet" /> is
+///     empty too. Callers must check <see cref="Diagnostic" /> before using
+///     the rest of the result.
 /// </summary>
 public sealed record GatherResult(
     CellRef Sink,
     string OriginalFormula,
     IReadOnlyList<BindingRow> Bindings,
-    string SynthesisedLet);
+    string SynthesisedLet,
+    GatherDiagnostic? Diagnostic = null);
+
+/// <summary>
+///     A reason the engine refused to synthesise a LET. Surfaced by
+///     <see cref="GatherEngine" /> via <see cref="GatherResult.Diagnostic" />
+///     so the slash-command handler can render a <c>MessageBox</c> instead
+///     of opening the dialog. PR 7 introduces cycle and multi-sink
+///     diagnostics; later PRs may add more kinds (e.g. LAMBDA-call sink in
+///     PR 8).
+/// </summary>
+public sealed record GatherDiagnostic(
+    GatherDiagnosticKind Kind,
+    string Message,
+    IReadOnlyList<CellRef> Cells);
+
+public enum GatherDiagnosticKind
+{
+    /// <summary>The precedent graph contains a cycle.</summary>
+    Cycle,
+
+    /// <summary>The multi-selection contains 2+ cells with no in-scope dependent.</summary>
+    MultipleSinks
+}
 
 /// <summary>
 ///     COM-free abstraction over the active workbook used by


### PR DESCRIPTION
Closes #137. Part of #130.

## Summary

- `CellGraphWalker.Walk` now detects cycles via DFS grey/black colouring during topological sort and returns a `WalkOutcome` (cells xor cycle) so the engine never spins on a circular reference.
- `GatherEngine.Gather` gains a selection-aware overload. It runs the multi-sink check first (refuses with `MultipleSinks` when 2+ selected cells have no in-scope dependent) and then the cycle-aware walk (refuses with `Cycle` listing the cells involved).
- Refusals are returned as a `GatherResult` whose new nullable `Diagnostic` field is set; `Bindings` and `SynthesisedLet` are empty in that case.
- `GatherCommand` reads `Application.Selection` (multi-area-aware), calls the new overload, and routes any diagnostic into a `MessageBox` without opening the dialog. Cycles win over multi-sink — the more fundamental error surfaces first.

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` clean
- [x] `dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj` — 574 / 574 pass (15 new)
- [x] Manual Excel smoke (per issue):
  1. `A1==B1+1`, `B1==A1+1` → select A1, run `/Gather` → cycle dialog naming A1 and B1; no `GatherWindow`.
  2. `A1=10`, `B1==A1*2`, `C1==A1+1` → multi-select B1+C1, run `/Gather` → multi-sink dialog; no `GatherWindow`.