### PR TITLE
Gather: LAMBDA-call sink rejection (PR 8 of 12)

### DIFF
--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -1333,4 +1333,104 @@ public class GatherEngineTests
 
         Assert.Equal(GatherDiagnosticKind.Cycle, result!.Diagnostic!.Kind);
     }
+
+    [Fact]
+    public void Gather_PureLambdaCallSink_ReturnsLambdaCallSinkDiagnostic()
+    {
+        // PR 8 acceptance #1: sink formula is exactly =Foo(A1, B1) with
+        // Foo registered as a LAMBDA. Engine refuses with a diagnostic
+        // pointing at /EditLambda and emits no bindings or LET.
+        var source = new StubCellSource()
+            .WithFormula("C1", "=Foo(A1, B1)")
+            .WithLambdaName("Foo");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Diagnostic);
+        Assert.Equal(GatherDiagnosticKind.LambdaCallSink, result.Diagnostic!.Kind);
+        Assert.Empty(result.Bindings);
+        Assert.Empty(result.SynthesisedLet);
+        Assert.Contains("/EditLambda", result.Diagnostic.Message);
+    }
+
+    [Fact]
+    public void Gather_LambdaCallWrappedInExpression_WalksNormally()
+    {
+        // PR 8 acceptance #2: =Foo(A1) + 1 is NOT a pure LAMBDA call —
+        // the trailing `+ 1` makes it an ordinary expression. The walk
+        // proceeds normally and Foo(A1) is left untouched in the
+        // rewritten step body (CellRefExtractor doesn't match function
+        // names, only cell-shaped tokens).
+        var source = new StubCellSource()
+            .WithFormula("D1", "=Foo(A1) + 1")
+            .WithLambdaName("Foo");
+
+        var result = GatherEngine.Gather(source.Ref("D1"), source);
+
+        Assert.NotNull(result);
+        Assert.Null(result.Diagnostic);
+        // A1 is the only in-scope precedent.
+        var aRow = result.Bindings.Single(b => b.Source.A1Address == "A1");
+        Assert.Equal(BindingRole.Input, aRow.Role);
+
+        // The synthesised LET body keeps the LAMBDA call verbatim and
+        // rewrites the cell ref inside it to the binding name.
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal($"Foo({aRow.Name}) + 1", parsed.Body);
+    }
+
+    [Fact]
+    public void Gather_NonLambdaCallSink_WalksNormally()
+    {
+        // PR 8 acceptance #3: a sink with no LAMBDA call at all must
+        // not be touched by the new check. Regression guard against
+        // accidentally refusing plain arithmetic sinks.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1 + 1");
+
+        var result = GatherEngine.Gather(source.Ref("B1"), source);
+
+        Assert.NotNull(result);
+        Assert.Null(result.Diagnostic);
+        Assert.NotEmpty(result.Bindings);
+    }
+
+    [Fact]
+    public void Gather_BuiltInFunctionCallSink_NotRefused()
+    {
+        // =SUM(A1, B1) matches the call-shape regex but SUM isn't a
+        // workbook-scoped LAMBDA, so the engine must walk it normally
+        // rather than refuse. This guards against the LAMBDA-call check
+        // accidentally catching every single-call formula.
+        var source = new StubCellSource()
+            .WithFormula("C1", "=SUM(A1, B1)");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source);
+
+        Assert.NotNull(result);
+        Assert.Null(result.Diagnostic);
+        Assert.Equal(2, result.Bindings.Count);
+    }
+
+    [Fact]
+    public void Gather_PureLetSink_StillExpandedNotRefused()
+    {
+        // =LET(...) matches the call-shape regex with name "LET" but
+        // LET isn't a registered LAMBDA, so the engine takes its
+        // existing pure-LET sink path (inline expansion) rather than
+        // refusing. Regression guard against the LAMBDA-call check
+        // catching the engine's own LET inlining flow.
+        var source = new StubCellSource()
+            .WithLabel("A1", "Numbers")
+            .WithFormula("B1", "=LET(doubled, A2*2, doubled+1)");
+
+        var result = GatherEngine.Gather(source.Ref("B1"), source);
+
+        Assert.NotNull(result);
+        Assert.Null(result.Diagnostic);
+        // Sink LET was inlined (body is `doubled+1`, not nested).
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal("doubled+1", parsed.Body);
+    }
 }

