### PR TITLE
Gather: keep demoted steps' orphaned precedents visible

### DIFF
--- a/addin/lambda-boss.Tests/OrphanedRowTrackerTests.cs
+++ b/addin/lambda-boss.Tests/OrphanedRowTrackerTests.cs
@@ -278,6 +278,38 @@ public sealed class OrphanedRowTrackerTests
     }
 
     [Fact]
+    public void Reconcile_ReincludedCellStillBlockedByDemote_LandsInOrphans()
+    {
+        // Edge case: user excluded x, demoted y (which cuts x's only
+        // path), then re-ticked x. The dialog asks the tracker to
+        // record what fell off, with causedBy = the still-active
+        // blocker (y) found via the dialog's FindCurrentBlocker
+        // heuristic. x is in snapshotBefore (vm.Include just flipped
+        // to true) but not in activeAfter (engine can't reach it
+        // through the demoted y). Tracker records x as orphaned-by-y
+        // so the user sees where to look — promoting y brings x back.
+        var x = Cell("X1");
+        var y = Cell("Y1");
+
+        var before = new Dictionary<FormulaRef, BindingRow>
+        {
+            [x] = Row(x, BindingRole.Input, "x_name", "X1"),
+            // y appears as input because the dialog passes its
+            // current (demoted) shape; engine still surfaces it.
+            [y] = Row(y, BindingRole.Input, "y_name", "Y1")
+        };
+        var after = new HashSet<FormulaRef> { y };
+        var excluded = new HashSet<FormulaRef>();
+
+        var tracker = new OrphanedRowTracker();
+        tracker.Reconcile(before, after, excluded, y);
+
+        Assert.True(tracker.HasOrphans);
+        Assert.Single(tracker.Orphans);
+        Assert.Equal(y, tracker.Orphans[x].CausedBy);
+    }
+
+    [Fact]
     public void Reconcile_ReincludeAfterExclude_OrphansClearViaResurfacing()
     {
         // Exclude B1 → A1 orphan. Re-include B1 → A1 surfaces again

--- a/addin/lambda-boss.Tests/OrphanedRowTrackerTests.cs
+++ b/addin/lambda-boss.Tests/OrphanedRowTrackerTests.cs
@@ -1,0 +1,345 @@
+using LambdaBoss;
+using LambdaBoss.UI;
+
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+/// <summary>
+///     Unit tests for <see cref="OrphanedRowTracker" />, the dialog's
+///     bookkeeping for the orphaned-rows section. The tracker is pure
+///     state — no engine or WPF coupling — so the diff logic between
+///     before/after Recompute snapshots is exercisable directly. The
+///     companion engine tests (GatherEngineTests) cover the underlying
+///     orphan behaviour; these tests just verify that the dialog
+///     records and clears orphans correctly across the user's
+///     toggling actions.
+/// </summary>
+public sealed class OrphanedRowTrackerTests
+{
+    [Fact]
+    public void Reconcile_DemoteCausesPrecedentToDrop_RecordsOrphan()
+    {
+        // Active before: A1, B1. After demoting B1 → A1 drops out
+        // (only reachable via B1). Tracker records A1 as orphaned-by-B1.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+
+        var before = new Dictionary<FormulaRef, BindingRow>
+        {
+            [a1] = Row(a1, BindingRole.Input, "numbers", "A1"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "numbers*2"),
+        };
+        var after = new HashSet<FormulaRef> { b1 };
+        var excluded = new HashSet<FormulaRef>();
+
+        var tracker = new OrphanedRowTracker();
+        tracker.Reconcile(before, after, excluded, demotedCell: b1);
+
+        Assert.True(tracker.HasOrphans);
+        Assert.Single(tracker.Orphans);
+        var orphan = tracker.Orphans[a1];
+        Assert.Equal(b1, orphan.DemotedBy);
+        Assert.Equal("numbers", orphan.Snapshot.Name);
+        Assert.Equal("A1", orphan.Snapshot.Rhs);
+    }
+
+    [Fact]
+    public void Reconcile_DemoteWithoutOrphans_RecordsNothing()
+    {
+        // Demoting a step whose precedents are still reachable via
+        // another path produces no orphans — the precedent stays in
+        // the active list, so the tracker has nothing to record.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+        var c1 = Cell("C1");
+
+        var before = new Dictionary<FormulaRef, BindingRow>
+        {
+            [a1] = Row(a1, BindingRole.Input, "n", "A1"),
+            [b1] = Row(b1, BindingRole.Step, "double", "n*2"),
+            [c1] = Row(c1, BindingRole.Step, "another", "n+1"),
+        };
+        // After demoting B1, A1 still reachable via C1's reference, so
+        // it stays active. Only B1's role flipped.
+        var after = new HashSet<FormulaRef> { a1, b1, c1 };
+        var excluded = new HashSet<FormulaRef>();
+
+        var tracker = new OrphanedRowTracker();
+        tracker.Reconcile(before, after, excluded, demotedCell: b1);
+
+        Assert.False(tracker.HasOrphans);
+    }
+
+    [Fact]
+    public void Reconcile_DemotedCellItself_IsNotOrphaned()
+    {
+        // The demoted cell stays as a binding (input role, RHS = cell-
+        // ref) — it's not an orphan even though its old step-shaped
+        // snapshot might look "dropped" if you only diff active sets.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+
+        var before = new Dictionary<FormulaRef, BindingRow>
+        {
+            [a1] = Row(a1, BindingRole.Input, "numbers", "A1"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "numbers*2"),
+        };
+        // Pretend after Recompute, B1 is in the active list as input.
+        var after = new HashSet<FormulaRef> { b1 };
+        var excluded = new HashSet<FormulaRef>();
+
+        var tracker = new OrphanedRowTracker();
+        tracker.Reconcile(before, after, excluded, demotedCell: b1);
+
+        Assert.DoesNotContain(b1, tracker.Orphans);
+        // A1 dropped — it's the orphan.
+        Assert.Contains(a1, tracker.Orphans);
+    }
+
+    [Fact]
+    public void Reconcile_ExcludedCellThatDropsOnDemote_IsNotOrphaned()
+    {
+        // A cell the user already excluded gets its excluded-row
+        // treatment (greyed snapshot, re-tickable). When a later demote
+        // happens to also drop it from the active set, the tracker
+        // skips it — it's already accounted for in the excluded lane.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+
+        var before = new Dictionary<FormulaRef, BindingRow>
+        {
+            [b1] = Row(b1, BindingRole.Step, "step_1", "A1*2"),
+        };
+        var after = new HashSet<FormulaRef> { b1 };
+        var excluded = new HashSet<FormulaRef> { a1 };
+
+        var tracker = new OrphanedRowTracker();
+        tracker.Reconcile(before, after, excluded, demotedCell: b1);
+
+        Assert.False(tracker.HasOrphans);
+    }
+
+    [Fact]
+    public void Reconcile_NonDemoteRecompute_DoesNotAddOrphans()
+    {
+        // A Recompute with no demotedCell (e.g. user toggled Include or
+        // promoted) shouldn't add orphan entries even if the active set
+        // shrank. Promote-driven shrinkage doesn't happen in practice
+        // (promote can only add precedents) but the contract is still:
+        // "no demote ⇒ no new orphans."
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+
+        var before = new Dictionary<FormulaRef, BindingRow>
+        {
+            [a1] = Row(a1, BindingRole.Input, "n", "A1"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "n*2"),
+        };
+        var after = new HashSet<FormulaRef> { b1 };
+        var excluded = new HashSet<FormulaRef>();
+
+        var tracker = new OrphanedRowTracker();
+        tracker.Reconcile(before, after, excluded, demotedCell: null);
+
+        Assert.False(tracker.HasOrphans);
+    }
+
+    [Fact]
+    public void Reconcile_OrphanResurfacesInActiveSet_IsDropped()
+    {
+        // An orphan that's been recorded should be dropped if a later
+        // Recompute surfaces its cell again in the active set — its
+        // "orphaned by X" label no longer reflects reality.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+
+        var tracker = new OrphanedRowTracker();
+        var before1 = new Dictionary<FormulaRef, BindingRow>
+        {
+            [a1] = Row(a1, BindingRole.Input, "n", "A1"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "n*2"),
+        };
+        tracker.Reconcile(before1, new HashSet<FormulaRef> { b1 }, new HashSet<FormulaRef>(), b1);
+        Assert.True(tracker.HasOrphans);
+
+        // Some later Recompute surfaces A1 again (e.g. user promoted
+        // some other cell whose formula refs A1). Tracker should drop
+        // the orphan record.
+        var before2 = new Dictionary<FormulaRef, BindingRow>
+        {
+            [b1] = Row(b1, BindingRole.Input, "step_1", "B1"),
+        };
+        tracker.Reconcile(
+            before2,
+            new HashSet<FormulaRef> { a1, b1 },
+            new HashSet<FormulaRef>(),
+            demotedCell: null);
+
+        Assert.False(tracker.HasOrphans);
+    }
+
+    [Fact]
+    public void OnPromote_DropsOrphansAttributedToTheCell()
+    {
+        // Demote B1 → A1 orphans. Then promote B1 — A1 should clear
+        // from the orphan list (the engine will surface A1 again on
+        // the subsequent Recompute, but the tracker drops its own
+        // entry up-front so the dialog's reconcile pass doesn't see
+        // a stale orphan during the rebuild).
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+
+        var tracker = new OrphanedRowTracker();
+        var before = new Dictionary<FormulaRef, BindingRow>
+        {
+            [a1] = Row(a1, BindingRole.Input, "n", "A1"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "n*2"),
+        };
+        tracker.Reconcile(before, new HashSet<FormulaRef> { b1 }, new HashSet<FormulaRef>(), b1);
+        Assert.True(tracker.HasOrphans);
+
+        tracker.OnPromote(b1);
+
+        Assert.False(tracker.HasOrphans);
+    }
+
+    [Fact]
+    public void OnPromote_LeavesOrphansFromOtherDemotersIntact()
+    {
+        // Two independent demotes orphan two different cells. Promoting
+        // only one demoter clears its own orphans without disturbing
+        // the others.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+        var c1 = Cell("C1");
+        var d1 = Cell("D1");
+
+        var tracker = new OrphanedRowTracker();
+        // Demote 1: B1 demoted, A1 orphans.
+        tracker.Reconcile(
+            new Dictionary<FormulaRef, BindingRow>
+            {
+                [a1] = Row(a1, BindingRole.Input, "a", "A1"),
+                [b1] = Row(b1, BindingRole.Step, "step_b", "a*2"),
+            },
+            new HashSet<FormulaRef> { b1 },
+            new HashSet<FormulaRef>(),
+            b1);
+        // Demote 2: D1 demoted, C1 orphans.
+        tracker.Reconcile(
+            new Dictionary<FormulaRef, BindingRow>
+            {
+                [c1] = Row(c1, BindingRole.Input, "c", "C1"),
+                [d1] = Row(d1, BindingRole.Step, "step_d", "c+1"),
+            },
+            new HashSet<FormulaRef> { d1, b1 },
+            new HashSet<FormulaRef>(),
+            d1);
+        Assert.Equal(2, tracker.Orphans.Count);
+
+        tracker.OnPromote(b1);
+
+        Assert.Single(tracker.Orphans);
+        Assert.Contains(c1, tracker.Orphans);
+    }
+
+    [Fact]
+    public void Reconcile_UnrelatedRoleChangeAfterDemote_PreservesOrphan()
+    {
+        // After a demote orphans A1, an unrelated role change shouldn't
+        // unintentionally clear A1 from the orphan list. The acceptance
+        // criteria call this out explicitly: changing one row's role
+        // doesn't drop another row's orphan-by attribution.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+        var c1 = Cell("C1");
+        var d1 = Cell("D1");
+
+        var tracker = new OrphanedRowTracker();
+        // Demote B1 → A1 orphans.
+        tracker.Reconcile(
+            new Dictionary<FormulaRef, BindingRow>
+            {
+                [a1] = Row(a1, BindingRole.Input, "a", "A1"),
+                [b1] = Row(b1, BindingRole.Step, "b", "a*2"),
+                [c1] = Row(c1, BindingRole.Input, "c", "C1"),
+                [d1] = Row(d1, BindingRole.Step, "d", "c+1"),
+            },
+            new HashSet<FormulaRef> { b1, c1, d1 },
+            new HashSet<FormulaRef>(),
+            b1);
+        Assert.True(tracker.HasOrphans);
+        Assert.Contains(a1, tracker.Orphans);
+
+        // Now demote D1 → C1 orphans. A1 should still be in orphans.
+        tracker.Reconcile(
+            new Dictionary<FormulaRef, BindingRow>
+            {
+                [b1] = Row(b1, BindingRole.Input, "b", "B1"),
+                [c1] = Row(c1, BindingRole.Input, "c", "C1"),
+                [d1] = Row(d1, BindingRole.Step, "d", "c+1"),
+            },
+            new HashSet<FormulaRef> { b1, d1 },
+            new HashSet<FormulaRef>(),
+            d1);
+
+        Assert.Equal(2, tracker.Orphans.Count);
+        Assert.Contains(a1, tracker.Orphans);
+        Assert.Contains(c1, tracker.Orphans);
+        Assert.Equal(b1, tracker.Orphans[a1].DemotedBy);
+        Assert.Equal(d1, tracker.Orphans[c1].DemotedBy);
+    }
+
+    [Fact]
+    public void Reconcile_AlreadyTrackedOrphan_IsNotReattributed()
+    {
+        // A cell already attributed to demoter X shouldn't get re-
+        // attributed to a later demoter Y just because Y's Recompute
+        // happens to also drop it from the active list. First-write
+        // wins — the original demote is the cause of record.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+        var c1 = Cell("C1");
+
+        var tracker = new OrphanedRowTracker();
+        // Demote B1 → A1 orphans (attributed to B1).
+        tracker.Reconcile(
+            new Dictionary<FormulaRef, BindingRow>
+            {
+                [a1] = Row(a1, BindingRole.Input, "a", "A1"),
+                [b1] = Row(b1, BindingRole.Step, "b", "a*2"),
+            },
+            new HashSet<FormulaRef> { b1 },
+            new HashSet<FormulaRef>(),
+            b1);
+        Assert.Equal(b1, tracker.Orphans[a1].DemotedBy);
+
+        // Now demote C1 — A1 still doesn't reappear in the active list
+        // (it's still orphaned). Second Reconcile shouldn't re-attribute
+        // A1 to C1.
+        tracker.Reconcile(
+            new Dictionary<FormulaRef, BindingRow>
+            {
+                [b1] = Row(b1, BindingRole.Input, "b", "B1"),
+                [c1] = Row(c1, BindingRole.Step, "c", "B1+1"),
+            },
+            new HashSet<FormulaRef> { b1, c1 },
+            new HashSet<FormulaRef>(),
+            c1);
+
+        Assert.Equal(b1, tracker.Orphans[a1].DemotedBy);
+    }
+
+    private static FormulaRef Cell(string a1)
+    {
+        var i = 0;
+        while (i < a1.Length && char.IsLetter(a1[i])) i++;
+        var col = CellRef.LettersToColumn(a1[..i]);
+        var row = int.Parse(a1[i..]);
+        return new FormulaRef(new CellRef("Sheet1", col, row));
+    }
+
+    private static BindingRow Row(FormulaRef source, BindingRole role, string name, string rhs) =>
+        new(source, role, name, rhs, IsExpansion: false, CanToggleRole: true);
+}

--- a/addin/lambda-boss.Tests/OrphanedRowTrackerTests.cs
+++ b/addin/lambda-boss.Tests/OrphanedRowTrackerTests.cs
@@ -39,7 +39,7 @@ public sealed class OrphanedRowTrackerTests
         Assert.True(tracker.HasOrphans);
         Assert.Single(tracker.Orphans);
         var orphan = tracker.Orphans[a1];
-        Assert.Equal(b1, orphan.DemotedBy);
+        Assert.Equal(b1, orphan.CausedBy);
         Assert.Equal("numbers", orphan.Snapshot.Name);
         Assert.Equal("A1", orphan.Snapshot.Rhs);
     }
