### PR TITLE
Allow ? in LET/LAMBDA names (e.g. Help?)

### DIFF
--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -1414,6 +1414,34 @@ public class GatherEngineTests
     }
 
     [Fact]
+    public void Gather_NestedLetWithQuestionMarkBinding_ParsesAndPreservesName()
+    {
+        // Issue 152: a step's nested LET uses 'Help?' as a binding name —
+        // the engine must parse it (LetParser allows '?' in body chars)
+        // and preserve the name in both the spliced inner row and any
+        // body references. Without the fix this throws "Invalid LET
+        // binding name: 'Help?'" before any walking happens.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=LET(Help?, A1+1, Help? * 2)")
+            .WithFormula("C1", "=B1+5");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source)!;
+
+        Assert.Null(result.Diagnostic);
+        var inner = result.Bindings.Single(b => b.Name == "Help?");
+        Assert.Equal("step_1+1", inner.Rhs);
+
+        var stepB1 = result.Bindings.Single(b => b.Source.A1Address == "B1" && b.Name != "Help?");
+        // The inner body 'Help? * 2' becomes the step's RHS — the
+        // tokenizer must recognise 'Help?' as one identifier so the
+        // (no-op) inner-rename pass doesn't truncate it.
+        Assert.Equal("Help? * 2", stepB1.Rhs);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Contains(parsed.Bindings, b => b.Name == "Help?");
+    }
+
+    [Fact]
     public void Gather_PureLetSink_StillExpandedNotRefused()
     {
         // =LET(...) matches the call-shape regex with name "LET" but

--- a/addin/lambda-boss.Tests/LambdaSignatureParserTests.cs
+++ b/addin/lambda-boss.Tests/LambdaSignatureParserTests.cs
@@ -130,4 +130,34 @@ public class LambdaSignatureParserTests
         Assert.Equal(new[] { "x", "y" }, sig.Parameters);
         Assert.Equal("x * y + 1", sig.Body);
     }
+
+    [Fact]
+    public void Parse_TrailingQuestionMarkParam_Accepted()
+    {
+        // Issue 152: predicate parameters like 'Help?' are a Lambda
+        // library convention — the parser must accept them, not just
+        // ExcelNameValidator.
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(Help?, IF(Help?, 1, 0))");
+
+        Assert.Equal(new[] { "Help?" }, sig.Parameters);
+        Assert.Equal("IF(Help?, 1, 0)", sig.Body);
+    }
+
+    [Fact]
+    public void Parse_OptionalTrailingQuestionMarkParam_StripsBracketsKeepsQuestionMark()
+    {
+        // [Help?] is an optional predicate parameter — bracket stripping
+        // must preserve the trailing '?'.
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(x, [Help?], x + 1)");
+
+        Assert.Equal(new[] { "x", "Help?" }, sig.Parameters);
+    }
+
+    [Fact]
+    public void Parse_QuestionMarkAtStart_Throws()
+    {
+        // '?' at the start is NOT a valid Excel name.
+        Assert.Throws<FormatException>(() =>
+            LambdaSignatureParser.Parse("=LAMBDA(?x, x)"));
+    }
 }

--- a/addin/lambda-boss.Tests/LetNameSanitizerTests.cs
+++ b/addin/lambda-boss.Tests/LetNameSanitizerTests.cs
@@ -67,4 +67,26 @@ public class LetNameSanitizerTests
     {
         Assert.Equal("aBC", LetNameSanitizer.Sanitize("a   ---   B   !!!   C"));
     }
