### PR TITLE
Gather: selection-restricted walk + header hint (PR 9 of 12)

### DIFF
--- a/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
+++ b/addin/lambda-boss.Tests/CellGraphWalkerTests.cs
@@ -296,6 +296,142 @@ public class CellGraphWalkerTests
     }
 
     [Fact]
+    public void Walk_RestrictedToSelection_OutOfSelectionPrecedentLeafed()
+    {
+        // PR 9: A1=10 literal, B1=A1*2, C1=B1+1 (sink). Restricting to
+        // {B1, C1} leaves A1 in the discovered set but with formula=null
+        // and no precedents — its ref still appears as a binding boundary
+        // for the engine, just as a leaf. Here A1 has no formula anyway,
+        // so the restriction is observationally indistinguishable from a
+        // free walk; the leaf-restricted counter is what tells the engine
+        // (and the dialog) that the user actually narrowed the walk.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var restrictTo = new HashSet<CellRef> { source.Ref("B1"), source.Ref("C1") };
+        var outcome = CellGraphWalker.Walk(source.Ref("C1"), source, restrictTo);
+
+        Assert.False(outcome.IsCycle);
+        var addresses = outcome.Cells!.Select(w => w.Ref.A1Address).ToList();
+        Assert.Equal(new[] { "A1", "B1", "C1" }, addresses);
+
+        var aLeaf = outcome.Cells!.Single(w => w.Ref.A1Address == "A1");
+        Assert.Null(aLeaf.Formula);
+        Assert.Empty(aLeaf.Precedents);
+        Assert.Equal(1, outcome.LeafRestrictedCount);
+    }
+
+    [Fact]
+    public void Walk_RestrictedSubTreeNotDiscovered_BeyondLeafBoundary()
+    {
+        // A1 → B1 → C1 → D1 (sink). Restricting to {C1, D1} leaves B1 as
+        // a leaf-restricted boundary; A1 is never even pushed because B1
+        // contributed no precedents to the walker stack. Ensures the
+        // restriction prunes the sub-tree wholesale rather than just
+        // hiding it post-walk.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1")
+            .WithFormula("D1", "=C1*3");
+
+        var restrictTo = new HashSet<CellRef> { source.Ref("C1"), source.Ref("D1") };
+        var outcome = CellGraphWalker.Walk(source.Ref("D1"), source, restrictTo);
+
+        var addresses = outcome.Cells!.Select(w => w.Ref.A1Address).ToHashSet();
+        Assert.Contains("D1", addresses);
+        Assert.Contains("C1", addresses);
+        Assert.Contains("B1", addresses);
+        Assert.DoesNotContain("A1", addresses);
+        Assert.Equal(1, outcome.LeafRestrictedCount);
+    }
+
+    [Fact]
+    public void Walk_RestrictedFullCover_BehavesLikeFreeWalk()
+    {
+        // Multi-selection that covers every cell in the precedent graph
+        // restricts nothing — leafRestrictedCount stays zero and the
+        // walked list matches the free walk.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var freeOutcome = CellGraphWalker.Walk(source.Ref("C1"), source);
+        var restrictTo = new HashSet<CellRef>
+        {
+            source.Ref("A1"), source.Ref("B1"), source.Ref("C1"),
+        };
+        var restrictedOutcome = CellGraphWalker.Walk(source.Ref("C1"), source, restrictTo);
+
+        Assert.Equal(0, restrictedOutcome.LeafRestrictedCount);
+        Assert.Equal(
+            freeOutcome.Cells!.Select(w => w.Ref.A1Address),
+            restrictedOutcome.Cells!.Select(w => w.Ref.A1Address));
+    }
+
+    [Fact]
+    public void Walk_RestrictedDoesNotApplyToSink_EvenWhenSinkOmittedFromSet()
+    {
+        // The sink is always processed, regardless of the restriction set.
+        // Defensive: even if a caller forgets to include the sink, the
+        // walker still walks the sink's formula so we get a valid LET.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2");
+
+        // Only B1 in the set, but B1 is also the sink — A1 is out, so
+        // gets leaf-restricted.
+        var restrictTo = new HashSet<CellRef> { source.Ref("B1") };
+        var outcome = CellGraphWalker.Walk(source.Ref("B1"), source, restrictTo);
+
+        var sink = outcome.Cells!.Single(w => w.Ref.A1Address == "B1");
+        Assert.Equal("=A1*2", sink.Formula);
+        Assert.NotEmpty(sink.Precedents);
+
+        var leaf = outcome.Cells!.Single(w => w.Ref.A1Address == "A1");
+        Assert.Null(leaf.Formula);
+        Assert.Equal(1, outcome.LeafRestrictedCount);
+    }
+
+    [Fact]
+    public void Walk_RestrictedSpillAnchor_KeepsHasSpillFlag()
+    {
+        // A spill anchor that's leaf-restricted still carries HasSpill so
+        // the engine emits `A1#` on the boundary input — preserving the
+        // dynamic-array semantics of the dropped sub-tree.
+        var source = new StubCellSource()
+            .WithFormula("A1", "=SEQUENCE(10)")
+            .WithSpill("A1")
+            .WithFormula("B1", "=SUM(A1#)");
+
+        var restrictTo = new HashSet<CellRef> { source.Ref("B1") };
+        var outcome = CellGraphWalker.Walk(source.Ref("B1"), source, restrictTo);
+
+        var anchor = outcome.Cells!.Single(w => w.Ref.A1Address == "A1");
+        Assert.Null(anchor.Formula);
+        Assert.True(anchor.HasSpill);
+        Assert.Equal(1, outcome.LeafRestrictedCount);
+    }
+
+    [Fact]
+    public void Walk_NullRestrictTo_BehavesLikeUnrestrictedOverload()
+    {
+        // Regression guard: the restriction-aware overload with a null set
+        // produces the same outcome as the convenience overload.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var unrestricted = CellGraphWalker.Walk(source.Ref("C1"), source);
+        var nullRestricted = CellGraphWalker.Walk(source.Ref("C1"), source, restrictTo: null);
+
+        Assert.Equal(0, unrestricted.LeafRestrictedCount);
+        Assert.Equal(0, nullRestricted.LeafRestrictedCount);
+        Assert.Equal(
+            unrestricted.Cells!.Select(w => w.Ref.A1Address),
+            nullRestricted.Cells!.Select(w => w.Ref.A1Address));
+    }
+
+    [Fact]
     public void Walk_AcyclicGraph_HasNoCycle()
     {
         // Regression guard: a normal acyclic walk surfaces Cells, not

--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -1461,4 +1461,134 @@ public class GatherEngineTests
         var parsed = LetParser.Parse(result.SynthesisedLet);
         Assert.Equal("doubled+1", parsed.Body);
     }