@@ -180,7 +180,7 @@ public sealed class OrphanedRowTrackerTests
     }
 
     [Fact]
-    public void OnPromote_DropsOrphansAttributedToTheCell()
+    public void Forget_DropsOrphansAttributedToTheCell()
     {
         // Demote B1 → A1 orphans. Then promote B1 — A1 should clear
         // from the orphan list (the engine will surface A1 again on
@@ -199,24 +199,24 @@ public sealed class OrphanedRowTrackerTests
         tracker.Reconcile(before, new HashSet<FormulaRef> { b1 }, new HashSet<FormulaRef>(), b1);
         Assert.True(tracker.HasOrphans);
 
-        tracker.OnPromote(b1);
+        tracker.Forget(b1);
 
         Assert.False(tracker.HasOrphans);
     }
 
     [Fact]
-    public void OnPromote_LeavesOrphansFromOtherDemotersIntact()
+    public void Forget_LeavesOrphansFromOtherCausersIntact()
     {
-        // Two independent demotes orphan two different cells. Promoting
-        // only one demoter clears its own orphans without disturbing
-        // the others.
+        // Two independent causes orphan two different cells (one
+        // demote, one exclude). Reversing only one of them clears its
+        // own orphans without disturbing the others.
         var a1 = Cell("A1");
         var b1 = Cell("B1");
         var c1 = Cell("C1");
         var d1 = Cell("D1");
 
         var tracker = new OrphanedRowTracker();
-        // Demote 1: B1 demoted, A1 orphans.
+        // Cause 1: B1 demoted → A1 orphans.
         tracker.Reconcile(
             new Dictionary<FormulaRef, BindingRow>
             {
@@ -226,22 +226,89 @@ public sealed class OrphanedRowTrackerTests
             new HashSet<FormulaRef> { b1 },
             new HashSet<FormulaRef>(),
             b1);
-        // Demote 2: D1 demoted, C1 orphans.
+        // Cause 2: D1 excluded → C1 orphans (D1 leaves snapshotBefore
+        // before Reconcile is called — same flow as the dialog's
+        // Recompute, where the just-excluded cell is filtered out
+        // before snapshotting; the cell is still passed as causedBy).
         tracker.Reconcile(
             new Dictionary<FormulaRef, BindingRow>
             {
                 [c1] = Row(c1, BindingRole.Input, "c", "C1"),
-                [d1] = Row(d1, BindingRole.Step, "step_d", "c+1")
             },
-            new HashSet<FormulaRef> { d1, b1 },
-            new HashSet<FormulaRef>(),
+            new HashSet<FormulaRef> { b1 },
+            new HashSet<FormulaRef> { d1 },
             d1);
         Assert.Equal(2, tracker.Orphans.Count);
 
-        tracker.OnPromote(b1);
+        tracker.Forget(b1);
 
         Assert.Single(tracker.Orphans);
         Assert.Contains(c1, tracker.Orphans);
+        Assert.Equal(d1, tracker.Orphans[c1].CausedBy);
+    }
+
+    [Fact]
+    public void Reconcile_ExcludeStepCausesPrecedentToDrop_RecordsOrphan()
+    {
+        // Mirror of the demote scenario, via the Include path. The
+        // excluded step itself is filtered out of activeBefore by the
+        // dialog (the just-excluded row's vm.Include is false at
+        // snapshot time), but it's still passed as causedBy. A1 was
+        // active and reachable only via B1, so the exclude drops it
+        // — tracker records A1 as orphaned-by-B1.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+
+        var before = new Dictionary<FormulaRef, BindingRow>
+        {
+            [a1] = Row(a1, BindingRole.Input, "numbers", "A1"),
+            // B1 deliberately absent — vm.Include just flipped to
+            // false in the dialog before Recompute, so it's filtered
+            // out of activeBefore.
+        };
+        var after = new HashSet<FormulaRef>();
+        var excluded = new HashSet<FormulaRef> { b1 };
+
+        var tracker = new OrphanedRowTracker();
+        tracker.Reconcile(before, after, excluded, b1);
+
+        Assert.True(tracker.HasOrphans);
+        Assert.Single(tracker.Orphans);
+        Assert.Equal(b1, tracker.Orphans[a1].CausedBy);
+    }
+
+    [Fact]
+    public void Reconcile_ReincludeAfterExclude_OrphansClearViaResurfacing()
+    {
+        // Exclude B1 → A1 orphan. Re-include B1 → A1 surfaces again
+        // in activeAfter. Reconcile alone (without an explicit Forget
+        // call) drops A1 from orphans because the engine restored it.
+        var a1 = Cell("A1");
+        var b1 = Cell("B1");
+
+        var tracker = new OrphanedRowTracker();
+        // Exclude B1 → A1 orphans.
+        tracker.Reconcile(
+            new Dictionary<FormulaRef, BindingRow>
+            {
+                [a1] = Row(a1, BindingRole.Input, "n", "A1"),
+            },
+            new HashSet<FormulaRef>(),
+            new HashSet<FormulaRef> { b1 },
+            b1);
+        Assert.True(tracker.HasOrphans);
+
+        // User re-includes B1; engine restores A1 to active. The dialog
+        // calls Forget(B1) up-front (covered by Forget tests above)
+        // and Reconcile with no causedBy. Even without Forget, the
+        // resurfacing path drops the orphan.
+        tracker.Reconcile(
+            new Dictionary<FormulaRef, BindingRow>(),
+            new HashSet<FormulaRef> { a1, b1 },
+            new HashSet<FormulaRef>(),
+            null);
+
+        Assert.False(tracker.HasOrphans);
     }
 
     [Fact]
@@ -287,8 +354,8 @@ public sealed class OrphanedRowTrackerTests
         Assert.Equal(2, tracker.Orphans.Count);
         Assert.Contains(a1, tracker.Orphans);
         Assert.Contains(c1, tracker.Orphans);
-        Assert.Equal(b1, tracker.Orphans[a1].DemotedBy);
-        Assert.Equal(d1, tracker.Orphans[c1].DemotedBy);
+        Assert.Equal(b1, tracker.Orphans[a1].CausedBy);
+        Assert.Equal(d1, tracker.Orphans[c1].CausedBy);
     }
 
     [Fact]