+
+    [Theory]
+    [InlineData("Help?", "help?")]
+    [InlineData("IsEmpty?", "isEmpty?")]
+    [InlineData("Has Value?", "hasValue?")]
+    public void Sanitize_TrailingQuestionMark_Preserved(string input, string expected)
+    {
+        // Issue 152: '?' is allowed inside Excel names, and predicate-style
+        // labels like 'Help?' should sanitise to 'help?' rather than have
+        // the '?' silently stripped.
+        Assert.Equal(expected, LetNameSanitizer.Sanitize(input));
+    }
+
+    [Fact]
+    public void Sanitize_LeadingQuestionMark_PrefixedWithUnderscore()
+    {
+        // '?' isn't a valid name-start character; the sanitizer prefixes
+        // with '_' so the result is still a usable name. Alternative
+        // would be to return null — picking '_' is consistent with the
+        // existing leading-digit handling.
+        Assert.Equal("_?help", LetNameSanitizer.Sanitize("?help"));
+    }
 }

--- a/addin/lambda-boss.Tests/LetParserTests.cs
+++ b/addin/lambda-boss.Tests/LetParserTests.cs
@@ -115,4 +115,38 @@ public class LetParserTests
         Assert.True(parsed.Bindings[1].IsCalculation);
         Assert.Equal("getMax", parsed.Body);
     }
+
+    [Fact]
+    public void Parse_BindingNameWithTrailingQuestionMark_Accepted()
+    {
+        // Issue 152: predicate-style names like 'Help?' are valid Excel
+        // names (per ExcelNameValidator) and the LAMBDA library uses
+        // them throughout. The parser must accept them as binding names.
+        var parsed = LetParser.Parse("=LET(Help?, 1, Help? + 1)");
+
+        Assert.Single(parsed.Bindings);
+        Assert.Equal("Help?", parsed.Bindings[0].Name);
+        Assert.Equal("Help? + 1", parsed.Body);
+    }
+
+    [Fact]
+    public void Parse_QuestionMarkInsideName_Accepted()
+    {
+        // '?' anywhere except the first character is valid; mid-name
+        // occurrences round-trip just like trailing ones.
+        var parsed = LetParser.Parse("=LET(is?valid, TRUE, is?valid)");
+
+        Assert.Equal("is?valid", parsed.Bindings[0].Name);
+        Assert.Equal("is?valid", parsed.Body);
+    }
+
+    [Fact]
+    public void Parse_BindingNameStartingWithQuestionMark_Throws()
+    {
+        // '?' at the start is NOT a valid Excel name — names must begin
+        // with a letter or underscore. Guard against accidentally
+        // accepting it via the relaxed pattern.
+        Assert.Throws<FormatException>(() =>
+            LetParser.Parse("=LET(?help, 1, ?help)"));
+    }
 }

--- a/addin/lambda-boss/CellRefExtractor.cs
+++ b/addin/lambda-boss/CellRefExtractor.cs
@@ -37,13 +37,18 @@ internal static class CellRefExtractor
             // 'Sheet'!  — quoted in-workbook sheet name
             @"'(?<sheetQ>(?:[^']|'')+)'!" +
             @"|" +
-            // Sheet!  — unquoted in-workbook sheet name
-            @"(?<![A-Za-z0-9_.!:'\]#])(?<sheet>[A-Za-z_][A-Za-z0-9_.]*)!" +
+            // Sheet!  — unquoted in-workbook sheet name. Lookbehind
+            // includes '?' so a name fragment ending in '?' (the
+            // predicate-marker convention) doesn't seed a bogus
+            // sheet-qualified match on its tail.
+            @"(?<![A-Za-z0-9_.!:'\]#?])(?<sheet>[A-Za-z_][A-Za-z0-9_.]*)!" +
             @"|" +
             // bare A1 — lookbehind also rejects '#' so a spill ref's tail
             // doesn't seed a follow-on bare-cell match (e.g. `A1#B1`
             // shouldn't extract B1 as a separate cell on the spill side).
-            @"(?<![A-Za-z0-9_.!:'\]#])" +
+            // '?' is in the class for the same reason: a name like
+            // 'Help?A1' is one identifier, not 'Help?' followed by 'A1'.
+            @"(?<![A-Za-z0-9_.!:'\]#?])" +
         @")" +
         @"\$?(?<col>[A-Za-z]{1,3})\$?(?<row>[0-9]+)" +
         // Optional tail: either a `:cell` range end OR a `#` spill marker,