+
+    [Fact]
+    public void Gather_SingleCellSelection_ReportsFreeWalkCounts()
+    {
+        // PR 9: single-cell selection means free walk. M and N both equal
+        // the count of cells the walker visited (sink + every reachable
+        // precedent). The dialog will render this as
+        // "Walking 3 cells from C1".
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var result = GatherEngine.Gather(source.Ref("C1"), source)!;
+
+        Assert.Equal(3, result.FreeWalkCount);
+        Assert.Equal(3, result.WalkedCount);
+    }
+
+    [Fact]
+    public void Gather_MultiSelectionFullCover_ReportsEqualCounts()
+    {
+        // PR 9: a multi-selection that covers every walked cell restricts
+        // nothing, so M == N. The dialog suppresses the "restricted by
+        // selection" hint when the selection didn't actually narrow the
+        // walk — this matches the issue's "behaves like a free walk".
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var result = GatherEngine.Gather(
+            source.Ref("C1"),
+            new[] { source.Ref("A1"), source.Ref("B1"), source.Ref("C1") },
+            source)!;
+
+        Assert.Equal(3, result.FreeWalkCount);
+        Assert.Equal(3, result.WalkedCount);
+    }
+
+    [Fact]
+    public void Gather_MultiSelectionPartialCover_DemotesPrecedentToCellRefInput()
+    {
+        // PR 9 acceptance scenario: A1=10 literal, B1=A1*2, C1=B1+1
+        // (sink). Selecting {B1, C1} restricts the walk so A1 isn't a
+        // step candidate, but its cell-ref still appears as an input
+        // binding on the boundary. A1 happens to be a literal here, so
+        // the binding shape is the same as the free-walk case — what
+        // changes is the count: the dialog header shows "2 of 3".
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var result = GatherEngine.Gather(
+            source.Ref("C1"),
+            new[] { source.Ref("B1"), source.Ref("C1") },
+            source)!;
+
+        Assert.Null(result.Diagnostic);
+        Assert.Equal(3, result.FreeWalkCount);
+        Assert.Equal(2, result.WalkedCount);
+
+        var aRow = result.Bindings.Single(b => b.Source.A1Address == "A1");
+        Assert.Equal(BindingRole.Input, aRow.Role);
+        Assert.Equal("A1", aRow.Rhs);
+
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B1");
+        Assert.Equal(BindingRole.Step, bRow.Role);
+    }
+
+    [Fact]
+    public void Gather_MultiSelectionPartialCover_DropsOutOfSelectionPrecedentSubTree()
+    {
+        // A1 (formula referencing X1) → B1 → C1 → D1 (sink). Selection
+        // {C1, D1} restricts B1 to a leaf-input (cell-ref RHS); A1 and
+        // X1 are never reached because B1's sub-tree is pruned. Without
+        // restriction the walk would visit 4 cells (A1 has no formula, so
+        // X1 isn't reached even in the free walk — it would only matter
+        // if A1 had a formula).
+        var source = new StubCellSource()
+            .WithFormula("A1", "=X1+1")
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1")
+            .WithFormula("D1", "=C1*3");
+
+        var freeResult = GatherEngine.Gather(source.Ref("D1"), source)!;
+        Assert.Equal(5, freeResult.FreeWalkCount);
+        Assert.Equal(5, freeResult.WalkedCount);
+
+        var restrictedResult = GatherEngine.Gather(
+            source.Ref("D1"),
+            new[] { source.Ref("C1"), source.Ref("D1") },
+            source)!;
+
+        Assert.Equal(5, restrictedResult.FreeWalkCount);
+        Assert.Equal(2, restrictedResult.WalkedCount);
+
+        var addresses = restrictedResult.Bindings
+            .Select(b => b.Source.A1Address)
+            .ToHashSet();
+        Assert.Contains("B1", addresses);
+        Assert.Contains("C1", addresses);
+        Assert.DoesNotContain("A1", addresses);
+        Assert.DoesNotContain("X1", addresses);
+
+        // B1 is the boundary leaf — input role with cell-ref RHS, no
+        // matter that its formula is "=A1*2" in the workbook.
+        var bRow = restrictedResult.Bindings.Single(b => b.Source.A1Address == "B1");
+        Assert.Equal(BindingRole.Input, bRow.Role);
+        Assert.Equal("B1", bRow.Rhs);
+    }
+
+    [Fact]
+    public void Gather_RestrictedWalk_LetRoundTripsThroughLetParser()
+    {
+        // Round-trip safety on the restricted-walk branch: synthesised
+        // LET still parses cleanly even though some bindings are leafs
+        // demoted from steps.
+        var source = new StubCellSource()
+            .WithLabel("A1", "Numbers")
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var result = GatherEngine.Gather(
+            source.Ref("C1"),
+            new[] { source.Ref("B1"), source.Ref("C1") },
+            source)!;
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.NotEmpty(parsed.Bindings);
+        Assert.NotEmpty(parsed.Body);
+    }
 }