@@ -313,7 +380,7 @@ public sealed class OrphanedRowTrackerTests
             new HashSet<FormulaRef> { b1 },
             new HashSet<FormulaRef>(),
             b1);
-        Assert.Equal(b1, tracker.Orphans[a1].DemotedBy);
+        Assert.Equal(b1, tracker.Orphans[a1].CausedBy);
 
         // Now demote C1 — A1 still doesn't reappear in the active list
         // (it's still orphaned). Second Reconcile shouldn't re-attribute
@@ -328,7 +395,7 @@ public sealed class OrphanedRowTrackerTests
             new HashSet<FormulaRef>(),
             c1);
 
-        Assert.Equal(b1, tracker.Orphans[a1].DemotedBy);
+        Assert.Equal(b1, tracker.Orphans[a1].CausedBy);
     }
 
     private static FormulaRef Cell(string a1)

--- a/addin/lambda-boss.Tests/OrphanedRowTrackerTests.cs
+++ b/addin/lambda-boss.Tests/OrphanedRowTrackerTests.cs
@@ -1,7 +1,7 @@
-using LambdaBoss;
 using LambdaBoss.UI;
-
 using Xunit;
+
+// ReSharper disable CollectionNeverUpdated.Local
 
 namespace LambdaBoss.Tests;
 
@@ -28,13 +28,13 @@ public sealed class OrphanedRowTrackerTests
         var before = new Dictionary<FormulaRef, BindingRow>
         {
             [a1] = Row(a1, BindingRole.Input, "numbers", "A1"),
-            [b1] = Row(b1, BindingRole.Step, "step_1", "numbers*2"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "numbers*2")
         };
         var after = new HashSet<FormulaRef> { b1 };
         var excluded = new HashSet<FormulaRef>();
 
         var tracker = new OrphanedRowTracker();
-        tracker.Reconcile(before, after, excluded, demotedCell: b1);
+        tracker.Reconcile(before, after, excluded, b1);
 
         Assert.True(tracker.HasOrphans);
         Assert.Single(tracker.Orphans);
@@ -58,7 +58,7 @@ public sealed class OrphanedRowTrackerTests
         {
             [a1] = Row(a1, BindingRole.Input, "n", "A1"),
             [b1] = Row(b1, BindingRole.Step, "double", "n*2"),
-            [c1] = Row(c1, BindingRole.Step, "another", "n+1"),
+            [c1] = Row(c1, BindingRole.Step, "another", "n+1")
         };
         // After demoting B1, A1 still reachable via C1's reference, so
         // it stays active. Only B1's role flipped.
@@ -66,7 +66,7 @@ public sealed class OrphanedRowTrackerTests
         var excluded = new HashSet<FormulaRef>();
 
         var tracker = new OrphanedRowTracker();
-        tracker.Reconcile(before, after, excluded, demotedCell: b1);
+        tracker.Reconcile(before, after, excluded, b1);
 
         Assert.False(tracker.HasOrphans);
     }
@@ -83,14 +83,14 @@ public sealed class OrphanedRowTrackerTests
         var before = new Dictionary<FormulaRef, BindingRow>
         {
             [a1] = Row(a1, BindingRole.Input, "numbers", "A1"),
-            [b1] = Row(b1, BindingRole.Step, "step_1", "numbers*2"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "numbers*2")
         };
         // Pretend after Recompute, B1 is in the active list as input.
         var after = new HashSet<FormulaRef> { b1 };
         var excluded = new HashSet<FormulaRef>();
 
         var tracker = new OrphanedRowTracker();
-        tracker.Reconcile(before, after, excluded, demotedCell: b1);
+        tracker.Reconcile(before, after, excluded, b1);
 
         Assert.DoesNotContain(b1, tracker.Orphans);
         // A1 dropped — it's the orphan.
@@ -109,13 +109,13 @@ public sealed class OrphanedRowTrackerTests
 
         var before = new Dictionary<FormulaRef, BindingRow>
         {
-            [b1] = Row(b1, BindingRole.Step, "step_1", "A1*2"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "A1*2")
         };
         var after = new HashSet<FormulaRef> { b1 };
         var excluded = new HashSet<FormulaRef> { a1 };
 
         var tracker = new OrphanedRowTracker();
-        tracker.Reconcile(before, after, excluded, demotedCell: b1);
+        tracker.Reconcile(before, after, excluded, b1);
 
         Assert.False(tracker.HasOrphans);
     }
@@ -134,13 +134,13 @@ public sealed class OrphanedRowTrackerTests
         var before = new Dictionary<FormulaRef, BindingRow>
         {
             [a1] = Row(a1, BindingRole.Input, "n", "A1"),
-            [b1] = Row(b1, BindingRole.Step, "step_1", "n*2"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "n*2")
         };
         var after = new HashSet<FormulaRef> { b1 };
         var excluded = new HashSet<FormulaRef>();
 
         var tracker = new OrphanedRowTracker();
-        tracker.Reconcile(before, after, excluded, demotedCell: null);
+        tracker.Reconcile(before, after, excluded, null);
 
         Assert.False(tracker.HasOrphans);
     }
@@ -158,7 +158,7 @@ public sealed class OrphanedRowTrackerTests
         var before1 = new Dictionary<FormulaRef, BindingRow>
         {
             [a1] = Row(a1, BindingRole.Input, "n", "A1"),
-            [b1] = Row(b1, BindingRole.Step, "step_1", "n*2"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "n*2")
         };
         tracker.Reconcile(before1, new HashSet<FormulaRef> { b1 }, new HashSet<FormulaRef>(), b1);
         Assert.True(tracker.HasOrphans);
@@ -168,13 +168,13 @@ public sealed class OrphanedRowTrackerTests
         // the orphan record.
         var before2 = new Dictionary<FormulaRef, BindingRow>
         {
-            [b1] = Row(b1, BindingRole.Input, "step_1", "B1"),
+            [b1] = Row(b1, BindingRole.Input, "step_1", "B1")
         };
         tracker.Reconcile(
             before2,
             new HashSet<FormulaRef> { a1, b1 },
             new HashSet<FormulaRef>(),
-            demotedCell: null);
+            null);
 
         Assert.False(tracker.HasOrphans);
     }
@@ -194,7 +194,7 @@ public sealed class OrphanedRowTrackerTests
         var before = new Dictionary<FormulaRef, BindingRow>
         {
             [a1] = Row(a1, BindingRole.Input, "n", "A1"),
-            [b1] = Row(b1, BindingRole.Step, "step_1", "n*2"),
+            [b1] = Row(b1, BindingRole.Step, "step_1", "n*2")
         };
         tracker.Reconcile(before, new HashSet<FormulaRef> { b1 }, new HashSet<FormulaRef>(), b1);
         Assert.True(tracker.HasOrphans);
@@ -221,7 +221,7 @@ public sealed class OrphanedRowTrackerTests
             new Dictionary<FormulaRef, BindingRow>
             {
                 [a1] = Row(a1, BindingRole.Input, "a", "A1"),
-                [b1] = Row(b1, BindingRole.Step, "step_b", "a*2"),
+                [b1] = Row(b1, BindingRole.Step, "step_b", "a*2")
             },
             new HashSet<FormulaRef> { b1 },
             new HashSet<FormulaRef>(),
@@ -231,7 +231,7 @@ public sealed class OrphanedRowTrackerTests
             new Dictionary<FormulaRef, BindingRow>
             {
                 [c1] = Row(c1, BindingRole.Input, "c", "C1"),
-                [d1] = Row(d1, BindingRole.Step, "step_d", "c+1"),
+                [d1] = Row(d1, BindingRole.Step, "step_d", "c+1")
             },
             new HashSet<FormulaRef> { d1, b1 },
             new HashSet<FormulaRef>(),
@@ -264,7 +264,7 @@ public sealed class OrphanedRowTrackerTests
                 [a1] = Row(a1, BindingRole.Input, "a", "A1"),
                 [b1] = Row(b1, BindingRole.Step, "b", "a*2"),
                 [c1] = Row(c1, BindingRole.Input, "c", "C1"),