@@ -58,7 +63,11 @@ internal static class CellRefExtractor
         // Trailing guards: not a longer identifier, not a sheet qualifier
         // ('!' for the next ref's sheet name), not a further range tail
         // (':') or a function-call tail ('('), not a further spill marker.
-        @"(?![A-Za-z0-9_.!:(#])",
+        // '?' is in the class so an identifier like 'A1?Result' (the
+        // predicate-marker convention applied to a name that happens to
+        // start with cell-address-shaped letters and digits) isn't
+        // truncated to its 'A1' prefix.
+        @"(?![A-Za-z0-9_.!:(#?])",
         RegexOptions.CultureInvariant);
 
     /// <summary>

--- a/addin/lambda-boss/GatherEngine.cs
+++ b/addin/lambda-boss/GatherEngine.cs
@@ -596,8 +596,11 @@ public static class GatherEngine
         return $"{baseName}_{suffix}";
     }
 
+    // Mirrors LetParser.IdentifierPattern. '?' is permitted anywhere
+    // except the first character so a binding renamed to a
+    // predicate-style name like 'Help?' is recognised as a single token.
     private static readonly Regex BareIdentifierPattern = new(
-        @"^[A-Za-z_][A-Za-z0-9_.]*$",
+        @"^[A-Za-z_][A-Za-z0-9_.?]*$",
         RegexOptions.CultureInvariant);
 
     /// <summary>
@@ -621,11 +624,13 @@ public static class GatherEngine
     /// <summary>
     ///     Replaces every bare-identifier occurrence of a key in
     ///     <paramref name="renames" /> with the mapped value. Tokens are