--- a/addin/lambda-boss/CellGraphWalker.cs
+++ b/addin/lambda-boss/CellGraphWalker.cs
@@ -14,15 +14,28 @@ namespace LambdaBoss;
 ///     pass — on a back-edge to a grey ancestor the walker returns a
 ///     <see cref="WalkOutcome" /> carrying the cycle's cells in path order
 ///     so the engine can refuse with a clear diagnostic instead of
-///     spinning forever.
+///     spinning forever. PR 9 adds an optional <c>restrictTo</c> set: when
+///     non-null, any non-sink cell outside the set is treated as a leaf
+///     (formula <c>null</c>, no precedents) so its sub-tree is dropped
+///     from the walk and its cell-ref appears as an input on the boundary.
+///     The sink itself is never restricted — gathering always processes the
+///     sink's formula. Spill anchors keep their <see cref="ICellSource.HasSpill" />
+///     flag even when leaf-restricted so the engine still emits <c>A1#</c>
+///     on the boundary input, preserving the array semantics of the
+///     dropped sub-tree.
 /// </summary>
 internal static class CellGraphWalker
 {
-    public static WalkOutcome Walk(CellRef sink, ICellSource source)
+    public static WalkOutcome Walk(CellRef sink, ICellSource source) =>
+        Walk(sink, source, restrictTo: null);
+
+    public static WalkOutcome Walk(
+        CellRef sink, ICellSource source, IReadOnlySet<CellRef>? restrictTo)
     {
         ArgumentNullException.ThrowIfNull(source);
 
         var byRef = new Dictionary<CellRef, WalkedCell>();
+        var leafRestricted = 0;
         var stack = new Stack<CellRef>();
         stack.Push(sink);
 
@@ -32,23 +45,42 @@ internal static class CellGraphWalker
             if (byRef.ContainsKey(cell))
                 continue;
 
-            var formula = source.GetFormula(cell);
+            // Cell is leaf-restricted when a restriction set is given and
+            // this cell isn't in it. The sink is exempt — gather always
+            // processes its formula. Cell-above/left labels and HasSpill
+            // are still queried so the boundary input's binding name and
+            // `#`-suffix come out the same as a natural leaf would.
+            var isRestricted = restrictTo != null
+                               && !cell.Equals(sink)
+                               && !restrictTo.Contains(cell);
+
             var cellAbove = source.GetCellAboveText(cell);
             var cellLeft = source.GetCellLeftText(cell);
             var hasSpill = source.HasSpill(cell);
 
+            string? formula;
             IReadOnlyList<FormulaRef> precedents;
-            if (formula == null)
+            if (isRestricted)
             {
+                formula = null;
                 precedents = Array.Empty<FormulaRef>();
+                leafRestricted++;
             }
             else
             {
-                // Unqualified refs in this cell's formula resolve against
-                // its OWN sheet, not the sink's — otherwise crossing into
-                // Sheet1 from a sink on Sheet2 would mis-route Sheet1's
-                // internal `B1` references back to Sheet2.
-                precedents = CellRefExtractor.Extract(formula, cell.Sheet);
+                formula = source.GetFormula(cell);
+                if (formula == null)
+                {
+                    precedents = Array.Empty<FormulaRef>();
+                }
+                else
+                {
+                    // Unqualified refs in this cell's formula resolve against
+                    // its OWN sheet, not the sink's — otherwise crossing into
+                    // Sheet1 from a sink on Sheet2 would mis-route Sheet1's
+                    // internal `B1` references back to Sheet2.
+                    precedents = CellRefExtractor.Extract(formula, cell.Sheet);
+                }
             }
 
             byRef[cell] = new WalkedCell(cell, formula, cellAbove, cellLeft, precedents, hasSpill);
@@ -67,7 +99,7 @@ internal static class CellGraphWalker
             }
         }
 
