### PR TITLE
Extend SetState and SetVars to 10 slots/pairs

### DIFF
--- a/lambdas/loops/SetState.lambda
+++ b/lambdas/loops/SetState.lambda
@@ -1,7 +1,8 @@
 /*  FUNCTION NAME:      SetState
-    DESCRIPTION:*//**Builds a fresh state holding up to 5 positional values, accessible by index via GetVarAt.*/
+    DESCRIPTION:*//**Builds a fresh state holding up to 10 positional values, accessible by index via GetVarAt.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-27  Claude      Initial version
+                        2026-05-02  Claude      Extend slot capacity from 5 to 10
 */
 SetState = LAMBDA(
 //  Parameter Declarations
@@ -10,14 +11,19 @@ SetState = LAMBDA(
     [v_3],
     [v_4],
     [v_5],
+    [v_6],
+    [v_7],
+    [v_8],
+    [v_9],
+    [v_10],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →SetState([v_1], [v_2], [v_3], [v_4], [v_5])¶" &
-                "DESCRIPTION:   →Builds a fresh state holding up to 5 positional values, accessible by index via GetVarAt.¶" &
-                "VERSION:       →Apr 27 2026¶" &
+                "FUNCTION:      →SetState([v_1], [v_2], [v_3], [v_4], [v_5], [v_6], [v_7], [v_8], [v_9], [v_10])¶" &
+                "DESCRIPTION:   →Builds a fresh state holding up to 10 positional values, accessible by index via GetVarAt.¶" &
+                "VERSION:       →May 02 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   v_1            →(Required) Slot 1 value. Read with GetVarAt(state, 1).¶" &
-                "   v_2..v_5       →(Optional) Up to four more slot values. Read with GetVarAt(state, N).¶" &
+                "   v_2..v_10      →(Optional) Up to nine more slot values. Read with GetVarAt(state, N).¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=SetState(1, 2, {10;20;30})¶" &
                 "Result         →state with slot 1 = 1, slot 2 = 2, slot 3 = {10;20;30}",
@@ -31,7 +37,12 @@ SetState = LAMBDA(
         s_3, IF(ISOMITTED(v_3), s_2, SetVar(s_2, "3", v_3)),
         s_4, IF(ISOMITTED(v_4), s_3, SetVar(s_3, "4", v_4)),
         s_5, IF(ISOMITTED(v_5), s_4, SetVar(s_4, "5", v_5)),
-        result, s_5,
+        s_6, IF(ISOMITTED(v_6), s_5, SetVar(s_5, "6", v_6)),
+        s_7, IF(ISOMITTED(v_7), s_6, SetVar(s_6, "7", v_7)),
+        s_8, IF(ISOMITTED(v_8), s_7, SetVar(s_7, "8", v_8)),
+        s_9, IF(ISOMITTED(v_9), s_8, SetVar(s_8, "9", v_9)),
+        s_10, IF(ISOMITTED(v_10), s_9, SetVar(s_9, "10", v_10)),
+        result, s_10,
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/loops/SetState.tests.yaml
+++ b/lambdas/loops/SetState.tests.yaml
@@ -11,6 +11,10 @@ tests:
     args: ["=1", "=2", "=3", "=4", "=5"]
     expected: "1\x1En\x1E1\x1F2\x1En\x1E2\x1F3\x1En\x1E3\x1F4\x1En\x1E4\x1F5\x1En\x1E5"
 
+  - name: ten numeric values
+    args: ["=1", "=2", "=3", "=4", "=5", "=6", "=7", "=8", "=9", "=10"]
+    expected: "1\x1En\x1E1\x1F2\x1En\x1E2\x1F3\x1En\x1E3\x1F4\x1En\x1E4\x1F5\x1En\x1E5\x1F6\x1En\x1E6\x1F7\x1En\x1E7\x1F8\x1En\x1E8\x1F9\x1En\x1E9\x1F10\x1En\x1E10"
+
   - name: numeric array value at slot 3
     args: ["=1", "=2", "={10;20;30}"]
     expected: "1\x1En\x1E1\x1F2\x1En\x1E2\x1F3\x1En\x1E10\x1D20\x1D30"

--- a/lambdas/loops/SetVars.lambda
+++ b/lambdas/loops/SetVars.lambda
@@ -1,7 +1,8 @@
 /*  FUNCTION NAME:      SetVars
-    DESCRIPTION:*//**Builds a fresh state holding up to 5 named variables. Alternating positional pairs.*/
+    DESCRIPTION:*//**Builds a fresh state holding up to 10 named variables. Alternating positional pairs.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-27  Claude      Initial version
+                        2026-05-02  Claude      Extend pair capacity from 5 to 10
 */
 SetVars = LAMBDA(
 //  Parameter Declarations
@@ -15,14 +16,24 @@ SetVars = LAMBDA(
     [v_4],
     [n_5],
     [v_5],
+    [n_6],
+    [v_6],
+    [n_7],
+    [v_7],
+    [n_8],
+    [v_8],
+    [n_9],
+    [v_9],
+    [n_10],
+    [v_10],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →SetVars(n_1, v_1, [n_2], [v_2], [n_3], [v_3], [n_4], [v_4], [n_5], [v_5])¶" &
-                "DESCRIPTION:   →Builds a fresh state holding up to 5 named variables. Alternating positional pairs.¶" &
-                "VERSION:       →Apr 27 2026¶" &
+                "FUNCTION:      →SetVars(n_1, v_1, [n_2], [v_2], ..., [n_10], [v_10])¶" &
+                "DESCRIPTION:   →Builds a fresh state holding up to 10 named variables. Alternating positional pairs.¶" &
+                "VERSION:       →May 02 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   n_1, v_1       →(Required) First name and value pair.¶" &
-                "   n_2..v_5       →(Optional) Up to four more name/value pairs.¶" &
+                "   n_2..v_10      →(Optional) Up to nine more name/value pairs.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=SetVars(""cur"", 1, ""best"", 1, ""ends"", 1)¶" &
                 "Result         →state holding cur=1, best=1, ends=1¶" &
@@ -37,7 +48,12 @@ SetVars = LAMBDA(
         s_3, IF(ISOMITTED(n_3), s_2, SetVar(s_2, n_3, v_3)),
         s_4, IF(ISOMITTED(n_4), s_3, SetVar(s_3, n_4, v_4)),
         s_5, IF(ISOMITTED(n_5), s_4, SetVar(s_4, n_5, v_5)),
-        result, s_5,
+        s_6, IF(ISOMITTED(n_6), s_5, SetVar(s_5, n_6, v_6)),
+        s_7, IF(ISOMITTED(n_7), s_6, SetVar(s_6, n_7, v_7)),
+        s_8, IF(ISOMITTED(n_8), s_7, SetVar(s_7, n_8, v_8)),
+        s_9, IF(ISOMITTED(n_9), s_8, SetVar(s_8, n_9, v_9)),
+        s_10, IF(ISOMITTED(n_10), s_9, SetVar(s_9, n_10, v_10)),
+        result, s_10,
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/loops/SetVars.tests.yaml
+++ b/lambdas/loops/SetVars.tests.yaml
@@ -11,6 +11,10 @@ tests:
     args: ["a", "=1", "b", "=2", "c", "=3", "d", "=4", "e", "=5"]
     expected: "a\x1En\x1E1\x1Fb\x1En\x1E2\x1Fc\x1En\x1E3\x1Fd\x1En\x1E4\x1Fe\x1En\x1E5"
 
+  - name: ten numeric pairs
+    args: ["a", "=1", "b", "=2", "c", "=3", "d", "=4", "e", "=5", "f", "=6", "g", "=7", "h", "=8", "i", "=9", "j", "=10"]
+    expected: "a\x1En\x1E1\x1Fb\x1En\x1E2\x1Fc\x1En\x1E3\x1Fd\x1En\x1E4\x1Fe\x1En\x1E5\x1Ff\x1En\x1E6\x1Fg\x1En\x1E7\x1Fh\x1En\x1E8\x1Fi\x1En\x1E9\x1Fj\x1En\x1E10"
+
   - name: numeric array uses gs separator
     args: ["arr", "={10;20;30}"]
     expected: "arr\x1En\x1E10\x1D20\x1D30"

--- a/lambdas/loops/SplitState.lambda
+++ b/lambdas/loops/SplitState.lambda
@@ -1,23 +1,26 @@
 /*  FUNCTION NAME:      SplitState
-    DESCRIPTION:*//**Splits a state (or column of states) into one row of values per state. Scalars are coerced to native types via the per-entry tag; arrays render as [a, b, c].*/
+    DESCRIPTION:*//**Splits a state (or column of states) into one row of values per state. Scalars are coerced to native types via the per-entry tag; arrays render as [a, b, c]. Optionally prepends a header row of variable names.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-27  Claude      Initial version
                         2026-04-29  Claude      Skip past per-entry type tag when extracting payload
                         2026-04-29  Claude      Coerce scalar payloads to native types via tag
+                        2026-05-02  Claude      Add IncludeHeaders to prepend a row of variable names
 */
 SplitState = LAMBDA(
 //  Parameter Declarations
     [state],
+    [IncludeHeaders],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →SplitState(state)¶" &
-                "DESCRIPTION:   →Splits a state (or column of states) into one row of values per state. Scalars are coerced to native types (number/boolean/text) via the per-entry tag; arrays render as [a, b, c].¶" &
-                "VERSION:       →Apr 29 2026¶" &
+                "FUNCTION:      →SplitState(state, [IncludeHeaders])¶" &
+                "DESCRIPTION:   →Splits a state (or column of states) into one row of values per state. Scalars are coerced to native types (number/boolean/text) via the per-entry tag; arrays render as [a, b, c]. Optionally prepends a header row of variable names.¶" &
+                "VERSION:       →May 02 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   state          →(Required) Scalar state, or a vertical column of states (e.g. SCAN result).¶" &
+                "   IncludeHeaders →(Optional) Pass TRUE to prepend a row of variable names taken from the first state. Defaults to FALSE.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=SplitState(SCAN(SetState(0,0), SEQUENCE(5), reducer))¶" &
-                "Result         →5xN table: each row is one iteration's variable values¶" &
+                "Formula        →=SplitState(SCAN(SetState(0,0), SEQUENCE(5), reducer), TRUE)¶" &
+                "Result         →(5+1)xN table: header row of variable names, then one row per iteration¶" &
                 "NOTE:          →Pair with SCAN to inspect REDUCE state at every iteration. Column order matches insertion order. Array slots are flattened to a [a, b, c] text preview because a 2D output cell can't hold a nested array.",
                 "→", "¶"
                 ),
@@ -31,7 +34,7 @@ SplitState = LAMBDA(
         firstState, INDEX(state, 1, 1),
         firstParts, IF(firstState = "", "(empty)", TEXTSPLIT(firstState, us)),
         numVars, COLUMNS(firstParts),
-        result, MAKEARRAY(n, numVars, LAMBDA(r, c,
+        body, MAKEARRAY(n, numVars, LAMBDA(r, c,
                     LET(
                         s, INDEX(state, r, 1),
                         IF(s = "", "(empty)",
@@ -49,6 +52,13 @@ SplitState = LAMBDA(
                         )
                     )
                 )),
+        wantHeaders?, AND(NOT(ISOMITTED(IncludeHeaders)), IncludeHeaders, firstState <> ""),
+        headers, IF(wantHeaders?,
+                    MAKEARRAY(1, numVars, LAMBDA(r, c,
+                        LET(part, INDEX(firstParts, 1, c),
+                            LEFT(part, FIND(rs, part) - 1)))),
+                    ""),
+        result, IF(wantHeaders?, VSTACK(headers, body), body),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/loops/SplitState.tests.yaml
+++ b/lambdas/loops/SplitState.tests.yaml
@@ -39,6 +39,27 @@ tests:
     args: ['=NewState()']
     expected: "(empty)"
 
+  - name: include headers prepends variable names row
+    args: ['=SetVars("cur", 1, "best", 5)', "=TRUE"]
+    expected:
+      - ["cur", "best"]
+      - [1, 5]
+
+  - name: include headers with column of states
+    args:
+      [
+        '=VSTACK(SetVars("a", 1, "b", 2), SetVars("a", 3, "b", 4))',
+        "=TRUE",
+      ]
+    expected:
+      - ["a", "b"]
+      - [1, 2]
+      - [3, 4]
+
+  - name: include headers FALSE matches default behaviour
+    args: ['=SetVars("cur", 1, "best", 5)', "=FALSE"]
+    expected: [[1, 5]]
+
   - name: help text
     args: []
     expected_type: array


### PR DESCRIPTION
## Summary
- Bump `SetState` from 5 to 10 positional slots (`v_1`..`v_10`)
- Bump `SetVars` from 5 to 10 name/value pairs (`n_1/v_1`..`n_10/v_10`)
- Add optional `IncludeHeaders` to `SplitState` — when TRUE, prepends a row of variable names taken from the first state (consistent with how the existing code already derives column count from the first state)

Closes #160

## Test plan
- [x] `dotnet build addin/lambda-boss.slnx` — clean
- [x] `dotnet test addin/lambda-boss.Tests` — 748 passed
- [x] `dotnet test addin/lambda-boss.AddinTests` (Excel harness) — 242 passed, including new `ten numeric values`, `ten numeric pairs`, and three new `IncludeHeaders` cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)