--- a/addin/lambda-boss.Tests/StubCellSource.cs
+++ b/addin/lambda-boss.Tests/StubCellSource.cs
@@ -14,6 +14,7 @@ internal sealed class StubCellSource : ICellSource
     private readonly Dictionary<string, string> _formulas = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, string> _labels = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _spills = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _lambdaNames = new(StringComparer.OrdinalIgnoreCase);
 
     public StubCellSource(string sheet = "Sheet1")
     {
@@ -44,6 +45,17 @@ internal sealed class StubCellSource : ICellSource
         return this;
     }
 
+    /// <summary>
+    ///     Registers <paramref name="name" /> as a workbook-scoped LAMBDA.
+    ///     Mirrors what the live adapter learns from <c>Workbook.Names</c>
+    ///     plus <see cref="LambdaSignatureParser.IsLambdaFormula" />.
+    /// </summary>
+    public StubCellSource WithLambdaName(string name)
+    {
+        _lambdaNames.Add(name);
+        return this;
+    }
+
     public string? GetFormula(CellRef cell)
     {
         if (cell.IsExternal)
@@ -70,6 +82,11 @@ internal sealed class StubCellSource : ICellSource
         if (cell.IsExternal)
             return false;
         return _spills.Contains(Key(cell.Sheet, cell.Column, cell.Row));
+    }
+
+    public bool IsLambdaName(string name)
+    {
+        return !string.IsNullOrEmpty(name) && _lambdaNames.Contains(name);
     }
 
     /// <summary>

--- a/addin/lambda-boss/Commands/GatherCommand.cs
+++ b/addin/lambda-boss/Commands/GatherCommand.cs
@@ -248,6 +248,26 @@ internal static class GatherCommand
             }
         }
 
+        public bool IsLambdaName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return false;
+            try
+            {
+                dynamic? n = _workbook.Names.Item(name);
+                var refersTo = n?.RefersTo as string;
+                return LambdaSignatureParser.IsLambdaFormula(refersTo);
+            }
+            catch
+            {
+                // Names.Item throws on missing names — that's the cheapest
+                // existence probe. Built-in functions like SUM aren't in
+                // the Names collection so they land here as "not a LAMBDA",
+                // which is exactly what PR 8 needs.
+                return false;
+            }
+        }
+
         private string? ReadStringValue(string sheetName, int row, int column, string context)
         {
             var sheet = TryGetWorksheet(sheetName);

--- a/addin/lambda-boss/GatherEngine.cs
+++ b/addin/lambda-boss/GatherEngine.cs
@@ -1,6 +1,8 @@
 using System.Text;
 using System.Text.RegularExpressions;
 
+using LambdaBoss.Commands;
+
 namespace LambdaBoss;
 
 /// <summary>
@@ -53,6 +55,21 @@ public static class GatherEngine
         var sinkFormula = source.GetFormula(sink);
         if (sinkFormula == null)
             return null;
+
+        // Pure-LAMBDA-call sink check (PR 8). A formula like
+        // `=Foo(A1, B1)` where Foo is a registered LAMBDA can't be
+        // gathered — the cell already IS a LAMBDA invocation, so the
+        // author should expand it via /EditLambda first and then re-run
+        // /Gather on the resulting LET. TryParseLambdaCall returns
+        // non-null only when the whole formula is a single call (modulo
+        // trailing whitespace), so wrapped calls like `=Foo(A1) + 1`
+        // slip through and walk normally. The IsLambdaName check
+        // distinguishes a registered LAMBDA from a built-in like
+        // `=SUM(A1, B1)` — built-ins aren't workbook names so they
+        // also walk normally.
+        var lambdaCallDiagnostic = CheckLambdaCallSink(sink, sinkFormula, source);
+        if (lambdaCallDiagnostic != null)
+            return lambdaCallDiagnostic;
 
         // Multi-sink check uses the cycle-aware walker on each selected
         // cell. If any walk hits a cycle, surface that cycle diagnostic
@@ -257,6 +274,39 @@ public static class GatherEngine
             bodyText);
 
         return new GatherResult(sink, sinkFormula, bindings, sb.ToString());