-        return CycleAwareTopoSort(sink, byRef);
+        return CycleAwareTopoSort(sink, byRef, leafRestricted);
     }
 
     /// <summary>
@@ -82,7 +114,7 @@ internal static class CellGraphWalker
     ///     spin forever pushing back and forth between the cycle's cells.
     /// </summary>
     private static WalkOutcome CycleAwareTopoSort(
-        CellRef sink, Dictionary<CellRef, WalkedCell> byRef)
+        CellRef sink, Dictionary<CellRef, WalkedCell> byRef, int leafRestrictedCount)
     {
         var ordered = new List<WalkedCell>(byRef.Count);
         var visited = new HashSet<CellRef>();
@@ -119,7 +151,7 @@ internal static class CellGraphWalker
             }
         }
 
-        return WalkOutcome.Success(ordered);
+        return WalkOutcome.Success(ordered, leafRestrictedCount);
     }
 
     /// <summary>
@@ -152,21 +184,32 @@ internal static class CellGraphWalker
 ///     Result of <see cref="CellGraphWalker.Walk" />: either a topo-ordered
 ///     list of cells or a cycle's cell list. Exactly one of
 ///     <see cref="Cells" /> and <see cref="Cycle" /> is non-null.
+///     <see cref="LeafRestrictedCount" /> reports how many cells were
+///     leaf-restricted by the walker's <c>restrictTo</c> set (PR 9) — zero
+///     for unrestricted walks. The engine subtracts this from
+///     <see cref="Cells" />'s count to derive the "M" in the
+///     <c>Walking M of N cells from &lt;addr&gt;</c> header.
 /// </summary>
 internal readonly struct WalkOutcome
 {
-    private WalkOutcome(IReadOnlyList<WalkedCell>? cells, IReadOnlyList<CellRef>? cycle)
+    private WalkOutcome(
+        IReadOnlyList<WalkedCell>? cells,
+        IReadOnlyList<CellRef>? cycle,
+        int leafRestrictedCount)
     {
         Cells = cells;
         Cycle = cycle;
+        LeafRestrictedCount = leafRestrictedCount;
     }
 
     public IReadOnlyList<WalkedCell>? Cells { get; }
     public IReadOnlyList<CellRef>? Cycle { get; }
+    public int LeafRestrictedCount { get; }
 
     public bool IsCycle => Cycle != null;
 
-    public static WalkOutcome Success(IReadOnlyList<WalkedCell> cells) => new(cells, null);
+    public static WalkOutcome Success(IReadOnlyList<WalkedCell> cells, int leafRestrictedCount = 0) =>
+        new(cells, null, leafRestrictedCount);
 
-    public static WalkOutcome WithCycle(IReadOnlyList<CellRef> cycle) => new(null, cycle);
+    public static WalkOutcome WithCycle(IReadOnlyList<CellRef> cycle) => new(null, cycle, 0);
 }