-                [d1] = Row(d1, BindingRole.Step, "d", "c+1"),
+                [d1] = Row(d1, BindingRole.Step, "d", "c+1")
             },
             new HashSet<FormulaRef> { b1, c1, d1 },
             new HashSet<FormulaRef>(),
@@ -278,7 +278,7 @@ public sealed class OrphanedRowTrackerTests
             {
                 [b1] = Row(b1, BindingRole.Input, "b", "B1"),
                 [c1] = Row(c1, BindingRole.Input, "c", "C1"),
-                [d1] = Row(d1, BindingRole.Step, "d", "c+1"),
+                [d1] = Row(d1, BindingRole.Step, "d", "c+1")
             },
             new HashSet<FormulaRef> { b1, d1 },
             new HashSet<FormulaRef>(),
@@ -308,7 +308,7 @@ public sealed class OrphanedRowTrackerTests
             new Dictionary<FormulaRef, BindingRow>
             {
                 [a1] = Row(a1, BindingRole.Input, "a", "A1"),
-                [b1] = Row(b1, BindingRole.Step, "b", "a*2"),
+                [b1] = Row(b1, BindingRole.Step, "b", "a*2")
             },
             new HashSet<FormulaRef> { b1 },
             new HashSet<FormulaRef>(),
@@ -322,7 +322,7 @@ public sealed class OrphanedRowTrackerTests
             new Dictionary<FormulaRef, BindingRow>
             {
                 [b1] = Row(b1, BindingRole.Input, "b", "B1"),
-                [c1] = Row(c1, BindingRole.Step, "c", "B1+1"),
+                [c1] = Row(c1, BindingRole.Step, "c", "B1+1")
             },
             new HashSet<FormulaRef> { b1, c1 },
             new HashSet<FormulaRef>(),
@@ -340,6 +340,8 @@ public sealed class OrphanedRowTrackerTests
         return new FormulaRef(new CellRef("Sheet1", col, row));
     }
 
-    private static BindingRow Row(FormulaRef source, BindingRole role, string name, string rhs) =>
-        new(source, role, name, rhs, IsExpansion: false, CanToggleRole: true);
+    private static BindingRow Row(FormulaRef source, BindingRole role, string name, string rhs)
+    {
+        return new BindingRow(source, role, name, rhs, false, true);
+    }
 }

--- a/addin/lambda-boss/UI/GatherWindow.xaml
+++ b/addin/lambda-boss/UI/GatherWindow.xaml
@@ -19,6 +19,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -150,7 +151,78 @@
             </ScrollViewer>
         </Border>
 
-        <Grid Grid.Row="7" Margin="0,12,0,0">
+        <StackPanel x:Name="OrphansSection"
+                    Grid.Row="7"
+                    Margin="0,8,0,0"
+                    Visibility="Collapsed">
+            <TextBlock Text="Orphaned (would re-appear if you promote a row above)"
+                       FontSize="12"
+                       FontStyle="Italic"
+                       Foreground="#9cdcfe"
+                       Margin="0,0,0,4" />
+            <Border Background="#252526"
+                    BorderBrush="#3e3e3e"
+                    BorderThickness="1"
+                    MaxHeight="120">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <ItemsControl x:Name="OrphansList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Margin="6,3">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="28" />
+                                        <ColumnDefinition Width="56" />
+                                        <ColumnDefinition Width="60" />
+                                        <ColumnDefinition Width="160" />
+                                        <ColumnDefinition Width="160" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                                    <!-- Empty 28px column to align with bindings list (no checkbox). -->
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding Address}"
+                                               FontFamily="Consolas"
+                                               FontSize="12"
+                                               Foreground="{Binding AddressBrush}"
+                                               VerticalAlignment="Center" />
+                                    <TextBlock Grid.Column="2"
+                                               Text="{Binding Role}"
+                                               FontFamily="Consolas"
+                                               FontSize="11"
+                                               Foreground="{Binding RoleBrush}"
+                                               VerticalAlignment="Center" />
+                                    <TextBlock Grid.Column="3"
+                                               Text="{Binding Name}"
+                                               FontFamily="Consolas"
+                                               FontSize="13"
+                                               Foreground="{Binding NameBrush}"
+                                               VerticalAlignment="Center" />
+                                    <TextBlock Grid.Column="4"
+                                               Text="{Binding Rhs}"
+                                               FontFamily="Consolas"
+                                               FontSize="12"
+                                               Foreground="{Binding RhsBrush}"
+                                               TextTrimming="CharacterEllipsis"
+                                               VerticalAlignment="Center"
+                                               ToolTip="{Binding Rhs}" />
+                                    <TextBlock Grid.Column="5"
+                                               Text="{Binding OrphanHintText}"
+                                               FontFamily="Consolas"
+                                               FontSize="11"
+                                               FontStyle="Italic"
+                                               Foreground="#6a6a6a"
+                                               VerticalAlignment="Center"
+                                               Margin="8,0,0,0" />
+                                    <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </Border>
+        </StackPanel>
+
+        <Grid Grid.Row="8" Margin="0,12,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -178,7 +250,7 @@
                      HorizontalScrollBarVisibility="Auto" />
         </Grid>
 
-        <DockPanel Grid.Row="8" Margin="0,12,0,0">
+        <DockPanel Grid.Row="9" Margin="0,12,0,0">
             <Button x:Name="CancelButton"
                     DockPanel.Dock="Right"
                     Content="Cancel"

--- a/addin/lambda-boss/UI/GatherWindow.xaml
+++ b/addin/lambda-boss/UI/GatherWindow.xaml
@@ -155,7 +155,7 @@
                     Grid.Row="7"
                     Margin="0,8,0,0"
                     Visibility="Collapsed">
-            <TextBlock Text="Orphaned (would re-appear if you promote a row above)"
+            <TextBlock Text="Orphaned (re-include or promote a row above to bring them back)"
                        FontSize="12"
                        FontStyle="Italic"
                        Foreground="#9cdcfe"

--- a/addin/lambda-boss/UI/GatherWindow.xaml.cs
+++ b/addin/lambda-boss/UI/GatherWindow.xaml.cs
@@ -228,6 +228,15 @@ public partial class GatherWindow
                 // the rebuild after Recompute doesn't render stale
                 // orphan rows. No-op when the cell never caused any.
                 _orphanTracker.Forget(vm.Source);
+                // The just-re-included cell may still be unreachable
+                // because some unrelated cell is currently demoted or
+                // excluded and cuts the path. Pass that cell as
+                // causedBy so the unsurfaced row lands in the orphan
+                // section attributed to the actual blocker, instead
+                // of vanishing. Reconcile no-ops when the cell does
+                // surface (the diff is empty), so this is safe in the
+                // common case.
+                causedBy = FindCurrentBlocker();
             }
 
             Recompute(causedBy);
@@ -275,6 +284,33 @@ public partial class GatherWindow
 
             Recompute(causedBy);
         }
+    }
+
+    /// <summary>
+    ///     Heuristic: pick any cell currently demoted-to-input or
+    ///     excluded — those are the only user actions that can block a
+    ///     path through the precedent graph. Used as the fallback
+    ///     <c>causedBy</c> when re-including a cell, so a re-included
+    ///     cell that still doesn't surface (because another override
+    ///     cuts its only path) lands in the orphan section attributed
+    ///     to whatever's plausibly blocking it. Returns the first
+    ///     candidate found; when several blockers are in effect we
+    ///     can't tell which one the user "really" meant, but the hint
+    ///     just needs to point at *a* row above so the user knows
+    ///     where to look — they can experiment to find the actual
+    ///     cause. Returns null when nothing is currently overridden;
+    ///     in that case a re-included cell that fails to surface
+    ///     genuinely has no recoverable explanation, and falling out
+    ///     of the UI is acceptable.
+    /// </summary>
+    private FormulaRef? FindCurrentBlocker()
+    {
+        foreach (var (src, role) in _roleOverrides)
+            if (role == BindingRole.Input)
+                return src;
+        foreach (var src in _excluded.Keys)
+            return src;
+        return null;
     }
 
     private void Recompute(FormulaRef? causedBy)

--- a/addin/lambda-boss/UI/GatherWindow.xaml.cs
+++ b/addin/lambda-boss/UI/GatherWindow.xaml.cs
@@ -14,18 +14,21 @@ namespace LambdaBoss.UI;
 ///     <see cref="_recompute" />, then rebuilds the row list:
 ///     re-included rows return as the engine surfaces them, explicitly-
 ///     excluded rows are kept visible (greyed out, checkbox off) so the
-///     user can re-tick them, and orphaned rows that the engine no longer
-///     surfaces drop out. Role overrides persist across rebuilds via
-///     <see cref="_roleOverrides" /> so a user's promote/demote choice
-///     stays in effect through subsequent Include toggles. Save returns
-///     the synthesised LET text from the latest result so the caller
-///     writes that back to the sink.
+///     user can re-tick them, and rows the engine no longer surfaces
+///     because their only path ran through a demoted cell appear in a
+///     separate "Orphaned" section beneath the active bindings (issue
+///     #157, mirrors the excluded-row pattern). Role overrides persist
+///     across rebuilds via <see cref="_roleOverrides" /> so a user's
+///     promote/demote choice stays in effect through subsequent Include
+///     toggles. Save returns the synthesised LET text from the latest
+///     result so the caller writes that back to the sink.
 /// </summary>
 public partial class GatherWindow
 {
     private readonly Func<IReadOnlyList<RowState>, GatherResult?> _recompute;
     private GatherResult _result;
     private readonly ObservableCollection<GatherRowVm> _rows = new();
+    private readonly ObservableCollection<GatherRowVm> _orphans = new();
     // Snapshots of explicitly-excluded rows so they can re-appear in the
     // visible list after a Recompute (which only returns included
     // bindings). Stored as plain BindingRow data — no VM subscriptions to
@@ -39,6 +42,11 @@ public partial class GatherWindow
     // overrides into every Recompute so the engine sees a consistent
     // view of user intent.
     private readonly Dictionary<FormulaRef, BindingRole> _roleOverrides = new();
+    // Orphan tracker: precedents that fell out of the active list because
+    // their only path ran through a cell the user demoted. Surfaced in
+    // the Orphaned section below the bindings list and removed when the
+    // user promotes the demoter back to a step.
+    private readonly OrphanedRowTracker _orphanTracker = new();
     // Reentrancy guard: rebuilding the row list during a Recompute fires
     // INotifyPropertyChanged on each VM, which would re-enter the change
     // handler and trigger another Recompute. The guard short-circuits the
@@ -60,6 +68,7 @@ public partial class GatherWindow
 
         BuildRowsFromBindings(initial.Bindings);
         BindingsList.ItemsSource = _rows;
+        OrphansList.ItemsSource = _orphans;
 
         StatusText.Text = "Save writes the LET into the sink cell · Esc to cancel";
     }