-    ///     identified by Excel's name-shape rule (<c>[A-Za-z_][A-Za-z0-9_.]*</c>).
-    ///     Strings (<c>"..."</c>) and single-quoted sheet/workbook
-    ///     qualifiers (<c>'My Sheet'!</c>) are skipped wholesale. A token
-    ///     followed by <c>!</c> is treated as a sheet qualifier and left
-    ///     alone — that's a cell-ref position, not a name reference.
+    ///     identified by Excel's name-shape rule (<c>[A-Za-z_][A-Za-z0-9_.?]*</c>) —
+    ///     <c>?</c> is part of the name body so a rename of <c>Help?</c>
+    ///     matches the whole token instead of just <c>Help</c>. Strings
+    ///     (<c>"..."</c>) and single-quoted sheet/workbook qualifiers
+    ///     (<c>'My Sheet'!</c>) are skipped wholesale. A token followed by
+    ///     <c>!</c> is treated as a sheet qualifier and left alone —
+    ///     that's a cell-ref position, not a name reference.
     /// </summary>
     private static string ApplyInnerRenames(string text, IReadOnlyDictionary<string, string> renames)
     {
@@ -680,7 +685,12 @@ public static class GatherEngine
 
     private static bool IsIdentStart(char c) => char.IsLetter(c) || c == '_';
 
-    private static bool IsIdentPart(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '.';
+    // '?' is allowed anywhere except the first char of an Excel name, so
+    // it's part of the identifier body but not its start. Without this,
+    // the tokenizer would split 'Help?' into 'Help' + '?' and an inner
+    // rename keyed on 'Help?' would never match the whole token.
+    private static bool IsIdentPart(char c) =>
+        char.IsLetterOrDigit(c) || c == '_' || c == '.' || c == '?';
 
     private static int SkipDoubleQuoted(string text, int openQuoteIndex)
     {

--- a/addin/lambda-boss/LambdaSignatureParser.cs
+++ b/addin/lambda-boss/LambdaSignatureParser.cs
@@ -17,8 +17,11 @@ public static class LambdaSignatureParser
         @"^=\s*LAMBDA\s*\(",
         RegexOptions.IgnoreCase);
 
+    // Mirrors LetParser.IdentifierPattern: '?' is permitted anywhere except
+    // as the first character so trailing-predicate parameters like 'Help?'
+    // round-trip cleanly through the parser.
     private static readonly Regex ParamNamePattern = new(
-        @"^\[?([A-Za-z_][A-Za-z0-9_.]*)\]?$");
+        @"^\[?([A-Za-z_][A-Za-z0-9_.?]*)\]?$");
 
     public static bool IsLambdaFormula(string? formula)
     {

--- a/addin/lambda-boss/LetNameSanitizer.cs
+++ b/addin/lambda-boss/LetNameSanitizer.cs
@@ -6,19 +6,24 @@ namespace LambdaBoss;
 ///     Turns a free-text label (e.g. a cell-above or cell-left value) into a
 ///     LET binding name. Splits on runs of non-identifier characters, lowercases
 ///     the first word's initial letter, TitleCases subsequent words, and
-///     prefixes with <c>_</c> if the result would start with a digit. Returns
-///     null when the input has no usable identifier characters at all, so the
-///     caller can fall through to the next naming level.
+///     prefixes with <c>_</c> if the result would otherwise start with a
+///     non-letter (a digit, or the trailing-predicate marker <c>?</c>).
+///     Returns null when the input has no usable identifier characters at
+///     all, so the caller can fall through to the next naming level.
 /// </summary>
 public static class LetNameSanitizer
 {
     /// <summary>
-    ///     Identifier characters: ASCII letters, digits, and underscore. Runs of
-    ///     anything else delimit "words" for camelCase joining.
+    ///     Identifier characters: ASCII letters, digits, underscore, and the
+    ///     trailing-predicate marker <c>?</c> (Excel allows it anywhere
+    ///     except the first character of a defined name; see
+    ///     <see cref="ExcelNameValidator" />). Treating <c>?</c> as part of
+    ///     the word means a label like <c>Help?</c> sanitises to <c>help?</c>
+    ///     rather than silently stripping the marker.
     /// </summary>
     private static bool IsIdentifierChar(char c)
     {
-        return c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_';
+        return c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_' or '?';
     }
 
     public static string? Sanitize(string? text)
@@ -65,7 +70,12 @@ public static class LetNameSanitizer
         if (sb.Length == 0)
             return null;
 
-        if (char.IsDigit(sb[0]))
+        // A valid Excel name starts with a letter or underscore; if the
+        // first sanitised character is anything else (a digit, or the
+        // trailing-predicate marker '?' that we now allow inside words),
+        // prefix with '_' so the result is still a usable name. Cases:
+        // "30" → "_30"; "?help" → "_?help".
+        if (sb[0] != '_' && !char.IsLetter(sb[0]))
             sb.Insert(0, '_');
 
         return sb.ToString();

--- a/addin/lambda-boss/LetParser.cs
+++ b/addin/lambda-boss/LetParser.cs
@@ -18,8 +18,14 @@ public static class LetParser
         @"^=\s*LET\s*\(",
         RegexOptions.IgnoreCase);
 
+    // Excel allows '?' anywhere except the first character of a defined
+    // name (per ExcelNameValidator), and our LAMBDA library follows the
+    // common convention of using a trailing '?' for predicate-style
+    // parameters (e.g. Help?, IsEmpty?). The pattern mirrors that rule:
+    // start with letter or underscore; subsequent chars also allow digits,
+    // dots, and '?'.
     private static readonly Regex IdentifierPattern = new(
-        @"^[A-Za-z_][A-Za-z0-9_.]*$");
+        @"^[A-Za-z_][A-Za-z0-9_.?]*$");
 
     public static bool IsLetFormula(string? formula)
     {

--- a/addin/lambda-boss/LetToLambdaBuilder.cs
+++ b/addin/lambda-boss/LetToLambdaBuilder.cs
@@ -165,8 +165,12 @@ public static class LetToLambdaBuilder
     {
         if (renames.Count == 0) return text;
 
+        // Lookbehind/lookahead include '?' so a rename of 'Help?' isn't
+        // accidentally matched inside a longer name like 'Help??' or
+        // 'foo?Help?'. Mirrors the identifier rule in LetParser /
+        // ExcelNameValidator: '?' is part of the name body.
         var pattern = string.Join("|", renames.Keys.Select(Regex.Escape));
-        var regex = new Regex($@"(?<![A-Za-z0-9_.]){pattern}(?![A-Za-z0-9_.])",
+        var regex = new Regex($@"(?<![A-Za-z0-9_.?]){pattern}(?![A-Za-z0-9_.?])",
             RegexOptions.IgnoreCase);
 
         var result = new StringBuilder();
@@ -209,8 +213,13 @@ public static class LetToLambdaBuilder
     /// </summary>
     internal static string AbsolutizeCellRefs(string text)
     {
+        // Lookbehind includes '?' so a name fragment like 'Help?A1' isn't
+        // accidentally absolutized as the cell ref 'A1'. The lookahead
+        // already guards the cell-ref tail; '?' is added there too in
+        // case a defined name happens to start with what looks like a
+        // cell address followed by '?'.
         var regex = new Regex(
-            @"(?<![A-Za-z0-9_.])(\$?)([A-Za-z]{1,3})(\$?)([0-9]+)(?![A-Za-z0-9_.!])");
+            @"(?<![A-Za-z0-9_.?])(\$?)([A-Za-z]{1,3})(\$?)([0-9]+)(?![A-Za-z0-9_.!?])");
 
         var result = new StringBuilder();
         var i = 0;


### PR DESCRIPTION
## Summary

`ExcelNameValidator` already accepts `?` anywhere except the first character, but the parsers and rename helpers used the older `[A-Za-z_][A-Za-z0-9_.]*` identifier shape — so `/Gather` and `/EditLambda` failed on any graph touching a `Help?`-style name. This PR aligns every name-shape regex / tokeniser with the validator.

Targets the `claude/lambda-from-formulas-wsF4Q` spec branch since one of the affected files (`GatherEngine`) doesn't exist on `main` yet; it'll come along when the gather feature ships.

### Changes

- `LetParser.IdentifierPattern` → `[A-Za-z_][A-Za-z0-9_.?]*`
- `LambdaSignatureParser.ParamNamePattern` → same shape, plus optional `[brackets]`
- `LetNameSanitizer`: `?` is now an identifier char; the `_`-prefix logic widens from "starts with digit" to "starts with non-letter, non-underscore" so a leading `?` no longer slips through as an invalid name
- `GatherEngine.BareIdentifierPattern` + `IsIdentPart`: inner-rename tokeniser recognises `Help?` as one token
- `LetToLambdaBuilder.ApplyRenames` + `AbsolutizeCellRefs`: lookarounds include `?` so a rename of `Help?` doesn't match inside `Help??`, and a name like `Help?A1` doesn't get its `A1` tail absolutized
- `CellRefExtractor`: lookbehind/lookahead char classes include `?` for the same reason

### Tests added

- `LetParser`: `Help?` and mid-name `is?valid` accepted; `?help` rejected.
- `LambdaSignatureParser`: `Help?` and `[Help?]` accepted; `?x` rejected.
- `LetNameSanitizer`: `Help?` → `help?`, `Has Value?` → `hasValue?`, `?help` → `_?help`.
- `GatherEngine`: end-to-end — a step's nested LET with `Help?` binding parses, splices into the outer LET, and the inner-rename tokeniser keeps `Help?` whole.

Closes #152

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` clean.
- [x] `dotnet test` — 590 tests pass (11 new).
- [x] Manual Excel smoke: `/Gather` on a sink whose graph references a LAMBDA with a `Help?` parameter no longer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)