--- a/addin/lambda-boss/CellGraphWalker.cs
+++ b/addin/lambda-boss/CellGraphWalker.cs
@@ -26,8 +26,10 @@ namespace LambdaBoss;
 /// </summary>
 internal static class CellGraphWalker
 {
-    public static WalkOutcome Walk(CellRef sink, ICellSource source) =>
-        Walk(sink, source, restrictTo: null);
+    public static WalkOutcome Walk(CellRef sink, ICellSource source)
+    {
+        return Walk(sink, source, null);
+    }
 
     public static WalkOutcome Walk(
         CellRef sink, ICellSource source, IReadOnlySet<CellRef>? restrictTo)
@@ -70,9 +72,7 @@ internal static class CellGraphWalker
             {
                 formula = source.GetFormula(cell);
                 if (formula == null)
-                {
                     precedents = Array.Empty<FormulaRef>();
-                }
                 else
                 {
                     // Unqualified refs in this cell's formula resolve against
@@ -181,7 +181,7 @@ internal static class CellGraphWalker
 }
 
 /// <summary>
-///     Result of <see cref="CellGraphWalker.Walk" />: either a topo-ordered
+///     Result of CellGraphWalker.Walk: either a topo-ordered
 ///     list of cells or a cycle's cell list. Exactly one of
 ///     <see cref="Cells" /> and <see cref="Cycle" /> is non-null.
 ///     <see cref="LeafRestrictedCount" /> reports how many cells were
@@ -208,8 +208,13 @@ internal readonly struct WalkOutcome
 
     public bool IsCycle => Cycle != null;
 
-    public static WalkOutcome Success(IReadOnlyList<WalkedCell> cells, int leafRestrictedCount = 0) =>
-        new(cells, null, leafRestrictedCount);
+    public static WalkOutcome Success(IReadOnlyList<WalkedCell> cells, int leafRestrictedCount = 0)
+    {
+        return new WalkOutcome(cells, null, leafRestrictedCount);
+    }
 
-    public static WalkOutcome WithCycle(IReadOnlyList<CellRef> cycle) => new(null, cycle, 0);
+    public static WalkOutcome WithCycle(IReadOnlyList<CellRef> cycle)
+    {
+        return new WalkOutcome(null, cycle, 0);
+    }
 }

--- a/addin/lambda-boss/GatherEngine.cs
+++ b/addin/lambda-boss/GatherEngine.cs
@@ -34,17 +34,23 @@ public static class GatherEngine
     }
 
     /// <summary>