@@ -132,6 +141,10 @@ public partial class GatherWindow
             foreach (var v in _rows)
                 v.PropertyChanged -= Row_PropertyChanged;
             _rows.Clear();
+            // Orphan rows are inert (no checkbox, no toggle) so they
+            // never raise PropertyChanged events — clearing the list
+            // is enough.
+            _orphans.Clear();
 
             var surfaced = new HashSet<FormulaRef>();
             foreach (var binding in bindings)
@@ -143,11 +156,11 @@ public partial class GatherWindow
             }
 
             // Explicitly-excluded rows that the engine didn't surface
-            // appear at the bottom so the user can find them to re-tick.
-            // An excluded ref the engine still surfaces (e.g. an inner-
-            // expansion row sharing a host cell that's still in the
-            // result) is suppressed here — surfacing once avoids
-            // duplicate rows for a single Source.
+            // appear at the bottom of the bindings list so the user can
+            // find them to re-tick. An excluded ref the engine still
+            // surfaces (e.g. an inner-expansion row sharing a host cell
+            // that's still in the result) is suppressed here — surfacing
+            // once avoids duplicate rows for a single Source.
             foreach (var (source, snapshot) in _excluded)
             {
                 if (surfaced.Contains(source)) continue;
@@ -155,11 +168,28 @@ public partial class GatherWindow
                 vm.PropertyChanged += Row_PropertyChanged;
                 _rows.Add(vm);
             }
+
+            // Orphaned rows go into a separate section. Filtering rules
+            // mirror the excluded lane: skip rows the engine just
+            // surfaced (the orphan came back) and rows the user has
+            // also explicitly excluded (excluded-row treatment wins —
+            // the user's deliberate choice trumps the implicit drop).
+            foreach (var (source, entry) in _orphanTracker.Orphans)
+            {
+                if (surfaced.Contains(source)) continue;
+                if (_excluded.ContainsKey(source)) continue;
+                var hint = entry.DemotedBy.Start.A1Address;
+                var vm = new GatherRowVm(entry.Snapshot, include: true, orphanedByAddress: hint);
+                _orphans.Add(vm);
+            }
         }
         finally
         {
             _suppressRecompute = false;
         }
+
+        OrphansSection.Visibility =
+            _orphans.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
     }
 
     private void Row_PropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -184,7 +214,7 @@ public partial class GatherWindow
                 _excluded.Remove(vm.Source);
             }
 
-            Recompute();
+            Recompute(demotedCell: null);
             return;
         }
 
@@ -197,31 +227,66 @@ public partial class GatherWindow
             // for a row that already matched its natural role is
             // harmless; the engine's defensive paths handle no-op
             // overrides without churn.
-            _roleOverrides[vm.Source] =
-                vm.IsStep ? BindingRole.Step : BindingRole.Input;
+            var newRole = vm.IsStep ? BindingRole.Step : BindingRole.Input;
+            _roleOverrides[vm.Source] = newRole;
 
             // If this row is currently marked excluded (snapshot in
             // _excluded), refresh that snapshot too so the cached row
             // carries the new role on its next re-render.
             if (_excluded.TryGetValue(vm.Source, out var existing))
             {
-                _excluded[vm.Source] = existing with
-                {
-                    Role = _roleOverrides[vm.Source],
-                };
+                _excluded[vm.Source] = existing with { Role = newRole };
             }
 
-            Recompute();
+            // Promotion: drop any orphans this cell originally caused.
+            // Done up-front (before Recompute) so the post-recompute
+            // reconcile pass doesn't see a stale orphan record while
+            // the engine is still surfacing the formerly-orphaned cell
+            // back into the active list. A role flip on an excluded
+            // row is a snapshot-only edit (the engine keeps treating
+            // the cell as excluded so the override never takes effect)
+            // — we skip the tracker hooks in that case so excluding a
+            // demoter doesn't accidentally lose its orphan attribution.
+            FormulaRef? newlyDemoted = null;
+            if (vm.Include)
+            {
+                if (newRole == BindingRole.Step)
+                    _orphanTracker.OnPromote(vm.Source);
+                else
+                    newlyDemoted = vm.Source;
+            }
+
+            Recompute(newlyDemoted);
         }
     }
 
-    private void Recompute()
+    private void Recompute(FormulaRef? demotedCell)
     {
-        // Build RowState list from the visible rows. Inner-LET rows are
-        // skipped because they share a Source with their host cell — the
-        // host's row owns the toggle, so passing the inner rows' state
-        // would double-flag their Source. Role overrides are layered on
-        // top of each row's Include flag so the engine sees a single
+        // Snapshot the active rows BEFORE the recompute. Used by the
+        // orphan tracker to detect cells that fell off the active list
+        // because of a demote — diff'd against the new active set
+        // returned by the engine. Skip expansion rows (they share a
+        // Source with their host cell, so snapshotting them would
+        // collide on the dictionary key) and excluded rows (those have
+        // their own visual lane and are explicitly not "active").
+        var snapshotBefore = new Dictionary<FormulaRef, BindingRow>();
+        foreach (var vm in _rows)
+        {
+            if (vm.IsExpansion) continue;
+            if (!vm.Include) continue;
+            if (snapshotBefore.ContainsKey(vm.Source)) continue;
+            snapshotBefore[vm.Source] = new BindingRow(
+                vm.Source, vm.RoleEnum, vm.Name, vm.Rhs,
+                vm.IsExpansion, vm.CanToggleRole);
+        }
+
+        // Build RowState list from the visible bindings. Inner-LET rows
+        // are skipped because they share a Source with their host cell
+        // — the host's row owns the toggle, so passing the inner rows'
+        // state would double-flag their Source. Orphan rows are inert
+        // and live in a separate collection (_orphans), so they don't
+        // appear in this loop at all. Role overrides are layered on top
+        // of each row's Include flag so the engine sees a single
         // consistent view of user intent.
         var states = new List<RowState>(_rows.Count);
         var seen = new HashSet<FormulaRef>();
@@ -246,6 +311,17 @@ public partial class GatherWindow
             return;
         }
 
+        var activeAfter = new HashSet<FormulaRef>(
+            newResult.Bindings.Count);
+        foreach (var b in newResult.Bindings)
+            activeAfter.Add(b.Source);
+
+        _orphanTracker.Reconcile(
+            snapshotBefore,
+            activeAfter,
+            new HashSet<FormulaRef>(_excluded.Keys),
+            demotedCell);
+
         _result = newResult;
         PreviewText.Text = newResult.SynthesisedLet;
         BuildRowsFromBindings(newResult.Bindings);
@@ -260,7 +336,11 @@ public partial class GatherWindow
 ///     rebuilds the collection rather than mutating individual rows, so
 ///     we don't need INPCC plumbing on those fields. Role flips through
 ///     <see cref="IsStep" /> trigger an override that the dialog
