### PR TITLE
Gather: Include checkbox + orphan drop (PR 10 of 12)

### DIFF
--- a/addin/lambda-boss.Tests/GatherEngineTests.cs
+++ b/addin/lambda-boss.Tests/GatherEngineTests.cs
@@ -1591,4 +1591,290 @@ public class GatherEngineTests
         Assert.NotEmpty(parsed.Bindings);
         Assert.NotEmpty(parsed.Body);
     }
+
+    // PR 10 — Include checkbox + orphan drop. Recompute takes per-row
+    // Include flags and re-walks from scratch: dropping a row removes it
+    // from the LET, the calling step keeps the cell-ref literally, and
+    // any precedents reachable only via the dropped cell also drop.
+    // Re-checking the row pulls it (and its newly-reachable precedents)
+    // back without losing earlier toggles on other rows.
+
+    [Fact]
+    public void Recompute_AllIncluded_MatchesGather()
+    {
+        // Sanity: with every row Include=true, Recompute returns the
+        // same shape as the initial Gather. Validates the Recompute path
+        // doesn't drift from Gather when nothing is excluded.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var initial = GatherEngine.Gather(source.Ref("C1"), source)!;
+        var states = initial.Bindings
+            .Select(b => new RowState(b.Source, true))
+            .ToList();
+
+        var recomputed = GatherEngine.Recompute(
+            source.Ref("C1"), new[] { source.Ref("C1") }, source, states)!;
+
+        Assert.Null(recomputed.Diagnostic);
+        Assert.Equal(initial.SynthesisedLet, recomputed.SynthesisedLet);
+        Assert.Equal(initial.Bindings.Count, recomputed.Bindings.Count);
+    }
+
+    [Fact]
+    public void Recompute_ExcludeLeaf_DropsRowAndKeepsCellRefInCallingStep()
+    {
+        // A1 leaf input, B1 step that references A1, C1 sink that
+        // references B1. Excluding A1 drops just A1 — B1 stays a step
+        // (its formula still has content) but its RHS keeps the literal
+        // "A1" since A1 has no binding name to rewrite to. C1 is the
+        // sink; its body is unchanged because it doesn't reference A1
+        // directly.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var states = new[]
+        {
+            new RowState(new FormulaRef(source.Ref("A1")), Include: false),
+            new RowState(new FormulaRef(source.Ref("B1")), Include: true),
+        };
+        var result = GatherEngine.Recompute(
+            source.Ref("C1"), new[] { source.Ref("C1") }, source, states)!;
+
+        Assert.Null(result.Diagnostic);
+        Assert.DoesNotContain(result.Bindings, b => b.Source.A1Address == "A1");
+
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B1");
+        Assert.Equal(BindingRole.Step, bRow.Role);
+        Assert.Equal("A1*2", bRow.Rhs);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Single(parsed.Bindings);
+        Assert.Equal("A1*2", parsed.Bindings[0].RhsText);
+    }
+
+    [Fact]
+    public void Recompute_ExcludeStep_CascadesToUpstreamOnlyReachable()
+    {
+        // Acceptance scenario from issue #140: A1=10, B1=A1*2, C1=B1+1
+        // (sink). Untick B1 (a step). B1 drops AND A1 also drops because
+        // A1 was only reachable via B1. The sink body keeps `B1+1` with
+        // B1 as a literal cell-ref.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var states = new[]
+        {
+            new RowState(new FormulaRef(source.Ref("A1")), Include: true),
+            new RowState(new FormulaRef(source.Ref("B1")), Include: false),
+        };
+        var result = GatherEngine.Recompute(
+            source.Ref("C1"), new[] { source.Ref("C1") }, source, states)!;
+
+        Assert.Null(result.Diagnostic);
+        // Both B1 (excluded) and A1 (orphaned) are absent from bindings.
+        Assert.Empty(result.Bindings);
+        // No bindings → bare formula (no LET wrapper). Excel rejects
+        // LET with zero binding pairs, so the engine emits just the
+        // body — observably the sink's formula minus any in-scope
+        // rewrites, which is what the user sees in the Preview pane.
+        Assert.Equal("=B1+1", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_ExcludeBranch_PreservesOtherBranches()
+    {
+        // Diamond graph: A1 (literal) feeds B1, C1 (literal) feeds D1,
+        // E1 = B1 + D1 (sink). Excluding B1 drops B1 + A1 (A1 only
+        // reaches the sink via B1) but D1 + C1 are preserved because
+        // they're on the other branch.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("D1", "=C1+5")
+            .WithFormula("E1", "=B1+D1");
+
+        var states = new[]
+        {
+            new RowState(new FormulaRef(source.Ref("A1")), Include: true),
+            new RowState(new FormulaRef(source.Ref("B1")), Include: false),
+            new RowState(new FormulaRef(source.Ref("C1")), Include: true),
+            new RowState(new FormulaRef(source.Ref("D1")), Include: true),
+        };
+        var result = GatherEngine.Recompute(
+            source.Ref("E1"), new[] { source.Ref("E1") }, source, states)!;
+
+        Assert.Null(result.Diagnostic);
+        var addrs = result.Bindings.Select(b => b.Source.A1Address).ToHashSet();
+        Assert.DoesNotContain("A1", addrs);
+        Assert.DoesNotContain("B1", addrs);
+        Assert.Contains("C1", addrs);
+        Assert.Contains("D1", addrs);
+
+        // D1 stays a step that rewrites C1's ref, B1's literal text
+        // survives in the sink body because B1 has no binding name now.
+        var dRow = result.Bindings.Single(b => b.Source.A1Address == "D1");
+        Assert.Equal(BindingRole.Step, dRow.Role);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        // Body shape: B1 literal + D1's binding name.
+        var dName = dRow.Name;
+        Assert.Equal($"B1+{dName}", parsed.Body);
+    }
+
+    [Fact]
+    public void Recompute_RetoggleRestoresPreviouslyOrphanedPrecedent()
+    {
+        // The acceptance scenario's "re-tick B1" flow: same chain, after
+        // toggling B1 off (which drops both B1 and A1), toggling B1 back
+        // on restores B1 *and* A1 as bindings, returning the LET to its
+        // original shape. Verifies Recompute is a stateless re-run of
+        // the engine — no leftover state from the previous excluded
+        // pass affects the next.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+        var sink = source.Ref("C1");
+        var selection = new[] { sink };
+
+        var initial = GatherEngine.Gather(sink, source)!;
+        var initialAddrs = initial.Bindings.Select(b => b.Source.A1Address).ToHashSet();
+        Assert.Contains("A1", initialAddrs);
+        Assert.Contains("B1", initialAddrs);
+
+        // Toggle B1 off — the dialog would also drop A1 from view
+        // (orphan), but the user can re-tick B1 via the row that's
+        // still rendered (the dialog snapshot keeps it visible).
+        var dropped = GatherEngine.Recompute(sink, selection, source, new[]
+        {
+            new RowState(new FormulaRef(source.Ref("A1")), Include: true),
+            new RowState(new FormulaRef(source.Ref("B1")), Include: false),
+        })!;
+        Assert.Empty(dropped.Bindings);
+
+        // Re-tick B1 — the engine walks back into A1 because nothing
+        // else is excluded. Bindings come back in topological order.
+        var restored = GatherEngine.Recompute(sink, selection, source, new[]
+        {
+            new RowState(new FormulaRef(source.Ref("A1")), Include: true),
+            new RowState(new FormulaRef(source.Ref("B1")), Include: true),
+        })!;
+
+        Assert.Equal(initial.SynthesisedLet, restored.SynthesisedLet);
+        var restoredAddrs = restored.Bindings.Select(b => b.Source.A1Address).ToHashSet();
+        Assert.Contains("A1", restoredAddrs);
+        Assert.Contains("B1", restoredAddrs);
+    }
+
+    [Fact]
+    public void Recompute_ExcludedCellReferencedFromMultipleBranches_OrphansOnlyWhereSole()
+    {
+        // A1 (literal) is referenced both via B1 = A1*2 AND C1 = A1+5.
+        // D1 = B1 + C1 (sink). Excluding B1 should drop B1 but keep A1
+        // (C1 still reaches it). The sink body's `B1` reference
+        // collapses to a literal cell-ref; C1's name still stands and
+        // C1's RHS still rewrites A1 to A1's binding name.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=A1+5")
+            .WithFormula("D1", "=B1+C1");
+
+        var states = new[]
+        {
+            new RowState(new FormulaRef(source.Ref("A1")), Include: true),
+            new RowState(new FormulaRef(source.Ref("B1")), Include: false),
+            new RowState(new FormulaRef(source.Ref("C1")), Include: true),
+        };
+        var result = GatherEngine.Recompute(
+            source.Ref("D1"), new[] { source.Ref("D1") }, source, states)!;
+
+        Assert.Null(result.Diagnostic);
+        var addrs = result.Bindings.Select(b => b.Source.A1Address).ToHashSet();
+        Assert.Contains("A1", addrs);
+        Assert.DoesNotContain("B1", addrs);
+        Assert.Contains("C1", addrs);
+
+        // C1's RHS rewrites A1 to A1's binding name — A1 is still in
+        // scope because C1 reaches it.
+        var aRow = result.Bindings.Single(b => b.Source.A1Address == "A1");
+        var cRow = result.Bindings.Single(b => b.Source.A1Address == "C1");
+        Assert.Equal($"{aRow.Name}+5", cRow.Rhs);
+    }
+
+    [Fact]
+    public void Recompute_ExcludeStepWithNoInScopePrecedents_StaysAStepWithLiteralRefs()
+    {
+        // B1 = `=A1*2` where A1 is excluded — there are no other
+        // in-scope precedents, but the step's role should still be
+        // Step (not Input) because the calling formula has content the
+        // user wants preserved literally. Without the "excluded
+        // counts as a binding for role classification" rule, B1 would
+        // demote to Input with RHS=B1, losing the `*2`.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+1");
+
+        var states = new[]
+        {
+            new RowState(new FormulaRef(source.Ref("A1")), Include: false),
+            new RowState(new FormulaRef(source.Ref("B1")), Include: true),
+        };
+        var result = GatherEngine.Recompute(
+            source.Ref("C1"), new[] { source.Ref("C1") }, source, states)!;
+
+        var bRow = result.Bindings.Single(b => b.Source.A1Address == "B1");
+        Assert.Equal(BindingRole.Step, bRow.Role);
+        Assert.Equal("A1*2", bRow.Rhs);
+    }
+
+    [Fact]
+    public void Recompute_ExcludeRange_KeepsLiteralRangeInCallingStep()
+    {
+        // B1 = SUM(A1:A3) sink. Excluding the A1:A3 range row drops the
+        // range binding from the LET; the sink body keeps `SUM(A1:A3)`
+        // literally because the rewriter leaves unmapped refs alone.
+        var source = new StubCellSource()
+            .WithFormula("B1", "=SUM(A1:A3)");
+
+        var rangeRef = new FormulaRef(source.Ref("A1"), source.Ref("A3"));
+        var states = new[]
+        {
+            new RowState(rangeRef, Include: false),
+        };
+        var result = GatherEngine.Recompute(
+            source.Ref("B1"), new[] { source.Ref("B1") }, source, states)!;
+
+        Assert.Null(result.Diagnostic);
+        Assert.Empty(result.Bindings);
+        // No bindings → bare formula. The literal range survives the
+        // rewrite (it's not in the lookup map), so the LET reduces to
+        // the original sink formula.
+        Assert.Equal("=SUM(A1:A3)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_LetRoundTripsThroughLetParser()
+    {
+        // Round-trip safety on the Recompute branch: an arbitrary
+        // exclusion shouldn't break LET parseability.
+        var source = new StubCellSource()
+            .WithLabel("A1", "Numbers")
+            .WithFormula("B1", "=A1*2")
+            .WithFormula("C1", "=B1+10")
+            .WithFormula("D1", "=C1+B1");
+
+        var states = new[]
+        {
+            new RowState(new FormulaRef(source.Ref("A1")), Include: true),
+            new RowState(new FormulaRef(source.Ref("B1")), Include: false),
+            new RowState(new FormulaRef(source.Ref("C1")), Include: true),
+        };
+        var result = GatherEngine.Recompute(
+            source.Ref("D1"), new[] { source.Ref("D1") }, source, states)!;
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.NotEmpty(parsed.Body);
+    }
 }

--- a/addin/lambda-boss/CellGraphWalker.cs
+++ b/addin/lambda-boss/CellGraphWalker.cs
@@ -23,6 +23,15 @@ namespace LambdaBoss;
 ///     flag even when leaf-restricted so the engine still emits <c>A1#</c>
 ///     on the boundary input, preserving the array semantics of the
 ///     dropped sub-tree.
+///     PR 10 adds an optional <c>excludedCells</c> set: cells in the set
+///     are not pushed onto the walk stack and never appear in the returned
+///     <see cref="WalkedCell" /> list. The sink itself is exempt (the
+///     dialog never lets the user exclude the sink). An excluded cell's
+///     ref still appears in any calling step's
+///     <see cref="WalkedCell.Precedents" />, so the engine's role
+///     classification can keep that step a step (its formula still has
+///     content), and the rewriter leaves the ref as a literal cell address
+///     because the lookup dictionary won't contain it.
 /// </summary>
 internal static class CellGraphWalker
 {
@@ -33,6 +42,15 @@ internal static class CellGraphWalker
 
     public static WalkOutcome Walk(
         CellRef sink, ICellSource source, IReadOnlySet<CellRef>? restrictTo)
+    {
+        return Walk(sink, source, restrictTo, null);
+    }
+
+    public static WalkOutcome Walk(
+        CellRef sink,
+        ICellSource source,
+        IReadOnlySet<CellRef>? restrictTo,
+        IReadOnlySet<CellRef>? excludedCells)
     {
         ArgumentNullException.ThrowIfNull(source);
 
@@ -93,6 +111,14 @@ internal static class CellGraphWalker
                 // range that happen to be reached via OTHER precedents are
                 // walked normally and dropped post-walk.
                 if (p.IsRange)
+                    continue;
+                // Excluded precedents don't get walked — that's how the
+                // user's "Include" toggle drops a cell and its
+                // upstream-only-reachable sub-tree. The ref still lives in
+                // this cell's Precedents list (we just don't push it), so
+                // the engine sees the precedent for role classification
+                // and the rewriter passes the literal cell-ref through.
+                if (excludedCells != null && excludedCells.Contains(p.Start))
                     continue;
                 if (!byRef.ContainsKey(p.Start))
                     stack.Push(p.Start);

--- a/addin/lambda-boss/Commands/GatherCommand.cs
+++ b/addin/lambda-boss/Commands/GatherCommand.cs
@@ -75,7 +75,25 @@ internal static class GatherCommand
 
                 dispatcher.Invoke(() =>
                 {
-                    var window = new GatherWindow(result);
+                    // Captured closure: PR 10's Recompute reuses the same
+                    // sink/selection/source that produced the initial
+                    // result, so the dialog only has to pass row state.
+                    // The closure runs on the UI thread alongside the
+                    // dialog (no thread marshalling needed).
+                    GatherResult? Recompute(IReadOnlyList<RowState> rows)
+                    {
+                        try
+                        {
+                            return GatherEngine.Recompute(sink, selection, source, rows);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error("Gather/Recompute", ex);
+                            return null;
+                        }
+                    }
+
+                    var window = new GatherWindow(result, Recompute);
                     var wpfHwnd = new WindowInteropHelper(window).EnsureHandle();
                     WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
 

--- a/addin/lambda-boss/GatherEngine.cs
+++ b/addin/lambda-boss/GatherEngine.cs
@@ -54,6 +54,44 @@ public static class GatherEngine
     /// </summary>
     public static GatherResult? Gather(CellRef sink, IReadOnlyList<CellRef> selection, ICellSource source)
     {
+        return GatherInternal(sink, selection, source, excluded: null);
+    }
+
+    /// <summary>
+    ///     PR 10: re-runs the gather with the dialog's current row state,
+    ///     supporting the Include checkbox. Each <see cref="RowState" />
+    ///     with <see cref="RowState.Include" /> = false drops its
+    ///     <see cref="RowState.Source" /> from the LET; the walker treats
+    ///     the cell as if it didn't exist, so any precedents reachable
+    ///     only via that cell drop too. Range exclusions stop the range
+    ///     from being promoted to a binding (the literal range stays in
+    ///     the calling step's formula). Skips the multi-sink and pure-
+    ///     LAMBDA-call diagnostic checks — those gated the initial
+    ///     <see cref="Gather(CellRef, IReadOnlyList{CellRef}, ICellSource)" />
+    ///     call so the dialog wouldn't be open if either fired; cycle
+    ///     detection still runs (exclusion only removes nodes, but the
+    ///     walker's cycle check is cheap and defensive).
+    /// </summary>
+    public static GatherResult? Recompute(
+        CellRef sink,
+        IReadOnlyList<CellRef> selection,
+        ICellSource source,
+        IReadOnlyList<RowState> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        var excluded = new HashSet<FormulaRef>();
+        foreach (var r in rows)
+            if (!r.Include)
+                excluded.Add(r.Source);
+        return GatherInternal(sink, selection, source, excluded);
+    }
+
+    private static GatherResult? GatherInternal(
+        CellRef sink,
+        IReadOnlyList<CellRef> selection,
+        ICellSource source,
+        IReadOnlySet<FormulaRef>? excluded)
+    {
         ArgumentNullException.ThrowIfNull(sink);
         ArgumentNullException.ThrowIfNull(selection);
         ArgumentNullException.ThrowIfNull(source);
@@ -62,48 +100,86 @@ public static class GatherEngine
         if (sinkFormula == null)
             return null;
 
-        // Pure-LAMBDA-call sink check (PR 8). A formula like
-        // `=Foo(A1, B1)` where Foo is a registered LAMBDA can't be
-        // gathered — the cell already IS a LAMBDA invocation, so the
-        // author should expand it via /EditLambda first and then re-run
-        // /Gather on the resulting LET. TryParseLambdaCall returns
-        // non-null only when the whole formula is a single call (modulo
-        // trailing whitespace), so wrapped calls like `=Foo(A1) + 1`
-        // slip through and walk normally. The IsLambdaName check
-        // distinguishes a registered LAMBDA from a built-in like
-        // `=SUM(A1, B1)` — built-ins aren't workbook names so they
-        // also walk normally.
-        var lambdaCallDiagnostic = CheckLambdaCallSink(sink, sinkFormula, source);
-        if (lambdaCallDiagnostic != null)
-            return lambdaCallDiagnostic;
+        // Split exclusion set by ref shape: cells get propagated to the
+        // walker (which skips pushing them onto the stack), ranges stay
+        // here and gate the engine's range-promotion + coverage logic.
+        // The sink itself is exempt — the dialog never offers an Include
+        // checkbox on the sink (it's the LET body, not a binding row), so
+        // a defensive Remove keeps malformed inputs from breaking gather.
+        HashSet<CellRef>? excludedCells = null;
+        HashSet<FormulaRef>? excludedRanges = null;
+        if (excluded != null && excluded.Count > 0)
+        {
+            excludedCells = new HashSet<CellRef>();
+            excludedRanges = new HashSet<FormulaRef>();
+            foreach (var fr in excluded)
+            {
+                if (fr.IsRange)
+                    excludedRanges.Add(fr);
+                else if (!fr.Start.Equals(sink))
+                    excludedCells.Add(fr.Start);
+            }
+        }
 
-        // Multi-sink check uses the cycle-aware walker on each selected
-        // cell. If any walk hits a cycle, surface that cycle diagnostic
-        // first — cycles are an unconditional refusal, while multi-sink
-        // is selection-shape dependent.
-        var multiSinkDiagnostic = CheckMultipleSinks(sink, selection, sinkFormula, source);
-        if (multiSinkDiagnostic != null)
-            return multiSinkDiagnostic;
+        // Diagnostic checks (PR 7/8) only gate the initial Gather. On
+        // Recompute the dialog wouldn't be open if either the multi-sink
+        // or pure-LAMBDA-call rule had fired, and exclusion can't
+        // introduce them: dropping a cell can't turn a single sink into
+        // multiple sinks, and the sink's formula text doesn't change.
+        if (excluded == null)
+        {
+            // Pure-LAMBDA-call sink check (PR 8). A formula like
+            // `=Foo(A1, B1)` where Foo is a registered LAMBDA can't be
+            // gathered — the cell already IS a LAMBDA invocation, so the
+            // author should expand it via /EditLambda first and then re-run
+            // /Gather on the resulting LET. TryParseLambdaCall returns
+            // non-null only when the whole formula is a single call (modulo
+            // trailing whitespace), so wrapped calls like `=Foo(A1) + 1`
+            // slip through and walk normally. The IsLambdaName check
+            // distinguishes a registered LAMBDA from a built-in like
+            // `=SUM(A1, B1)` — built-ins aren't workbook names so they
+            // also walk normally.
+            var lambdaCallDiagnostic = CheckLambdaCallSink(sink, sinkFormula, source);
+            if (lambdaCallDiagnostic != null)
+                return lambdaCallDiagnostic;
+
+            // Multi-sink check uses the cycle-aware walker on each selected
+            // cell. If any walk hits a cycle, surface that cycle diagnostic
+            // first — cycles are an unconditional refusal, while multi-sink
+            // is selection-shape dependent.
+            var multiSinkDiagnostic = CheckMultipleSinks(sink, selection, sinkFormula, source);
+            if (multiSinkDiagnostic != null)
+                return multiSinkDiagnostic;
+        }
 
         // Free walk first — surfaces cycles ahead of any restriction work
         // and gives us "N" (the count of cells the walk would have visited
         // without restriction) for the dialog header. The restricted walk
         // is a strict sub-walk of this graph (subgraph of an acyclic graph
         // is acyclic), so cycle detection on the free walk is sufficient.
+        // The free walk doesn't apply exclusion — the dialog header reads
+        // a count of "what the walker would visit on a fresh open", which
+        // stays stable across Include toggles so the user sees one
+        // anchor count rather than a number that drifts on every click.
         var freeOutcome = CellGraphWalker.Walk(sink, source);
         if (freeOutcome.IsCycle)
             return RefusedWithCycle(sink, sinkFormula, freeOutcome.Cycle!);
 
         var freeWalkCount = freeOutcome.Cells!.Count;
 
-        // Restricted walk only when the multi-selection meaningfully
-        // narrows the walk. A single-cell selection — the common case —
-        // skips this and reuses the free walk verbatim.
+        // Restricted/excluded walk: applies the selection restriction
+        // (PR 9) and the user's Include exclusions (PR 10) together.
+        // Either narrows the visited cell set; both compose without
+        // interaction (a cell can be leaf-restricted by selection AND
+        // excluded by Include — the exclusion path wins because it's
+        // checked at push-time, before the leaf-restriction logic runs).
         WalkOutcome outcome;
-        if (selection.Count > 1)
+        var hasRestriction = selection.Count > 1;
+        var hasExclusion = excludedCells != null && excludedCells.Count > 0;
+        if (hasRestriction || hasExclusion)
         {
-            var restrictTo = new HashSet<CellRef>(selection);
-            outcome = CellGraphWalker.Walk(sink, source, restrictTo);
+            var restrictTo = hasRestriction ? new HashSet<CellRef>(selection) : null;
+            outcome = CellGraphWalker.Walk(sink, source, restrictTo, excludedCells);
         }
         else
         {
@@ -115,14 +191,20 @@ public static class GatherEngine
 
         // Collect unique range refs encountered anywhere in the walk. Order
         // is by first-encountered; that becomes the binding order for
-        // ranges (which always sort before cell bindings).
+        // ranges (which always sort before cell bindings). Excluded ranges
+        // (PR 10) skip both promotion and coverage: the literal range
+        // text stays in the calling step's formula and any cells reached
+        // via other paths reappear as their own bindings instead of being
+        // dropped under a range that no longer exists.
         var ranges = new List<FormulaRef>();
         var rangeSet = new HashSet<FormulaRef>();
         foreach (var cell in walked)
         {
             foreach (var p in cell.Precedents)
             {
-                if (p.IsRange && rangeSet.Add(p))
+                if (!p.IsRange) continue;
+                if (excludedRanges != null && excludedRanges.Contains(p)) continue;
+                if (rangeSet.Add(p))
                     ranges.Add(p);
             }
         }
@@ -176,7 +258,7 @@ public static class GatherEngine
         {
             var cellFormulaRef = new FormulaRef(cell.Ref);
             var name = nameByRef[cellFormulaRef];
-            var role = ClassifyRole(cell, nameByRef);
+            var role = ClassifyRole(cell, nameByRef, excluded);
             if (role == BindingRole.Input)
             {
                 // Bare A1 for in-sheet refs, sheet-qualified otherwise,
@@ -293,13 +375,26 @@ public static class GatherEngine
                 StripLeadingEquals(sinkFormula), source.SinkSheet, nameByRef);
         }
 
+        // PR 10: when every row was excluded (or alias-elimination
+        // collapsed the bindings to nothing) the LET would be invalid —
+        // Excel requires at least one binding pair. Emit just the body
+        // as a bare formula in that case; the synthesised result is
+        // observably the original formula minus any in-scope rewrites,
+        // which is the right output for a "gather nothing" pass.
         var sb = new StringBuilder();
         sb.Append('=');
-        FormulaFormatter.AppendLet(
-            sb,
-            indent: 0,
-            bindings.Select(b => (b.Name, b.Rhs)).ToList(),
-            bodyText);
+        if (bindings.Count == 0)
+        {
+            sb.Append(bodyText);
+        }
+        else
+        {
+            FormulaFormatter.AppendLet(
+                sb,
+                indent: 0,
+                bindings.Select(b => (b.Name, b.Rhs)).ToList(),
+                bodyText);
+        }
 
         return new GatherResult(
             sink, sinkFormula, bindings, sb.ToString(),
@@ -492,7 +587,10 @@ public static class GatherEngine
         return source.GetCellLeftText(cell);
     }
 
-    private static BindingRole ClassifyRole(WalkedCell cell, IReadOnlyDictionary<FormulaRef, string> nameByRef)
+    private static BindingRole ClassifyRole(
+        WalkedCell cell,
+        IReadOnlyDictionary<FormulaRef, string> nameByRef,
+        IReadOnlySet<FormulaRef>? excluded)
     {
         // External refs and missing-sheet refs surface here as null-formula
         // cells (the source can't reach them) and so naturally classify as
@@ -508,7 +606,19 @@ public static class GatherEngine
         // precedents is a step (RHS = rewritten formula, array semantics
         // flow through naturally); a spilling leaf is an input with RHS
         // suffixed by `#` to preserve the dynamic-array binding.
-        return cell.Precedents.Any(nameByRef.ContainsKey) ? BindingRole.Step : BindingRole.Input;
+        // PR 10: a precedent the user explicitly excluded still keeps the
+        // cell a step. The rewritten formula will carry the excluded
+        // ref's literal text (the rewriter leaves unmapped refs alone),
+        // which is the spec's "calling step keeps the cell-ref" — turning
+        // the cell into an input would discard the formula instead.
+        foreach (var p in cell.Precedents)
+        {
+            if (nameByRef.ContainsKey(p))
+                return BindingRole.Step;
+            if (excluded != null && excluded.Contains(p))
+                return BindingRole.Step;
+        }
+        return BindingRole.Input;
     }
 
     private static string StripLeadingEquals(string formula)
@@ -606,8 +716,13 @@ public static class GatherEngine
             // value/reference is an input, a calculation is a step.
             // Inputs/steps are rendered identically in the LET text — this
             // distinction only matters for the dialog's visual grouping.
+            // Inner-LET rows are flagged as expansions so the dialog can
+            // hide the Include checkbox: they share their host cell's
+            // Source and don't represent a discrete cell the user can drop
+            // independently — toggling the host cell's checkbox is the
+            // way to remove an inner LET from the gather output.
             var role = binding.IsCalculation ? BindingRole.Step : BindingRole.Input;
-            innerRows.Add(new BindingRow(hostCell, role, finalName, rhs));
+            innerRows.Add(new BindingRow(hostCell, role, finalName, rhs, IsExpansion: true));
         }
 
         var body = ApplyInnerRenames(parsed.Body, innerRenames);

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -208,13 +208,35 @@ public sealed record WalkedCell(
 ///     A finalised LET binding row in PR 1's read-only dialog. PR 2 onwards
 ///     will allow the user to edit <see cref="Name" /> and toggle role. The
 ///     <see cref="Source" /> is a single cell for cell-derived bindings and
-///     a range for range-promoted leaves (PR 4).
+///     a range for range-promoted leaves (PR 4). PR 10 adds
+///     <see cref="IsExpansion" />: rows produced by inlining an inner
+///     <c>=LET(...)</c> share their host cell's <see cref="Source" />, so
+///     they're indistinguishable from the host's own row by source alone —
+///     this flag lets the dialog hide the Include checkbox on the inner
+///     rows (the user toggles the host cell, and its inner rows follow).
 /// </summary>
 public sealed record BindingRow(
     FormulaRef Source,
     BindingRole Role,
     string Name,
-    string Rhs);
+    string Rhs,
+    bool IsExpansion = false);
+
+/// <summary>
+///     Per-row state passed to <see cref="GatherEngine.Recompute" /> by the
+///     dialog (PR 10). Carries the binding's <see cref="Source" /> — the
+///     ref the row represents — plus the user's Include choice. PR 11/12
+///     will extend this with role and name overrides; for now Include is
+///     the only field that affects engine output.
+///
+///     A row state with <see cref="Include" /> = false drops the matching
+///     ref from the LET: the binding disappears, any precedents reachable
+///     only via the dropped cell also drop, and references to the dropped
+///     cell in any calling step's formula stay as literal cell-refs (the
+///     <see cref="CellRefExtractor.Rewrite" /> path leaves unmapped refs
+///     untouched, which is exactly the spec behaviour).
+/// </summary>
+public sealed record RowState(FormulaRef Source, bool Include);
 
 public enum BindingRole
 {

--- a/addin/lambda-boss/UI/GatherWindow.xaml
+++ b/addin/lambda-boss/UI/GatherWindow.xaml
@@ -79,42 +79,48 @@
                 Background="#252526"
                 BorderBrush="#3e3e3e"
                 BorderThickness="1"
-                MaxHeight="160">
+                MaxHeight="200">
             <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <ItemsControl x:Name="BindingsList">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Grid Margin="6,3">
                                 <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="28" />
                                     <ColumnDefinition Width="56" />
                                     <ColumnDefinition Width="60" />
                                     <ColumnDefinition Width="160" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
-                                <TextBlock Grid.Column="0"
+                                <CheckBox Grid.Column="0"
+                                          IsChecked="{Binding Include, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                          Visibility="{Binding IncludeCheckboxVisibility}"
+                                          VerticalAlignment="Center"
+                                          ToolTip="Include in the synthesised LET" />
+                                <TextBlock Grid.Column="1"
                                            Text="{Binding Address}"
                                            FontFamily="Consolas"
                                            FontSize="12"
-                                           Foreground="#9cdcfe"
+                                           Foreground="{Binding AddressBrush}"
                                            VerticalAlignment="Center" />
-                                <TextBlock Grid.Column="1"
+                                <TextBlock Grid.Column="2"
                                            Text="{Binding Role}"
                                            FontFamily="Consolas"
                                            FontSize="11"
-                                           Foreground="#808080"
+                                           Foreground="{Binding RoleBrush}"
                                            VerticalAlignment="Center" />
-                                <TextBlock Grid.Column="2"
+                                <TextBlock Grid.Column="3"
                                            Text="{Binding Name}"
                                            FontFamily="Consolas"
                                            FontSize="13"
-                                           Foreground="#dcdcaa"
+                                           Foreground="{Binding NameBrush}"
                                            VerticalAlignment="Center" />
-                                <TextBlock Grid.Column="3"
+                                <TextBlock Grid.Column="4"
                                            Text="{Binding Rhs}"
                                            FontFamily="Consolas"
                                            FontSize="12"
-                                           Foreground="#cccccc"
+                                           Foreground="{Binding RhsBrush}"
                                            TextTrimming="CharacterEllipsis"
                                            VerticalAlignment="Center"
                                            ToolTip="{Binding Rhs}" />

--- a/addin/lambda-boss/UI/GatherWindow.xaml.cs
+++ b/addin/lambda-boss/UI/GatherWindow.xaml.cs
@@ -1,37 +1,55 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
 
 namespace LambdaBoss.UI;
 
 /// <summary>
-///     Read-only display of a <see cref="GatherResult" />. PR 1 wires the
-///     header, binding list, and preview pane; Save returns the engine's
-///     synthesised LET text so the caller can write it back to the sink.
-///     Editable rows, role toggles, and live re-rendering land in PR 10+.
+///     Display of a <see cref="GatherResult" /> with PR 10's Include
+///     checkbox column. Toggling Include calls back into
+///     <see cref="GatherEngine.Recompute" /> via
+///     <see cref="_recompute" />, then rebuilds the row list:
+///     re-included rows return as the engine surfaces them, explicitly-
+///     excluded rows are kept visible (greyed out, checkbox off) so the
+///     user can re-tick them, and orphaned rows that the engine no longer
+///     surfaces drop out. Save returns the synthesised LET text from the
+///     latest result so the caller writes that back to the sink.
 /// </summary>
 public partial class GatherWindow
 {
-    private readonly GatherResult _result;
+    private readonly Func<IReadOnlyList<RowState>, GatherResult?> _recompute;
+    private GatherResult _result;
+    private readonly ObservableCollection<GatherRowVm> _rows = new();
+    // Snapshots of explicitly-excluded rows so they can re-appear in the
+    // visible list after a Recompute (which only returns included
+    // bindings). Stored as plain BindingRow data — no VM subscriptions to
+    // manage across rebuilds. Re-checking removes the entry; the engine's
+    // result is the source of truth for re-included rows.
+    private readonly Dictionary<FormulaRef, BindingRow> _excluded = new();
+    // Reentrancy guard: rebuilding the row list during a Recompute fires
+    // INotifyPropertyChanged on each VM, which would re-enter the change
+    // handler and trigger another Recompute. The guard short-circuits the
+    // nested calls so a single user toggle yields exactly one Recompute.
+    private bool _suppressRecompute;
 
-    public GatherWindow(GatherResult result)
+    public GatherWindow(
+        GatherResult initial,
+        Func<IReadOnlyList<RowState>, GatherResult?> recompute)
     {
         InitializeComponent();
-        _result = result;
+        _result = initial;
+        _recompute = recompute;
 
-        WalkHintText.Text = BuildWalkHint(result);
-        SinkAddressText.Text = result.Sink.A1Address;
-        OriginalFormulaText.Text = result.OriginalFormula;
-        PreviewText.Text = result.SynthesisedLet;
+        WalkHintText.Text = BuildWalkHint(initial);
+        SinkAddressText.Text = initial.Sink.A1Address;
+        OriginalFormulaText.Text = initial.OriginalFormula;
+        PreviewText.Text = initial.SynthesisedLet;
 
-        BindingsList.ItemsSource = result.Bindings
-            .Select(b => new GatherRowDisplay
-            {
-                Address = b.Source.A1Address,
-                Role = b.Role == BindingRole.Input ? "input" : "step",
-                Name = b.Name,
-                Rhs = b.Rhs,
-            })
-            .ToList();
+        BuildRowsFromBindings(initial.Bindings);
+        BindingsList.ItemsSource = _rows;
 
         StatusText.Text = "Save writes the LET into the sink cell · Esc to cancel";
     }
@@ -64,7 +82,10 @@ public partial class GatherWindow
     ///     when the selection was multi-cell, matching the issue's "behaves
     ///     like a free walk" wording — restricting and then happening to
     ///     cover everything is observationally indistinguishable from a
-    ///     free walk and showing "N of N" reads as noise.
+    ///     free walk and showing "N of N" reads as noise. The hint stays
+    ///     stable across Include toggles — we anchor on the initial walk
+    ///     so the user has one consistent reference point rather than a
+    ///     count that drifts on every checkbox click.
     /// </summary>
     private static string BuildWalkHint(GatherResult result)
     {
@@ -92,12 +113,176 @@ public partial class GatherWindow
             e.Handled = true;
         }
     }
+
+    private void BuildRowsFromBindings(IReadOnlyList<BindingRow> bindings)
+    {
+        _suppressRecompute = true;
+        try
+        {
+            foreach (var v in _rows)
+                v.PropertyChanged -= Row_PropertyChanged;
+            _rows.Clear();
+
+            var surfaced = new HashSet<FormulaRef>();
+            foreach (var binding in bindings)
+            {
+                var vm = new GatherRowVm(binding, include: true);
+                vm.PropertyChanged += Row_PropertyChanged;
+                _rows.Add(vm);
+                surfaced.Add(binding.Source);
+            }
+
+            // Explicitly-excluded rows that the engine didn't surface
+            // appear at the bottom so the user can find them to re-tick.
+            // An excluded ref the engine still surfaces (e.g. an inner-
+            // expansion row sharing a host cell that's still in the
+            // result) is suppressed here — surfacing once avoids
+            // duplicate rows for a single Source.
+            foreach (var (source, snapshot) in _excluded)
+            {
+                if (surfaced.Contains(source)) continue;
+                var vm = new GatherRowVm(snapshot, include: false);
+                vm.PropertyChanged += Row_PropertyChanged;
+                _rows.Add(vm);
+            }
+        }
+        finally
+        {
+            _suppressRecompute = false;
+        }
+    }
+
+    private void Row_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_suppressRecompute) return;
+        if (e.PropertyName != nameof(GatherRowVm.Include)) return;
+        if (sender is not GatherRowVm vm) return;
+
+        // Snapshot when unchecking so the row stays visible for re-tick;
+        // forget the snapshot when re-checking so the engine result
+        // owns the row's display (Role/Name/Rhs may have shifted as
+        // other rows toggled in the meantime).
+        if (!vm.Include)
+        {
+            _excluded[vm.Source] = new BindingRow(
+                vm.Source, vm.RoleEnum, vm.Name, vm.Rhs, vm.IsExpansion);
+        }
+        else
+        {
+            _excluded.Remove(vm.Source);
+        }
+
+        Recompute();
+    }
+
+    private void Recompute()
+    {
+        // Build RowState list from the visible rows. Inner-LET rows are
+        // skipped because they share a Source with their host cell — the
+        // host's row owns the toggle, so passing the inner rows' state
+        // would double-flag their Source.
+        var states = new List<RowState>(_rows.Count);
+        var seen = new HashSet<FormulaRef>();
+        foreach (var vm in _rows)
+        {
+            if (vm.IsExpansion) continue;
+            if (!seen.Add(vm.Source)) continue;
+            states.Add(new RowState(vm.Source, vm.Include));
+        }
+
+        var newResult = _recompute(states);
+        if (newResult == null || newResult.Diagnostic != null)
+        {
+            // Defensive: a Recompute shouldn't return null or a
+            // diagnostic for a sink that gathered cleanly the first
+            // time — exclusion only removes nodes. If it does (e.g. the
+            // workbook changed under us), leave the dialog state as-is
+            // and skip the rebuild.
+            return;
+        }
+
+        _result = newResult;
+        PreviewText.Text = newResult.SynthesisedLet;
+        BuildRowsFromBindings(newResult.Bindings);
+    }
 }
 
-internal sealed class GatherRowDisplay
+/// <summary>
+///     Row view-model bound to <see cref="GatherWindow" />'s ItemsControl.
+///     Carries the row's static identity (Source, IsExpansion) plus the
+///     mutable Include flag; engine-driven fields (Role, Name, Rhs) are
+///     immutable per VM instance — a Recompute rebuilds the collection
+///     rather than mutating individual rows, so we don't need INPCC
+///     plumbing on those fields.
+/// </summary>
+public class GatherRowVm : INotifyPropertyChanged
 {
-    public string Address { get; init; } = "";
-    public string Role { get; init; } = "";
-    public string Name { get; init; } = "";
-    public string Rhs { get; init; } = "";
+    private static readonly Brush ActiveAddressBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#9cdcfe"));
+    private static readonly Brush ActiveRoleBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#808080"));
+    private static readonly Brush ActiveNameBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#dcdcaa"));
+    private static readonly Brush ActiveRhsBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#cccccc"));
+    private static readonly Brush MutedBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#6a6a6a"));
+
+    private bool _include;
+
+    public GatherRowVm(BindingRow binding, bool include)
+    {
+        Source = binding.Source;
+        RoleEnum = binding.Role;
+        Name = binding.Name;
+        Rhs = binding.Rhs;
+        IsExpansion = binding.IsExpansion;
+        _include = include;
+    }
+
+    public FormulaRef Source { get; }
+    public BindingRole RoleEnum { get; }
+    public string Address => Source.A1Address;
+    public string Role => RoleEnum == BindingRole.Input ? "input" : "step";
+    public string Name { get; }
+    public string Rhs { get; }
+    public bool IsExpansion { get; }
+
+    public bool Include
+    {
+        get => _include;
+        set
+        {
+            if (_include == value) return;
+            _include = value;
+            OnPropertyChanged();
+            // Brushes change with Include — mute when off so excluded
+            // rows visibly read as "kept around for re-tick" rather than
+            // active bindings.
+            OnPropertyChanged(nameof(AddressBrush));
+            OnPropertyChanged(nameof(RoleBrush));
+            OnPropertyChanged(nameof(NameBrush));
+            OnPropertyChanged(nameof(RhsBrush));
+        }
+    }
+
+    /// <summary>
+    ///     Inner-LET expansion rows hide their checkbox: the host cell
+    ///     drives the toggle, and a checkbox here would be a confusing
+    ///     no-op (the engine doesn't expose per-inner-binding exclusion).
+    /// </summary>
+    public Visibility IncludeCheckboxVisibility =>
+        IsExpansion ? Visibility.Hidden : Visibility.Visible;
+
+    public Brush AddressBrush => Include ? ActiveAddressBrush : MutedBrush;
+    public Brush RoleBrush => Include ? ActiveRoleBrush : MutedBrush;
+    public Brush NameBrush => Include ? ActiveNameBrush : MutedBrush;
+    public Brush RhsBrush => Include ? ActiveRhsBrush : MutedBrush;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? prop = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+    }
 }


### PR DESCRIPTION
## Summary

- Each binding row in `GatherWindow` now has an Include checkbox. Toggling it off calls `GatherEngine.Recompute`, which re-walks from scratch with the cell excluded — any precedents reachable only via the dropped cell also drop, while the calling step keeps the literal cell-ref. Re-toggling pulls the cell (and any newly-reachable precedents) back.
- New `RowState(Source, Include)` carries dialog state into the engine. Excluded ranges skip range promotion + coverage so cells reached via other paths reappear. Excluded refs that still appear in a step's formula keep that step a step (rather than demoting to input) so the literal cell-ref text is preserved.
- The dialog snapshots explicitly-excluded rows in `_excluded` so they stay visible (greyed, checkbox off) at the bottom of the list for re-tick. Inner-LET expansion rows hide their checkbox via `BindingRow.IsExpansion` — the host cell's toggle drives them.
- When every binding is dropped, the engine emits a bare formula (Excel rejects `LET` with zero bindings); the synthesised output is the original formula minus any in-scope rewrites, which is the right "gather nothing" result.
- Header hint stays anchored on the initial walk counts so the user has one stable reference point as they toggle.

Closes #140

## Test plan

Engine unit tests cover the acceptance criteria:
- [x] Recompute_ExcludeLeaf — drops the leaf row, calling step keeps `A1` literal in its RHS.
- [x] Recompute_ExcludeStep_Cascades — dropping a step orphans its sole-path precedents.
- [x] Recompute_ExcludeBranch_Preserves — diamond graph, dropping one branch keeps the other.
- [x] Recompute_RetoggleRestores — re-checking restores the row and its precedents to the original LET shape.
- [x] Recompute_MultiBranch — excluded cell that's reached via another branch isn't orphaned.
- [x] Recompute_StepWithNoInScopePrecedents — step keeps Step role with literal refs (would otherwise demote to input).
- [x] Recompute_ExcludeRange — literal range stays in calling step's formula.
- [x] Recompute_AllIncluded_MatchesGather — sanity check that Recompute matches Gather when nothing's excluded.
- [x] Recompute_LetRoundTripsThroughLetParser — round-trip safety on the new path.

Manual Excel smoke (per the issue):
- [x] Build a chain A1=10, B1=`=A1*2`, C1=`=B1+1`. `/Gather` → uncheck B1 → preview body shows `B1+1`, A1 also drops. Re-tick B1 → original LET back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)