-    ///     Selection-aware overload (PR 7). When
-    ///     <paramref name="selection" /> contains more than one cell, the
-    ///     engine first checks the multi-sink rule: if 2+ selected cells
-    ///     have no in-scope dependent (i.e. aren't transitively referenced
-    ///     by another selected cell), the engine refuses with a
+    ///     Selection-aware overload. When <paramref name="selection" />
+    ///     contains more than one cell, the engine first checks the
+    ///     multi-sink rule (PR 7): if 2+ selected cells have no in-scope
+    ///     dependent (i.e. aren't transitively referenced by another
+    ///     selected cell), the engine refuses with a
     ///     <see cref="GatherDiagnosticKind.MultipleSinks" /> diagnostic.
     ///     Cycle detection runs whether or not the selection is multi-cell;
     ///     a cycle anywhere in the walked graph surfaces as
-    ///     <see cref="GatherDiagnosticKind.Cycle" />. PR 9 will additionally
-    ///     use the selection to restrict the walk; for PR 7 the selection
-    ///     only feeds the multi-sink check.
+    ///     <see cref="GatherDiagnosticKind.Cycle" />.
+    ///     PR 9 adds selection-restricted walking: when the multi-selection
+    ///     covers the active cell plus others, the walker leaf-restricts
+    ///     any precedent that isn't in the selection — its sub-tree drops
+    ///     out of the LET and its cell-ref appears as an input on the
+    ///     boundary. The result's <see cref="GatherResult.WalkedCount" />
+    ///     and <see cref="GatherResult.FreeWalkCount" /> let the dialog
+    ///     render the header hint (free: <c>Walking N cells from &lt;addr&gt;</c>;
+    ///     restricted: <c>Walking M of N cells from &lt;addr&gt; — restricted by selection</c>).
     /// </summary>
     public static GatherResult? Gather(CellRef sink, IReadOnlyList<CellRef> selection, ICellSource source)
     {
@@ -79,11 +85,33 @@ public static class GatherEngine
         if (multiSinkDiagnostic != null)
             return multiSinkDiagnostic;
 
-        var outcome = CellGraphWalker.Walk(sink, source);
-        if (outcome.IsCycle)
-            return RefusedWithCycle(sink, sinkFormula, outcome.Cycle!);
+        // Free walk first — surfaces cycles ahead of any restriction work
+        // and gives us "N" (the count of cells the walk would have visited
+        // without restriction) for the dialog header. The restricted walk
+        // is a strict sub-walk of this graph (subgraph of an acyclic graph
+        // is acyclic), so cycle detection on the free walk is sufficient.
+        var freeOutcome = CellGraphWalker.Walk(sink, source);
+        if (freeOutcome.IsCycle)
+            return RefusedWithCycle(sink, sinkFormula, freeOutcome.Cycle!);
+
+        var freeWalkCount = freeOutcome.Cells!.Count;
+
+        // Restricted walk only when the multi-selection meaningfully
+        // narrows the walk. A single-cell selection — the common case —
+        // skips this and reuses the free walk verbatim.
+        WalkOutcome outcome;
+        if (selection.Count > 1)
+        {
+            var restrictTo = new HashSet<CellRef>(selection);
+            outcome = CellGraphWalker.Walk(sink, source, restrictTo);
+        }
+        else
+        {
+            outcome = freeOutcome;
+        }
 
         var walked = outcome.Cells!;
+        var walkedCount = walked.Count - outcome.LeafRestrictedCount;
 
         // Collect unique range refs encountered anywhere in the walk. Order
         // is by first-encountered; that becomes the binding order for
@@ -273,7 +301,9 @@ public static class GatherEngine
             bindings.Select(b => (b.Name, b.Rhs)).ToList(),
             bodyText);
 