-///     persists across rebuilds.
+///     persists across rebuilds. Orphan rows (issue #157) reuse this VM
+///     with <see cref="OrphanedByAddress" /> set: the row stays visible
+///     in a separate section, hides its checkbox and role toggle (those
+///     don't apply to inert orphan rows), shows an "orphaned by &lt;addr&gt;"
+///     hint, and stays muted regardless of the Include flag.
 /// </summary>
 public class GatherRowVm : INotifyPropertyChanged
 {
@@ -278,7 +358,7 @@ public class GatherRowVm : INotifyPropertyChanged
     private bool _include;
     private bool _isStep;
 
-    public GatherRowVm(BindingRow binding, bool include)
+    public GatherRowVm(BindingRow binding, bool include, string? orphanedByAddress = null)
     {
         Source = binding.Source;
         RoleEnum = binding.Role;
@@ -286,6 +366,7 @@ public class GatherRowVm : INotifyPropertyChanged
         Rhs = binding.Rhs;
         IsExpansion = binding.IsExpansion;
         CanToggleRole = binding.CanToggleRole;
+        OrphanedByAddress = orphanedByAddress;
         _include = include;
         _isStep = binding.Role == BindingRole.Step;
     }
@@ -298,6 +379,19 @@ public class GatherRowVm : INotifyPropertyChanged
     public string Rhs { get; }
     public bool IsExpansion { get; }
     public bool CanToggleRole { get; }
+
+    /// <summary>
+    ///     Address of the cell whose demotion orphaned this row, or
+    ///     null when the row isn't an orphan. Drives the
+    ///     "orphaned by &lt;addr&gt;" hint in the orphan section
+    ///     and gates which controls render on the row.
+    /// </summary>
+    public string? OrphanedByAddress { get; }
+
+    public bool IsOrphan => OrphanedByAddress != null;
+
+    public string OrphanHintText =>
+        OrphanedByAddress == null ? "" : $"orphaned by {OrphanedByAddress}";
 
     public bool Include
     {
@@ -340,9 +434,11 @@ public class GatherRowVm : INotifyPropertyChanged
     ///     Inner-LET expansion rows hide their checkbox: the host cell
     ///     drives the toggle, and a checkbox here would be a confusing
     ///     no-op (the engine doesn't expose per-inner-binding exclusion).
+    ///     Orphan rows hide it too — they're inert until the user
+    ///     promotes the demoter that orphaned them back to a step.
     /// </summary>
     public Visibility IncludeCheckboxVisibility =>
-        IsExpansion ? Visibility.Hidden : Visibility.Visible;
+        IsExpansion || IsOrphan ? Visibility.Hidden : Visibility.Visible;
 
     /// <summary>
     ///     Show the role toggle button only on rows where promote/demote
@@ -350,17 +446,24 @@ public class GatherRowVm : INotifyPropertyChanged
     ///     literal-cell inputs, and inner-LET expansions all keep the
     ///     toggle hidden). When hidden, the static Role text takes the
     ///     same column slot via <see cref="RoleStaticVisibility" />.
+    ///     Orphan rows always render the static text so they read as
+    ///     read-only — toggling on an orphan row would imply you can
+    ///     edit it, which you can't.
     /// </summary>
     public Visibility RoleToggleVisibility =>
-        CanToggleRole ? Visibility.Visible : Visibility.Collapsed;
+        CanToggleRole && !IsOrphan ? Visibility.Visible : Visibility.Collapsed;
 
     public Visibility RoleStaticVisibility =>
-        CanToggleRole ? Visibility.Collapsed : Visibility.Visible;
+        CanToggleRole && !IsOrphan ? Visibility.Collapsed : Visibility.Visible;
 
-    public Brush AddressBrush => Include ? ActiveAddressBrush : MutedBrush;
-    public Brush RoleBrush => Include ? ActiveRoleBrush : MutedBrush;
-    public Brush NameBrush => Include ? ActiveNameBrush : MutedBrush;
-    public Brush RhsBrush => Include ? ActiveRhsBrush : MutedBrush;
+    // Orphan rows always render muted regardless of Include — they're
+    // visually distinct from active rows by design (the user lost them
+    // from view, the muted treatment communicates "this isn't in the
+    // LET right now").
+    public Brush AddressBrush => Include && !IsOrphan ? ActiveAddressBrush : MutedBrush;
+    public Brush RoleBrush => Include && !IsOrphan ? ActiveRoleBrush : MutedBrush;
+    public Brush NameBrush => Include && !IsOrphan ? ActiveNameBrush : MutedBrush;
+    public Brush RhsBrush => Include && !IsOrphan ? ActiveRhsBrush : MutedBrush;
 
     public event PropertyChangedEventHandler? PropertyChanged;
 

--- a/addin/lambda-boss/UI/GatherWindow.xaml.cs
+++ b/addin/lambda-boss/UI/GatherWindow.xaml.cs
@@ -26,29 +26,35 @@ namespace LambdaBoss.UI;
 /// </summary>
 public partial class GatherWindow
 {
-    private readonly Func<IReadOnlyList<RowState>, GatherResult?> _recompute;
-    private GatherResult _result;
-    private readonly ObservableCollection<GatherRowVm> _rows = new();
-    private readonly ObservableCollection<GatherRowVm> _orphans = new();
     // Snapshots of explicitly-excluded rows so they can re-appear in the
     // visible list after a Recompute (which only returns included
     // bindings). Stored as plain BindingRow data — no VM subscriptions to
     // manage across rebuilds. Re-checking removes the entry; the engine's
     // result is the source of truth for re-included rows.
-    private readonly Dictionary<FormulaRef, BindingRow> _excluded = new();
-    // Role overrides persist across rebuilds: when the user demotes B1 to
-    // input, that choice survives an unrelated checkbox toggle on A1
-    // (which would otherwise re-run the engine without the override and
-    // restore B1 to its natural classification). The dialog re-injects
-    // overrides into every Recompute so the engine sees a consistent
-    // view of user intent.
-    private readonly Dictionary<FormulaRef, BindingRole> _roleOverrides = new();
+    private readonly Dictionary<FormulaRef, BindingRow> _excluded = [];
+
+    private readonly ObservableCollection<GatherRowVm> _orphans = [];
+
     // Orphan tracker: precedents that fell out of the active list because
     // their only path ran through a cell the user demoted or excluded.
     // Surfaced in the Orphaned section below the bindings list and
     // removed when the user reverses the causing action — re-includes
     // an excluded cell, or promotes a demoted one back to a step.
     private readonly OrphanedRowTracker _orphanTracker = new();
+
+    private readonly Func<IReadOnlyList<RowState>, GatherResult?> _recompute;
+
+    // Role overrides persist across rebuilds: when the user demotes B1 to
+    // input, that choice survives an unrelated checkbox toggle on A1
+    // (which would otherwise re-run the engine without the override and
+    // restore B1 to its natural classification). The dialog re-injects
+    // overrides into every Recompute so the engine sees a consistent
+    // view of user intent.
+    private readonly Dictionary<FormulaRef, BindingRole> _roleOverrides = [];
+    private readonly ObservableCollection<GatherRowVm> _rows = [];
+
+    private GatherResult _result;
+
     // Reentrancy guard: rebuilding the row list during a Recompute fires
     // INotifyPropertyChanged on each VM, which would re-enter the change
     // handler and trigger another Recompute. The guard short-circuits the
@@ -151,7 +157,7 @@ public partial class GatherWindow
             var surfaced = new HashSet<FormulaRef>();
             foreach (var binding in bindings)
             {
-                var vm = new GatherRowVm(binding, include: true);
+                var vm = new GatherRowVm(binding, true);
                 vm.PropertyChanged += Row_PropertyChanged;
                 _rows.Add(vm);
                 surfaced.Add(binding.Source);
@@ -166,7 +172,7 @@ public partial class GatherWindow
             foreach (var (source, snapshot) in _excluded)
             {
                 if (surfaced.Contains(source)) continue;
-                var vm = new GatherRowVm(snapshot, include: false);
+                var vm = new GatherRowVm(snapshot, false);
                 vm.PropertyChanged += Row_PropertyChanged;
                 _rows.Add(vm);
             }
@@ -181,7 +187,7 @@ public partial class GatherWindow
                 if (surfaced.Contains(source)) continue;
                 if (_excluded.ContainsKey(source)) continue;
                 var hint = entry.CausedBy.Start.A1Address;
-                var vm = new GatherRowVm(entry.Snapshot, include: true, orphanedByAddress: hint);
+                var vm = new GatherRowVm(entry.Snapshot, true, hint);
                 _orphans.Add(vm);
             }
         }
@@ -205,7 +211,7 @@ public partial class GatherWindow
             // forget the snapshot when re-checking so the engine result
             // owns the row's display (Role/Name/Rhs may have shifted as
             // other rows toggled in the meantime).
-            FormulaRef? causedBy = null;
+            FormulaRef? causedBy;
             if (!vm.Include)
             {
                 _excluded[vm.Source] = new BindingRow(
@@ -259,9 +265,7 @@ public partial class GatherWindow
             // _excluded), refresh that snapshot too so the cached row
             // carries the new role on its next re-render.
             if (_excluded.TryGetValue(vm.Source, out var existing))
-            {
                 _excluded[vm.Source] = existing with { Role = newRole };
-            }
 
             // Promotion: drop any orphans this cell originally caused
             // (whether by a prior demote or a prior exclude). Done up-
@@ -400,12 +404,16 @@ public class GatherRowVm : INotifyPropertyChanged
 {
     private static readonly Brush ActiveAddressBrush =
         new SolidColorBrush((Color)ColorConverter.ConvertFromString("#9cdcfe"));
+
     private static readonly Brush ActiveRoleBrush =
         new SolidColorBrush((Color)ColorConverter.ConvertFromString("#808080"));
+
     private static readonly Brush ActiveNameBrush =
         new SolidColorBrush((Color)ColorConverter.ConvertFromString("#dcdcaa"));
+
     private static readonly Brush ActiveRhsBrush =
         new SolidColorBrush((Color)ColorConverter.ConvertFromString("#cccccc"));
+
     private static readonly Brush MutedBrush =
         new SolidColorBrush((Color)ColorConverter.ConvertFromString("#6a6a6a"));
 

--- a/addin/lambda-boss/UI/GatherWindow.xaml.cs
+++ b/addin/lambda-boss/UI/GatherWindow.xaml.cs
@@ -15,13 +15,14 @@ namespace LambdaBoss.UI;
 ///     re-included rows return as the engine surfaces them, explicitly-
 ///     excluded rows are kept visible (greyed out, checkbox off) so the
 ///     user can re-tick them, and rows the engine no longer surfaces
-///     because their only path ran through a demoted cell appear in a
-///     separate "Orphaned" section beneath the active bindings (issue
-///     #157, mirrors the excluded-row pattern). Role overrides persist
-///     across rebuilds via <see cref="_roleOverrides" /> so a user's
-///     promote/demote choice stays in effect through subsequent Include
-///     toggles. Save returns the synthesised LET text from the latest
-///     result so the caller writes that back to the sink.
+///     because their only path ran through a cell the user demoted or
+///     excluded appear in a separate "Orphaned" section beneath the
+///     active bindings (issue #157, mirrors the excluded-row pattern).
+///     Role overrides persist across rebuilds via
+///     <see cref="_roleOverrides" /> so a user's promote/demote choice
+///     stays in effect through subsequent Include toggles. Save returns
+///     the synthesised LET text from the latest result so the caller
+///     writes that back to the sink.
 /// </summary>
 public partial class GatherWindow
 {
@@ -43,9 +44,10 @@ public partial class GatherWindow
     // view of user intent.
     private readonly Dictionary<FormulaRef, BindingRole> _roleOverrides = new();
     // Orphan tracker: precedents that fell out of the active list because
-    // their only path ran through a cell the user demoted. Surfaced in
-    // the Orphaned section below the bindings list and removed when the
-    // user promotes the demoter back to a step.
+    // their only path ran through a cell the user demoted or excluded.
+    // Surfaced in the Orphaned section below the bindings list and
+    // removed when the user reverses the causing action — re-includes
+    // an excluded cell, or promotes a demoted one back to a step.
     private readonly OrphanedRowTracker _orphanTracker = new();
     // Reentrancy guard: rebuilding the row list during a Recompute fires
     // INotifyPropertyChanged on each VM, which would re-enter the change
@@ -178,7 +180,7 @@ public partial class GatherWindow
             {
                 if (surfaced.Contains(source)) continue;
                 if (_excluded.ContainsKey(source)) continue;
-                var hint = entry.DemotedBy.Start.A1Address;
+                var hint = entry.CausedBy.Start.A1Address;
                 var vm = new GatherRowVm(entry.Snapshot, include: true, orphanedByAddress: hint);
                 _orphans.Add(vm);
             }
@@ -203,18 +205,32 @@ public partial class GatherWindow
             // forget the snapshot when re-checking so the engine result
             // owns the row's display (Role/Name/Rhs may have shifted as
             // other rows toggled in the meantime).
+            FormulaRef? causedBy = null;
             if (!vm.Include)
             {
                 _excluded[vm.Source] = new BindingRow(
                     vm.Source, vm.RoleEnum, vm.Name, vm.Rhs,
                     vm.IsExpansion, vm.CanToggleRole);
+                // Excluding a step drops any precedents reachable only
+                // via this cell — same upstream effect as a demote.
+                // Pass the cell as the cause so the tracker records
+                // those drops as orphans instead of letting them
+                // vanish silently. Reconcile no-ops on excludes that
+                // don't drop anything (leaves, or steps with no sole-
+                // path upstream cells).
+                causedBy = vm.Source;
             }
             else
             {
                 _excluded.Remove(vm.Source);
+                // Re-including the cell reverses the exclude; any
+                // orphans we attributed to it should clear up-front so
+                // the rebuild after Recompute doesn't render stale
+                // orphan rows. No-op when the cell never caused any.
+                _orphanTracker.Forget(vm.Source);
             }
 
-            Recompute(demotedCell: null);
+            Recompute(causedBy);
             return;
         }
 
@@ -238,37 +254,39 @@ public partial class GatherWindow
                 _excluded[vm.Source] = existing with { Role = newRole };
             }
 
-            // Promotion: drop any orphans this cell originally caused.
-            // Done up-front (before Recompute) so the post-recompute
-            // reconcile pass doesn't see a stale orphan record while
-            // the engine is still surfacing the formerly-orphaned cell
-            // back into the active list. A role flip on an excluded
-            // row is a snapshot-only edit (the engine keeps treating
-            // the cell as excluded so the override never takes effect)
-            // — we skip the tracker hooks in that case so excluding a
-            // demoter doesn't accidentally lose its orphan attribution.
-            FormulaRef? newlyDemoted = null;
+            // Promotion: drop any orphans this cell originally caused
+            // (whether by a prior demote or a prior exclude). Done up-
+            // front so the post-recompute reconcile pass doesn't see a
+            // stale orphan record while the engine is still surfacing
+            // the formerly-orphaned cell back into the active list. A
+            // role flip on an excluded row is a snapshot-only edit
+            // (the engine keeps treating the cell as excluded so the
+            // override never takes effect) — we skip the tracker
+            // hooks in that case so excluding a causer doesn't
+            // accidentally lose its orphan attribution.
+            FormulaRef? causedBy = null;
             if (vm.Include)
             {
                 if (newRole == BindingRole.Step)
-                    _orphanTracker.OnPromote(vm.Source);
+                    _orphanTracker.Forget(vm.Source);
                 else
-                    newlyDemoted = vm.Source;
+                    causedBy = vm.Source;
             }
 
-            Recompute(newlyDemoted);
+            Recompute(causedBy);
         }
     }
 
-    private void Recompute(FormulaRef? demotedCell)
+    private void Recompute(FormulaRef? causedBy)
     {
         // Snapshot the active rows BEFORE the recompute. Used by the
         // orphan tracker to detect cells that fell off the active list
-        // because of a demote — diff'd against the new active set
-        // returned by the engine. Skip expansion rows (they share a
-        // Source with their host cell, so snapshotting them would
-        // collide on the dictionary key) and excluded rows (those have
-        // their own visual lane and are explicitly not "active").
+        // because of a demote or an exclude — diff'd against the new
+        // active set returned by the engine. Skip expansion rows (they
+        // share a Source with their host cell, so snapshotting them
+        // would collide on the dictionary key) and excluded rows
+        // (those have their own visual lane and are explicitly not
+        // "active").
         var snapshotBefore = new Dictionary<FormulaRef, BindingRow>();
         foreach (var vm in _rows)
         {
@@ -320,7 +338,7 @@ public partial class GatherWindow
             snapshotBefore,
             activeAfter,
             new HashSet<FormulaRef>(_excluded.Keys),
-            demotedCell);
+            causedBy);
 
         _result = newResult;
         PreviewText.Text = newResult.SynthesisedLet;
@@ -381,10 +399,10 @@ public class GatherRowVm : INotifyPropertyChanged
     public bool CanToggleRole { get; }
 
     /// <summary>
-    ///     Address of the cell whose demotion orphaned this row, or
-    ///     null when the row isn't an orphan. Drives the
-    ///     "orphaned by &lt;addr&gt;" hint in the orphan section
-    ///     and gates which controls render on the row.
+    ///     Address of the cell whose demote-or-exclude orphaned this
+    ///     row, or null when the row isn't an orphan. Drives the
+    ///     "orphaned by &lt;addr&gt;" hint in the orphan section and
+    ///     gates which controls render on the row.
     /// </summary>
     public string? OrphanedByAddress { get; }
 
@@ -435,7 +453,8 @@ public class GatherRowVm : INotifyPropertyChanged
     ///     drives the toggle, and a checkbox here would be a confusing
     ///     no-op (the engine doesn't expose per-inner-binding exclusion).
     ///     Orphan rows hide it too — they're inert until the user
-    ///     promotes the demoter that orphaned them back to a step.
+    ///     reverses the action on the row above (re-include or
+    ///     promote) that orphaned them.
     /// </summary>
     public Visibility IncludeCheckboxVisibility =>
         IsExpansion || IsOrphan ? Visibility.Hidden : Visibility.Visible;

--- a/addin/lambda-boss/UI/OrphanedRowTracker.cs
+++ b/addin/lambda-boss/UI/OrphanedRowTracker.cs
@@ -1,0 +1,118 @@
+namespace LambdaBoss.UI;
+
+/// <summary>
+///     A row that the engine no longer surfaces because its only path
+///     into the LET ran through a cell the user demoted to input. The
+///     dialog renders these in a separate "Orphaned" section beneath
+///     the active bindings so a demote doesn't silently drop precedents
+///     from view (mirrors the excluded-row pattern from PR 10).
+///     <see cref="Snapshot" /> carries the cell's last-known
+///     <see cref="BindingRow" /> shape (Address, Role, Name, Rhs) for
+///     display; <see cref="DemotedBy" /> identifies the cell whose
+///     demote orphaned this row, used both to compose the
+///     "orphaned by &lt;addr&gt;" hint and to drop the orphan when the
+///     user re-promotes that cell.
+/// </summary>
+internal sealed record OrphanedRow(BindingRow Snapshot, FormulaRef DemotedBy);
+
+/// <summary>
+///     Bookkeeping for the orphaned-rows section in
+///     <see cref="GatherWindow" />. Tracks which cells the user lost from
+///     view by demoting a step (precedents reachable only via the
+///     demoted cell), so the dialog can keep them visible in a separate
+///     read-only list rather than letting them disappear silently.
+///     This class is pure state — no WPF or engine coupling — so the
+///     diff logic is exercisable without spinning up a dialog. The
+///     dialog wires it into <see cref="GatherEngine.Recompute" />:
+///     <list type="bullet">
+///         <item>
+///             Before each Recompute, capture the active rows'
+///             <see cref="BindingRow" /> snapshots.
+///         </item>
+///         <item>
+///             After Recompute, call <see cref="Reconcile" /> with the
+///             pre/post active sets and (if the trigger was a demote)
+///             the demoted cell. New orphans are recorded; orphans that
+///             reappeared in the active set are dropped.
+///         </item>
+///         <item>
+///             On a promote, call <see cref="OnPromote" /> to drop any
+///             orphans the now-promoted cell originally caused.
+///         </item>
+///     </list>
+/// </summary>
+internal sealed class OrphanedRowTracker
+{
+    private readonly Dictionary<FormulaRef, OrphanedRow> _orphaned = new();
+
+    /// <summary>The current orphan rows, keyed by their cell ref.</summary>
+    public IReadOnlyDictionary<FormulaRef, OrphanedRow> Orphans => _orphaned;
+
+    /// <summary>True if any orphan rows are currently tracked.</summary>
+    public bool HasOrphans => _orphaned.Count > 0;
+
+    /// <summary>
+    ///     Drop every orphan that was caused by the user demoting
+    ///     <paramref name="promotedCell" />. Called when the user flips
+    ///     that same cell's role back from input to step — the precedents
+    ///     it was hiding will surface naturally on the next Recompute,
+    ///     so they shouldn't keep their orphan-row treatment.
+    /// </summary>
+    public void OnPromote(FormulaRef promotedCell)
+    {
+        var keys = new List<FormulaRef>();
+        foreach (var (key, entry) in _orphaned)
+            if (entry.DemotedBy.Equals(promotedCell))
+                keys.Add(key);
+        foreach (var k in keys)
+            _orphaned.Remove(k);
+    }
+
+    /// <summary>
+    ///     Reconcile orphan tracking with the result of a Recompute.
+    ///     Always drops orphans whose cell reappeared in
+    ///     <paramref name="activeAfter" /> (the engine surfaced them
+    ///     again, e.g. after another role change opened a new path
+    ///     into the cell). When <paramref name="demotedCell" /> is
+    ///     non-null (the Recompute was triggered by a demote), records
+    ///     each cell that was active before but isn't now — and isn't
+    ///     excluded, isn't the demoted cell itself, and isn't already
+    ///     tracked — as a new orphan, with its
+    ///     <see cref="OrphanedRow.Snapshot" /> drawn from
+    ///     <paramref name="activeBefore" />.
+    /// </summary>
+    public void Reconcile(
+        IReadOnlyDictionary<FormulaRef, BindingRow> activeBefore,
+        IReadOnlySet<FormulaRef> activeAfter,
+        IReadOnlySet<FormulaRef> excluded,
+        FormulaRef? demotedCell)
+    {
+        // Drop orphans that the engine resurfaced. A row reappears when
+        // some unrelated change (e.g. promoting another cell that
+        // restored a path into it) opens a new route into the LET; the
+        // orphan-by-X label no longer reflects reality once the row is
+        // back in active rotation.
+        foreach (var src in activeAfter)
+            _orphaned.Remove(src);
+
+        if (demotedCell == null)
+            return;
+
+        foreach (var (src, snap) in activeBefore)
+        {
+            if (activeAfter.Contains(src)) continue;
+            // Excluded cells already have their own visual treatment
+            // (the excluded-row snapshot lane); they're not orphans.
+            if (excluded.Contains(src)) continue;
+            // The demoted cell itself stays as a binding (now an input
+            // RHS = cell-ref) — it's the one row the demote keeps
+            // visible by design, not an orphan.
+            if (src.Equals(demotedCell)) continue;
+            // First-write wins. A cell already attributed to a
+            // previous demoter shouldn't get re-attributed by a fresh
+            // demote that didn't actually cause this drop.
+            if (_orphaned.ContainsKey(src)) continue;
+            _orphaned[src] = new OrphanedRow(snap, demotedCell);
+        }
+    }
+}

--- a/addin/lambda-boss/UI/OrphanedRowTracker.cs
+++ b/addin/lambda-boss/UI/OrphanedRowTracker.cs
@@ -2,25 +2,28 @@ namespace LambdaBoss.UI;
 
 /// <summary>
 ///     A row that the engine no longer surfaces because its only path
-///     into the LET ran through a cell the user demoted to input. The
-///     dialog renders these in a separate "Orphaned" section beneath
-///     the active bindings so a demote doesn't silently drop precedents
-///     from view (mirrors the excluded-row pattern from PR 10).
+///     into the LET ran through a cell the user demoted to input or
+///     excluded. The dialog renders these in a separate "Orphaned"
+///     section beneath the active bindings so the drop doesn't pass
+///     silently (mirrors the excluded-row pattern from PR 10).
 ///     <see cref="Snapshot" /> carries the cell's last-known
 ///     <see cref="BindingRow" /> shape (Address, Role, Name, Rhs) for
-///     display; <see cref="DemotedBy" /> identifies the cell whose
-///     demote orphaned this row, used both to compose the
+///     display; <see cref="CausedBy" /> identifies the cell whose
+///     demote-or-exclude orphaned this row, used both to compose the
 ///     "orphaned by &lt;addr&gt;" hint and to drop the orphan when the
-///     user re-promotes that cell.
+///     user reverses that action (promote a demoted cell, re-include
+///     an excluded one).
 /// </summary>
-internal sealed record OrphanedRow(BindingRow Snapshot, FormulaRef DemotedBy);
+internal sealed record OrphanedRow(BindingRow Snapshot, FormulaRef CausedBy);
 
 /// <summary>
 ///     Bookkeeping for the orphaned-rows section in
-///     <see cref="GatherWindow" />. Tracks which cells the user lost from
-///     view by demoting a step (precedents reachable only via the
-///     demoted cell), so the dialog can keep them visible in a separate
-///     read-only list rather than letting them disappear silently.
+///     <see cref="GatherWindow" />. Tracks which cells the user lost
+///     from view by demoting a step to input, or by excluding a step
+///     entirely — both actions drop precedents that were only reachable
+///     via the affected cell. The dialog uses this to keep the dropped
+///     rows visible in a separate read-only list rather than letting
+///     them disappear silently.
 ///     This class is pure state — no WPF or engine coupling — so the
 ///     diff logic is exercisable without spinning up a dialog. The
 ///     dialog wires it into <see cref="GatherEngine.Recompute" />:
@@ -31,13 +34,15 @@ internal sealed record OrphanedRow(BindingRow Snapshot, FormulaRef DemotedBy);
 ///         </item>
 ///         <item>
 ///             After Recompute, call <see cref="Reconcile" /> with the
-///             pre/post active sets and (if the trigger was a demote)
-///             the demoted cell. New orphans are recorded; orphans that
+///             pre/post active sets and (if the trigger was a demote
+///             or an exclude on an active row) the cell whose action
+///             caused the drop. New orphans are recorded; orphans that
 ///             reappeared in the active set are dropped.
 ///         </item>
 ///         <item>
-///             On a promote, call <see cref="OnPromote" /> to drop any
-///             orphans the now-promoted cell originally caused.
+///             On a promote or re-include of a previously orphan-
+///             causing cell, call <see cref="Forget" /> to drop any
+///             orphans attributed to it.
 ///         </item>
 ///     </list>
 /// </summary>
@@ -52,17 +57,21 @@ internal sealed class OrphanedRowTracker
     public bool HasOrphans => _orphaned.Count > 0;
 
     /// <summary>
-    ///     Drop every orphan that was caused by the user demoting
-    ///     <paramref name="promotedCell" />. Called when the user flips
-    ///     that same cell's role back from input to step — the precedents
-    ///     it was hiding will surface naturally on the next Recompute,
-    ///     so they shouldn't keep their orphan-row treatment.
+    ///     Drop every orphan attributed to <paramref name="cell" />.
+    ///     Called when the user reverses the action that originally
+    ///     caused those orphans — promoting a demoted cell back to a
+    ///     step, or re-including an excluded cell. Done up-front so
+    ///     the dialog's reconcile pass during the rebuild doesn't see
+    ///     a stale "orphaned by" record while the engine is still
+    ///     surfacing the formerly-orphaned cell back into the active
+    ///     list. Safe to call on cells that don't have orphans
+    ///     attributed (no-op).
     /// </summary>
-    public void OnPromote(FormulaRef promotedCell)
+    public void Forget(FormulaRef cell)
     {
         var keys = new List<FormulaRef>();
         foreach (var (key, entry) in _orphaned)
-            if (entry.DemotedBy.Equals(promotedCell))
+            if (entry.CausedBy.Equals(cell))
                 keys.Add(key);
         foreach (var k in keys)
             _orphaned.Remove(k);
@@ -72,20 +81,20 @@ internal sealed class OrphanedRowTracker
     ///     Reconcile orphan tracking with the result of a Recompute.
     ///     Always drops orphans whose cell reappeared in
     ///     <paramref name="activeAfter" /> (the engine surfaced them
-    ///     again, e.g. after another role change opened a new path
-    ///     into the cell). When <paramref name="demotedCell" /> is
-    ///     non-null (the Recompute was triggered by a demote), records
-    ///     each cell that was active before but isn't now — and isn't
-    ///     excluded, isn't the demoted cell itself, and isn't already
-    ///     tracked — as a new orphan, with its
-    ///     <see cref="OrphanedRow.Snapshot" /> drawn from
-    ///     <paramref name="activeBefore" />.
+    ///     again, e.g. after another role/include change opened a new
+    ///     path into the cell). When <paramref name="causedBy" /> is
+    ///     non-null (the Recompute was triggered by the user demoting
+    ///     or excluding that cell), records each cell that was active
+    ///     before but isn't now — and isn't excluded, isn't the
+    ///     causing cell itself, and isn't already tracked — as a new
+    ///     orphan, with its <see cref="OrphanedRow.Snapshot" /> drawn
+    ///     from <paramref name="activeBefore" />.
     /// </summary>
     public void Reconcile(
         IReadOnlyDictionary<FormulaRef, BindingRow> activeBefore,
         IReadOnlySet<FormulaRef> activeAfter,
         IReadOnlySet<FormulaRef> excluded,
-        FormulaRef? demotedCell)
+        FormulaRef? causedBy)
     {
         // Drop orphans that the engine resurfaced. A row reappears when
         // some unrelated change (e.g. promoting another cell that
@@ -95,7 +104,7 @@ internal sealed class OrphanedRowTracker
         foreach (var src in activeAfter)
             _orphaned.Remove(src);
 
-        if (demotedCell == null)
+        if (causedBy == null)
             return;
 
         foreach (var (src, snap) in activeBefore)
@@ -104,15 +113,15 @@ internal sealed class OrphanedRowTracker
             // Excluded cells already have their own visual treatment
             // (the excluded-row snapshot lane); they're not orphans.
             if (excluded.Contains(src)) continue;
-            // The demoted cell itself stays as a binding (now an input
-            // RHS = cell-ref) — it's the one row the demote keeps
-            // visible by design, not an orphan.
-            if (src.Equals(demotedCell)) continue;
+            // The causing cell stays visible by design — demoted to
+            // input in the bindings list, or muted in the excluded
+            // lane — not an orphan.
+            if (src.Equals(causedBy)) continue;
             // First-write wins. A cell already attributed to a
-            // previous demoter shouldn't get re-attributed by a fresh
-            // demote that didn't actually cause this drop.
+            // previous causer shouldn't get re-attributed by a fresh
+            // demote/exclude that didn't actually cause this drop.
             if (_orphaned.ContainsKey(src)) continue;
-            _orphaned[src] = new OrphanedRow(snap, demotedCell);
+            _orphaned[src] = new OrphanedRow(snap, causedBy);
         }
     }
 }