+    }
+
+    /// <summary>
+    ///     Pure-LAMBDA-call sink check (PR 8). Returns a refusal result
+    ///     when the sink's formula is exactly a call to a registered
+    ///     LAMBDA (e.g. <c>=Foo(A1, B1)</c>); the message points the
+    ///     author at <c>/EditLambda</c>. Reuses
+    ///     <see cref="EditLambdaCommand.TryParseLambdaCall" /> which
+    ///     enforces the "no trailing content" rule, so wrapped calls
+    ///     like <c>=Foo(A1) + 1</c> walk normally. The
+    ///     <see cref="ICellSource.IsLambdaName" /> probe distinguishes a
+    ///     registered LAMBDA from a built-in function call (a built-in
+    ///     like SUM isn't a workbook name) and from the engine's own
+    ///     pure-<c>=LET(...)</c> sink path (LET isn't a workbook name
+    ///     either, so the engine still expands it inline).
+    /// </summary>
+    private static GatherResult? CheckLambdaCallSink(
+        CellRef sink, string sinkFormula, ICellSource source)
+    {
+        var call = EditLambdaCommand.TryParseLambdaCall(sinkFormula);
+        if (call == null)
+            return null;
+        if (!source.IsLambdaName(call.Name))
+            return null;
+
+        var diagnostic = new GatherDiagnostic(
+            GatherDiagnosticKind.LambdaCallSink,
+            "This cell is a LAMBDA call. Run /EditLambda first to expand it " +
+            "into a LET, then re-run /Gather.",
+            new[] { sink });
+
+        return new GatherResult(
+            sink, sinkFormula, Array.Empty<BindingRow>(), string.Empty, diagnostic);
     }
 
     /// <summary>

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -257,7 +257,15 @@ public enum GatherDiagnosticKind
     Cycle,
 
     /// <summary>The multi-selection contains 2+ cells with no in-scope dependent.</summary>
-    MultipleSinks
+    MultipleSinks,
+
+    /// <summary>
+    ///     The sink's formula is exactly a single call to a registered
+    ///     LAMBDA (e.g. <c>=Foo(A1, B1)</c>). The author should run
+    ///     <c>/EditLambda</c> first to expand it into a LET, then re-run
+    ///     <c>/Gather</c>.
+    /// </summary>
+    LambdaCallSink
 }
 
 /// <summary>
@@ -312,4 +320,17 @@ public interface ICellSource
     ///     as an input with RHS <c>A1#</c>.
     /// </summary>
     bool HasSpill(CellRef cell);
+
+    /// <summary>
+    ///     True when <paramref name="name" /> resolves to a workbook-scoped
+    ///     LAMBDA. The live adapter checks <c>Workbook.Names</c> and the
+    ///     name's <c>RefersTo</c> via <see cref="LambdaSignatureParser.IsLambdaFormula" />.
+    ///     PR 8 uses this to refuse pure-LAMBDA-call sinks (e.g.
+    ///     <c>=Foo(A1, B1)</c>) and steer the author to <c>/EditLambda</c>
+    ///     first. Names that don't exist on the workbook (built-in
+    ///     functions like <c>SUM</c>, sheet-scoped names, free-floating
+    ///     identifiers) return false so the engine treats their calls as
+    ///     ordinary expressions and walks them normally.
+    /// </summary>
+    bool IsLambdaName(string name);
 }


### PR DESCRIPTION
## Summary

PR 8 of 12 in the `/Gather` feature stack (parent #130).

Refuses sinks whose formula is exactly a single call to a registered LAMBDA — e.g. `=MyCalc(A1, B1)` — with a message pointing the author at `/EditLambda`. Wrapped calls like `=Foo(A1) + 1` and built-ins like `=SUM(A1, B1)` walk normally.

- Reuses `EditLambdaCommand.TryParseLambdaCall` for the pure-call shape detection (already enforces "no trailing content").
- New `ICellSource.IsLambdaName(string)` distinguishes registered LAMBDAs from built-in functions and from the engine's own `=LET(...)` sink path. The live adapter checks `Workbook.Names` + `LambdaSignatureParser.IsLambdaFormula`; the test stub takes a `WithLambdaName(...)` builder.
- New `GatherDiagnosticKind.LambdaCallSink` carries the diagnostic; `GatherCommand` already routes any non-null `Diagnostic` into a `MessageBox` and skips the dialog (no UI changes needed in this PR).

Closes #138

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` clean (0 errors).
- [x] `dotnet test` — 579 tests pass (5 new).
- [x] Manual Excel smoke (per issue): pure-call sink refused with `/EditLambda` hint and no dialog; wrapped-call sink walks and the LAMBDA call is preserved verbatim in the rewritten step body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)