-        return new GatherResult(sink, sinkFormula, bindings, sb.ToString());
+        return new GatherResult(
+            sink, sinkFormula, bindings, sb.ToString(),
+            WalkedCount: walkedCount, FreeWalkCount: freeWalkCount);
     }
 
     /// <summary>

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -229,14 +229,21 @@ public enum BindingRole
 ///     cycle in the precedent graph or multi-sink selection); in that case
 ///     <see cref="Bindings" /> is empty and <see cref="SynthesisedLet" /> is
 ///     empty too. Callers must check <see cref="Diagnostic" /> before using
-///     the rest of the result.
+///     the rest of the result. PR 9 adds <see cref="WalkedCount" /> and
+///     <see cref="FreeWalkCount" /> so the dialog can render the header
+///     hint: <c>WalkedCount</c> ("M") is cells the walker actually walked
+///     into, and <c>FreeWalkCount</c> ("N") is cells the walk would have
+///     visited without selection-based restriction. Both are zero when the
+///     engine refused.
 /// </summary>
 public sealed record GatherResult(
     CellRef Sink,
     string OriginalFormula,
     IReadOnlyList<BindingRow> Bindings,
     string SynthesisedLet,
-    GatherDiagnostic? Diagnostic = null);
+    GatherDiagnostic? Diagnostic = null,
+    int WalkedCount = 0,
+    int FreeWalkCount = 0);
 
 /// <summary>
 ///     A reason the engine refused to synthesise a LET. Surfaced by

--- a/addin/lambda-boss/UI/GatherWindow.xaml
+++ b/addin/lambda-boss/UI/GatherWindow.xaml
@@ -18,11 +18,19 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <TextBlock Grid.Row="0"
+        <TextBlock x:Name="WalkHintText"
+                   Grid.Row="0"
+                   FontSize="12"
+                   FontStyle="Italic"
+                   Foreground="#9cdcfe"
+                   Margin="0,0,0,8" />
+
+        <TextBlock Grid.Row="1"
                    Text="Sink"
                    FontSize="13"
                    FontWeight="Bold"
@@ -30,14 +38,14 @@
                    Margin="0,0,0,4" />
 
         <TextBlock x:Name="SinkAddressText"
-                   Grid.Row="1"
+                   Grid.Row="2"
                    Padding="6,4"
                    FontSize="13"
                    FontFamily="Consolas"
                    Background="#2d2d2d"
                    Foreground="#cccccc" />
 
-        <TextBlock Grid.Row="2"
+        <TextBlock Grid.Row="3"
                    Text="Original formula"
                    FontSize="13"
                    FontWeight="Bold"
@@ -45,7 +53,7 @@
                    Margin="0,12,0,4" />
 
         <TextBox x:Name="OriginalFormulaText"
-                 Grid.Row="3"
+                 Grid.Row="4"
                  IsReadOnly="True"
                  IsReadOnlyCaretVisible="False"
                  Padding="6,4"
@@ -60,14 +68,14 @@
                  VerticalScrollBarVisibility="Auto"
                  MaxHeight="80" />
 
-        <TextBlock Grid.Row="4"
+        <TextBlock Grid.Row="5"
                    Text="Bindings"
                    FontSize="13"
                    FontWeight="Bold"
                    Foreground="#dcdcaa"
                    Margin="0,12,0,4" />
 
-        <Border Grid.Row="5"
+        <Border Grid.Row="6"
                 Background="#252526"
                 BorderBrush="#3e3e3e"
                 BorderThickness="1"