### PR DESCRIPTION
## Summary

- New `OrphanedRowTracker` records precedents that fell off the active bindings list because their only path ran through a cell the user demoted **or excluded**, plus the cause cell.
- `GatherWindow` surfaces them in a separate "Orphaned" section beneath the active bindings, with an "orphaned by &lt;addr&gt;" hint per row. Mirrors the excluded-row pattern from PR 10.
- Orphan rows are inert (no checkbox, no role toggle, muted) and don't participate in `Recompute` as `RowState` entries. Reversing the cause — re-include the excluded cell, or promote the demoted one — clears its orphans.
- No engine changes — the existing demote/exclude already drops unreachable precedents; this PR just keeps them visible.

Closes #157

## Test plan

- [x] 12 unit tests on `OrphanedRowTracker` covering demote and exclude paths: cells dropped via cause, demoted-or-excluded cell itself isn't tracked as orphan, excluded-cell exclusion, no-cause Recompute adds nothing, resurfacing drops orphans, `Forget` drops only its own orphans, unrelated demotes preserve attribution, first-write-wins on re-attribution, exclude-step records orphan, re-include surfaces back via Reconcile.
- [x] All 634 unit tests pass.
- [ ] Manual Excel smoke (Tim): A1=10, B1=`=A1*2`, C1=`=B1+1` (sink). `/Gather` → demote B1 → A1 appears in new Orphaned section with "orphaned by B1" hint. Promote B1 → A1 returns to bindings. Re-test with the **Include** checkbox: uncheck B1 → A1 appears as "orphaned by B1" → re-tick B1 → A1 returns. Toggle Include on an unrelated row → A1 stays in Orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)