@@ -118,7 +126,7 @@
             </ScrollViewer>
         </Border>
 
-        <Grid Grid.Row="6" Margin="0,12,0,0">
+        <Grid Grid.Row="7" Margin="0,12,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -146,7 +154,7 @@
                      HorizontalScrollBarVisibility="Auto" />
         </Grid>
 
-        <DockPanel Grid.Row="7" Margin="0,12,0,0">
+        <DockPanel Grid.Row="8" Margin="0,12,0,0">
             <Button x:Name="CancelButton"
                     DockPanel.Dock="Right"
                     Content="Cancel"

--- a/addin/lambda-boss/UI/GatherWindow.xaml.cs
+++ b/addin/lambda-boss/UI/GatherWindow.xaml.cs
@@ -18,6 +18,7 @@ public partial class GatherWindow
         InitializeComponent();
         _result = result;
 
+        WalkHintText.Text = BuildWalkHint(result);
         SinkAddressText.Text = result.Sink.A1Address;
         OriginalFormulaText.Text = result.OriginalFormula;
         PreviewText.Text = result.SynthesisedLet;
@@ -50,6 +51,29 @@ public partial class GatherWindow
         SavedFormula = null;
         DialogResult = false;
         Close();
+    }
+
+    /// <summary>
+    ///     Renders the header hint per spec 0005 §"Selection-restricted
+    ///     walk". A free walk (single-cell selection, or a multi-selection
+    ///     that happened to cover every walked cell) reads
+    ///     <c>Walking N cells from &lt;addr&gt;</c>; a restriction that
+    ///     actually narrowed the walk reads
+    ///     <c>Walking M of N cells from &lt;addr&gt; — restricted by selection</c>.
+    ///     The "M == N" case is treated as a free walk in the header even
+    ///     when the selection was multi-cell, matching the issue's "behaves
+    ///     like a free walk" wording — restricting and then happening to
+    ///     cover everything is observationally indistinguishable from a
+    ///     free walk and showing "N of N" reads as noise.
+    /// </summary>
+    private static string BuildWalkHint(GatherResult result)
+    {
+        var addr = result.Sink.A1Address;
+        var n = result.FreeWalkCount;
+        var m = result.WalkedCount;
+        if (m == n)
+            return $"Walking {n} cells from {addr}";
+        return $"Walking {m} of {n} cells from {addr} — restricted by selection";
     }
 
     private void Window_PreviewKeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
Closes #139. Part of #130.

## Summary

- `CellGraphWalker.Walk` gains an optional `restrictTo: IReadOnlySet<CellRef>?` parameter. When non-null, any non-sink cell outside the set is leaf-restricted: formula `null`, no precedents, but cell-above/left labels and `HasSpill` are still queried so the boundary input's binding name and `#`-suffix come out the same as a natural leaf.
- `WalkOutcome` exposes `LeafRestrictedCount` so the engine can derive M.
- `GatherEngine.Gather` does a free walk first (for cycle detection + N), then a restricted walk when `selection.Count > 1`. The restricted graph is a subgraph of an acyclic graph, so cycle detection on the free walk is sufficient.
- `GatherResult` carries `WalkedCount` (M) and `FreeWalkCount` (N).
- `GatherWindow` renders the header hint above the sink address — free format when `M == N`, restricted form otherwise.

## Test plan

- [x] Walker tests: out-of-selection precedent leafed; sub-tree pruned beyond boundary; full-cover behaves like free walk; sink never restricted; spill anchor keeps `HasSpill` flag; `restrictTo: null` regression guard.
- [x] Engine tests: single-cell reports free counts; full-cover reports equal counts; partial cover demotes to cell-ref input; sub-tree drops; round-trip through `LetParser`.
- [x] All 601 unit tests pass.
- [x] Manual Excel test (per issue): A1=10, B1=`=A1*2`, C1=`=B1+1`. Select C1 → header `Walking 3 cells from C1`. Select B1+C1 → header `Walking 2 of 3 cells from C1 — restricted by selection`, A1 binding has RHS `A1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)