### PR TITLE
Fix Edit Lambda for omitted optional arguments

### DIFF
--- a/addin/lambda-boss.Tests/EditLambdaCommandTests.cs
+++ b/addin/lambda-boss.Tests/EditLambdaCommandTests.cs
@@ -137,25 +137,33 @@ public class EditLambdaCommandTests
     }
 
     [Fact]
-    public void BuildExpandedLet_FewerArgsThanParams_LeavesTrailingUnbound()
+    public void BuildExpandedLet_FewerArgsThanParams_BindsOmittedToNa()
     {
+        // No ISOMITTED default to extract, so omitted params fall back to NA()
+        // — a valid binding that surfaces #N/A rather than an invalid LET.
         var sig = new LambdaSignature(["x", "y", "z"], "x + y + z");
         var result = EditLambdaCommand.BuildExpandedLet(sig, ["A1"]);
 
         Assert.Equal(Lines(
             "=LET(",
             "    x, A1,",
+            "    y, NA(),",
+            "    z, NA(),",
             "    x + y + z",
             ")"), result);
     }
 
     [Fact]
-    public void BuildExpandedLet_ZeroArgsWithParams_OmitsLetWrapper()
+    public void BuildExpandedLet_ZeroArgsWithParams_BindsOmittedToNa()
     {
         var sig = new LambdaSignature(["x"], "x + 1");
         var result = EditLambdaCommand.BuildExpandedLet(sig, []);
 
-        Assert.Equal("=x + 1", result);
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, NA(),",
+            "    x + 1",
+            ")"), result);
     }
 
     [Fact]
@@ -286,5 +294,163 @@ public class EditLambdaCommandTests
             "    y, MAX(x),",
             "    x + y",
             ")"), expanded);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_OmittedOptional_GeneratedLambda_MergesWrapperToDefault()
+    {
+        // LET to Lambda emits the optional param as `c, IF(ISOMITTED(c), 3, c)`.
+        // Omitting c should merge that wrapper back to the bare default `c, 3`.
+        var sig = LambdaSignatureParser.Parse(
+            "=LAMBDA(a, b, [c], LET(c, IF(ISOMITTED(c), 3, c), a + b + c))");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, ["1", "2"]);
+
+        Assert.Equal(Lines(
+            "=LET(",
+            "    a, 1,",
+            "    b, 2,",
+            "    c, 3,",
+            "    a + b + c",
+            ")"), result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_SuppliedOptional_GeneratedLambda_MergesWrapperToArg()
+    {
+        // Supplying c should merge the wrapper to the supplied argument, not the
+        // default.
+        var sig = LambdaSignatureParser.Parse(
+            "=LAMBDA(a, b, [c], LET(c, IF(ISOMITTED(c), 3, c), a + b + c))");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, ["1", "2", "9"]);
+
+        Assert.Equal(Lines(
+            "=LET(",
+            "    a, 1,",
+            "    b, 2,",
+            "    c, 9,",
+            "    a + b + c",
+            ")"), result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_OmittedOptional_HandAuthored_AddsParamBinding()
+    {
+        // EXPLODE-style: the wrapper's binding name (_size) differs from the
+        // param (chunk_size). The param has no binding of its own, so one is
+        // added with the extracted default, and the stray ISOMITTED is
+        // neutralised to FALSE.
+        var sig = LambdaSignatureParser.Parse(
+            "=LAMBDA(text, [chunk_size], "
+            + "LET(_size, IF(ISOMITTED(chunk_size), 1, chunk_size), "
+            + "MID(text, 1, _size)))");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, ["A1"]);
+
+        Assert.Equal(Lines(
+            "=LET(",
+            "    text, A1,",
+            "    chunk_size, 1,",
+            "    _size, IF(FALSE, 1, chunk_size),",
+            "    MID(text, 1, _size)",
+            ")"), result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_NeutralizesIsOmittedToFalse_ForSuppliedParam()
+    {
+        // `Help?, ISOMITTED(text)` references a supplied param; ISOMITTED is
+        // illegal in a LET so it must become FALSE.
+        var sig = LambdaSignatureParser.Parse(
+            "=LAMBDA(text, LET(Help?, ISOMITTED(text), IF(Help?, 0, text)))");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, ["A1"]);
+
+        Assert.Equal(Lines(
+            "=LET(",
+            "    text, A1,",
+            "    Help?, FALSE,",
+            "    IF(Help?, 0, text)",
+            ")"), result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_IsOmittedInsideStringLiteral_NotReplaced()
+    {
+        // The literal text "ISOMITTED" inside a help string must be left alone.
+        var sig = LambdaSignatureParser.Parse(
+            "=LAMBDA(x, LET(note, \"uses ISOMITTED(y) internally\", "
+            + "CONCAT(note, x)))");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, ["A1"]);
+
+        Assert.Contains("uses ISOMITTED(y) internally", result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_OmittedNoDefault_FallsBackToNa()
+    {
+        var sig = LambdaSignatureParser.Parse("=LAMBDA(x, y, x + y)");
+        var result = EditLambdaCommand.BuildExpandedLet(sig, ["A1"]);
+
+        Assert.Equal(Lines(
+            "=LET(",
+            "    x, A1,",
+            "    y, NA(),",
+            "    x + y",
+            ")"), result);
+    }
+
+    [Fact]
+    public void ExtractIsOmittedDefault_ParamSubstring_NotMatched()
+    {
+        // `size` must not match inside `chunk_size`.
+        var defaultFor = EditLambdaCommand.ExtractIsOmittedDefault(
+            ["IF(ISOMITTED(chunk_size), 1, chunk_size)"], "size");
+
+        Assert.Null(defaultFor);
+    }
+
+    [Fact]
+    public void ExtractIsOmittedDefault_NestedIf_ExtractsFullDefault()
+    {
+        var defaultFor = EditLambdaCommand.ExtractIsOmittedDefault(
+            ["IF(ISOMITTED(p), IF(A1>0, 1, 2), p)"], "p");
+
+        Assert.Equal("IF(A1>0, 1, 2)", defaultFor);
+    }
+
+    [Fact]
+    public void NeutralizeIsOmitted_ReplacesOutsideStringsOnly()
+    {
+        var result = EditLambdaCommand.NeutralizeIsOmitted(
+            "IF(ISOMITTED(a), \"ISOMITTED(b)\", a)");
+
+        Assert.Equal("IF(FALSE, \"ISOMITTED(b)\", a)", result);
+    }
+
+    [Fact]
+    public void BuildExpandedLet_FullExplode_ProducesValidLet()
+    {
+        // A faithful registered form of EXPLODE (no // comments, brackets kept
+        // on optional params). Calling with only `text` must yield a valid LET
+        // with no surviving ISOMITTED and both optional params bound.
+        var refersTo =
+            "=LAMBDA([text], [chunk_size], [horizontal], "
+            + "LET("
+            + "Help, TEXTSPLIT(\"FUNCTION: EXPLODE(text, chunk_size, horizontal)\", \"->\", \"|\"), "
+            + "Help?, ISOMITTED(text), "
+            + "_size, IF(ISOMITTED(chunk_size), 1, chunk_size), "
+            + "_horiz, IF(ISOMITTED(horizontal), FALSE, horizontal), "
+            + "_count, CEILING(LEN(text) / _size, 1), "
+            + "_starts, IF(_horiz, SEQUENCE(1, _count, 1, _size), SEQUENCE(_count, 1, 1, _size)), "
+            + "result, MID(text, _starts, _size), "
+            + "IF(Help?, Help, result)))";
+
+        var sig = LambdaSignatureParser.Parse(refersTo);
+        var result = EditLambdaCommand.BuildExpandedLet(sig, ["O13"]);
+
+        Assert.StartsWith("=LET(", result);
+        Assert.DoesNotContain("ISOMITTED", result);
+        Assert.Contains("text, O13,", result);
+        Assert.Contains("chunk_size, 1,", result);
+        Assert.Contains("horizontal, FALSE,", result);
+        Assert.Contains("Help?, FALSE,", result);
     }
 }

--- a/addin/lambda-boss/Commands/EditLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/EditLambdaCommand.cs
@@ -134,12 +134,25 @@ internal static class EditLambdaCommand
 
     /// <summary>
     ///     Builds a <c>=LET(param1, arg1, ..., body)</c> formula that binds
-    ///     as many of the LAMBDA's parameters as call-site arguments were
-    ///     provided. When the LAMBDA body is itself a LET, its bindings are
-    ///     folded into the outer LET so the result is a single flat LET
-    ///     rather than a LET-inside-LET. Output is formatted with newlines so
-    ///     it renders legibly in Excel's formula bar. Throws when the caller
-    ///     passed more arguments than the LAMBDA declares.
+    ///     every one of the LAMBDA's parameters to a concrete value. When the
+    ///     LAMBDA body is itself a LET, its bindings are folded into the outer
+    ///     LET so the result is a single flat LET rather than a LET-inside-LET.
+    ///     Output is formatted with newlines so it renders legibly in Excel's
+    ///     formula bar. Throws when the caller passed more arguments than the
+    ///     LAMBDA declares.
+    ///     <para>
+    ///         Optional arguments the caller omitted still need a value, because
+    ///         the body references them — both directly and via
+    ///         <c>ISOMITTED(p)</c>, which is meaningless outside a LAMBDA and so
+    ///         would make the LET invalid. Each omitted parameter is bound to a
+    ///         default extracted from the canonical
+    ///         <c>IF(ISOMITTED(p), default, p)</c> wrapper (or <c>NA()</c> when
+    ///         no default is discoverable), and every remaining
+    ///         <c>ISOMITTED(x)</c> is neutralised to <c>FALSE</c>. The result is
+    ///         the plain LET the author started with before LET to LAMBDA was
+    ///         run; optionality is not preserved (it cannot be in a LET) and is
+    ///         re-applied by re-running LET to LAMBDA.
+    ///     </para>
     /// </summary>
     internal static string BuildExpandedLet(LambdaSignature signature, IReadOnlyList<string> arguments)
     {
@@ -153,18 +166,72 @@ internal static class EditLambdaCommand
                 + $"but {arguments.Count} were provided.");
         }
 
-        var pairs = new List<(string Name, string Value)>();
-        for (var i = 0; i < arguments.Count; i++)
-            pairs.Add((signature.Parameters[i], arguments[i]));
-
+        // Fold a body that is itself a single LET into the outer binding list.
+        List<(string Name, string Value)> folded;
         string body;
         if (TryParseBodyAsLet(signature.Body, out var innerBindings, out var innerBody))
         {
-            pairs.AddRange(innerBindings);
+            folded = innerBindings;
             body = innerBody;
         }
         else
+        {
+            folded = [];
             body = signature.Body;
+        }
+
+        // Original (pre-neutralisation) text in which to discover the default
+        // expression for omitted parameters. Defaults live inside the canonical
+        // IF(ISOMITTED(p), default, p) wrapper, which may sit in any folded
+        // binding RHS or the body.
+        var corpus = folded.Select(b => b.Value).Append(body).ToList();
+
+        // Leading parameter block. Supplied params are always bound to their
+        // argument. Omitted params are bound to their extracted default (or
+        // NA()), but only when referenced and not already represented by a
+        // same-named folded binding.
+        var paramBlock = new List<(string Name, string Value)>();
+        for (var i = 0; i < signature.Parameters.Count; i++)
+        {
+            var name = signature.Parameters[i];
+            var supplied = i < arguments.Count;
+            var value = supplied
+                ? arguments[i]
+                : ExtractIsOmittedDefault(corpus, name) ?? "NA()";
+
+            // A folded binding whose name == param and whose RHS is the param's
+            // ISOMITTED wrapper IS the param's binding (the shape
+            // LetToLambdaBuilder emits for an optional param). Replace its RHS
+            // with the resolved value rather than adding a duplicate — this also
+            // removes the self-reference (p, IF(ISOMITTED(p), d, p)) that Excel
+            // rejects outright when writing the formula.
+            var mergeIndex = folded.FindIndex(b =>
+                string.Equals(b.Name, name, StringComparison.OrdinalIgnoreCase)
+                && IsIsOmittedWrapperFor(b.Value, name));
+            if (mergeIndex >= 0)
+            {
+                folded[mergeIndex] = (folded[mergeIndex].Name, value);
+                continue;
+            }
+
+            // A same-named folded binding that isn't a wrapper already binds the
+            // name (e.g. a calculation); don't shadow it with a duplicate.
+            if (folded.Any(b => string.Equals(b.Name, name, StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            // An omitted parameter that nothing references needs no binding.
+            if (!supplied && !corpus.Any(t => ReferencesIdentifier(t, name)))
+                continue;
+
+            paramBlock.Add((name, value));
+        }
+
+        var pairs = paramBlock.Concat(folded).ToList();
+
+        // ISOMITTED is meaningless in a LET, and every parameter now has a
+        // concrete value, so neutralise any remaining ISOMITTED(x) to FALSE.
+        pairs = pairs.Select(p => (p.Name, NeutralizeIsOmitted(p.Value))).ToList();
+        body = NeutralizeIsOmitted(body);
 
         if (pairs.Count == 0)
             return "=" + body;
@@ -173,6 +240,209 @@ internal static class EditLambdaCommand
         sb.Append('=');
         FormulaFormatter.AppendLet(sb, 0, pairs, body);
         return sb.ToString();
+    }
+
+    private static readonly Regex IsOmittedCallPattern = new(
+        @"^ISOMITTED\s*\(\s*([A-Za-z_][A-Za-z0-9_.?]*)\s*\)$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex IsOmittedAnyPattern = new(
+        @"ISOMITTED\s*\(\s*[A-Za-z_][A-Za-z0-9_.?]*\s*\)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    ///     Returns the default expression for <paramref name="param" /> by
+    ///     scanning each text for a top-level <c>IF(ISOMITTED(param), default,
+    ///     ...)</c> and returning its second argument, or null if none is found.
+    ///     String literals are skipped so an IF embedded in a help string is
+    ///     ignored. Nested IFs are descended into so a wrapper inside another
+    ///     expression is still discovered.
+    /// </summary>
+    internal static string? ExtractIsOmittedDefault(IEnumerable<string> texts, string param)
+    {
+        foreach (var text in texts)
+        {
+            var i = 0;
+            while (i < text.Length)
+            {
+                if (text[i] == '"')
+                {
+                    i = SkipString(text, i);
+                    continue;
+                }
+
+                if (!StartsWithIfOpen(text, i, out var afterOpenParen))
+                {
+                    i++;
+                    continue;
+                }
+
+                var openParen = afterOpenParen - 1;
+                var closeParen = LetParser.FindMatchingClose(text, openParen);
+                if (closeParen < 0)
+                {
+                    i++;
+                    continue;
+                }
+
+                var inner = text[(openParen + 1)..closeParen];
+                var args = LetParser.SplitTopLevelCommas(inner).Select(a => a.Trim()).ToList();
+                if (args.Count == 3 && IsIsOmittedCall(args[0], param))
+                    return args[1];
+
+                // Not a match for this param; descend in case a wrapper is
+                // nested inside.
+                i = afterOpenParen;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     True when <paramref name="rhs" /> is exactly the canonical optional
+    ///     wrapper <c>IF(ISOMITTED(param), default, param)</c>.
+    /// </summary>
+    private static bool IsIsOmittedWrapperFor(string rhs, string param)
+    {
+        var trimmed = rhs.Trim();
+        if (!StartsWithIfOpen(trimmed, 0, out var afterOpenParen))
+            return false;
+
+        var openParen = afterOpenParen - 1;
+        var closeParen = LetParser.FindMatchingClose(trimmed, openParen);
+        if (closeParen < 0)
+            return false;
+
+        for (var i = closeParen + 1; i < trimmed.Length; i++)
+            if (!char.IsWhiteSpace(trimmed[i]))
+                return false;
+
+        var inner = trimmed[(openParen + 1)..closeParen];
+        var args = LetParser.SplitTopLevelCommas(inner).Select(a => a.Trim()).ToList();
+        return args.Count == 3
+            && IsIsOmittedCall(args[0], param)
+            && string.Equals(args[2], param, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsIsOmittedCall(string text, string param)
+    {
+        var match = IsOmittedCallPattern.Match(text.Trim());
+        return match.Success
+            && string.Equals(match.Groups[1].Value, param, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    ///     Replaces every <c>ISOMITTED(identifier)</c> outside a string literal
+    ///     with <c>FALSE</c>. ISOMITTED has no meaning in a LET; once every
+    ///     parameter is bound, the answer is always "not omitted".
+    /// </summary>
+    internal static string NeutralizeIsOmitted(string text)
+    {
+        if (text.IndexOf("ISOMITTED", StringComparison.OrdinalIgnoreCase) < 0)
+            return text;
+
+        var result = new StringBuilder();
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (text[i] == '"')
+            {
+                var end = SkipString(text, i);
+                result.Append(text, i, end - i);
+                i = end;
+                continue;
+            }
+
+            var nextQuote = text.IndexOf('"', i);
+            var segEnd = nextQuote < 0 ? text.Length : nextQuote;
+            result.Append(IsOmittedAnyPattern.Replace(text[i..segEnd], "FALSE"));
+            i = segEnd;
+        }
+
+        return result.ToString();
+    }
+
+    /// <summary>
+    ///     True when <paramref name="ident" /> appears as a whole identifier in
+    ///     <paramref name="text" /> outside any string literal.
+    /// </summary>
+    private static bool ReferencesIdentifier(string text, string ident)
+    {
+        var pattern = new Regex(
+            $@"(?<![A-Za-z0-9_.?])(?:{Regex.Escape(ident)})(?![A-Za-z0-9_.?])",
+            RegexOptions.IgnoreCase);
+
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (text[i] == '"')
+            {
+                i = SkipString(text, i);
+                continue;
+            }
+
+            var nextQuote = text.IndexOf('"', i);
+            var segEnd = nextQuote < 0 ? text.Length : nextQuote;
+            if (pattern.IsMatch(text[i..segEnd]))
+                return true;
+            i = segEnd;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     True when the text at <paramref name="position" /> starts a
+    ///     case-insensitive <c>IF(</c> token with an identifier boundary on the
+    ///     left. <paramref name="afterOpenParen" /> is set to the index just
+    ///     after the open paren on success.
+    /// </summary>
+    private static bool StartsWithIfOpen(string text, int position, out int afterOpenParen)
+    {
+        afterOpenParen = -1;
+        if (position + 1 >= text.Length)
+            return false;
+        if ((text[position] | 0x20) != 'i')
+            return false;
+        if ((text[position + 1] | 0x20) != 'f')
+            return false;
+        if (position > 0 && IsIdentifierChar(text[position - 1]))
+            return false;
+
+        var j = position + 2;
+        while (j < text.Length && char.IsWhiteSpace(text[j]))
+            j++;
+        if (j >= text.Length || text[j] != '(')
+            return false;
+
+        afterOpenParen = j + 1;
+        return true;
+    }
+
+    private static bool IsIdentifierChar(char c)
+        => char.IsLetterOrDigit(c) || c == '_' || c == '.' || c == '?';
+
+    private static int SkipString(string text, int openQuoteIndex)
+    {
+        var i = openQuoteIndex + 1;
+        while (i < text.Length)
+        {
+            if (text[i] == '"')
+            {
+                if (i + 1 < text.Length && text[i + 1] == '"')
+                {
+                    i += 2;
+                    continue;
+                }
+
+                return i + 1;
+            }
+
+            i++;
+        }
+
+        return text.Length;
     }
 
     /// <summary>

--- a/addin/lambda-boss/Commands/RefactorCommand.cs
+++ b/addin/lambda-boss/Commands/RefactorCommand.cs
@@ -1,11 +1,8 @@
+using ExcelDna.Integration;
+using LambdaBoss.Common;
+using LambdaBoss.UI;
 using System.Windows;
 using System.Windows.Interop;
-
-using ExcelDna.Integration;
-
-using LambdaBoss.UI;
-
-using LambdaBoss.Common;
 
 namespace LambdaBoss.Commands;
 
@@ -25,25 +22,25 @@ internal static class RefactorCommand
         try
         {
             dynamic app = ExcelDnaUtil.Application;
-            dynamic workbook = app.ActiveWorkbook;
+            var workbook = app.ActiveWorkbook;
             if (workbook == null)
                 return;
 
-            dynamic activeCell = app.ActiveCell;
+            var activeCell = app.ActiveCell;
             if (activeCell == null)
                 return;
 
-            dynamic worksheet = activeCell.Worksheet;
-            string sheetName = (string)worksheet.Name;
+            var worksheet = activeCell.Worksheet;
+            var sheetName = (string)worksheet.Name;
 
-            bool hasFormula = (bool)activeCell.HasFormula;
+            var hasFormula = (bool)activeCell.HasFormula;
             if (!hasFormula)
                 return;
 
             // Formula2 is the dynamic-array-aware reader — the legacy
             // Formula property returns `@`-prefixed text for spill-shaped
             // cells, which would corrupt our refactor.
-            string formula = (string)activeCell.Formula2;
+            var formula = (string)activeCell.Formula2;
 
             // PR 3 — snapshot the workbook + active-sheet defined-name
             // catalogue once when the dialog opens. The engine consults
@@ -156,11 +153,11 @@ internal static class RefactorCommand
         {
             var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-            TryHarvestNames(dict, workbook?.Names, "workbook");
+            TryHarvestNames(dict, workbook.Names, "workbook");
 
             try
             {
-                TryHarvestNames(dict, worksheet?.Names, "worksheet");
+                TryHarvestNames(dict, worksheet.Names, "worksheet");
             }
             catch (Exception ex)
             {
@@ -178,13 +175,13 @@ internal static class RefactorCommand
             if (names is null) return;
             try
             {
-                int count = (int)names.Count;
+                var count = (int)names.Count;
                 for (var i = 1; i <= count; i++)
                 {
                     string? key = null;
                     try
                     {
-                        dynamic item = names[i];
+                        var item = names[i];
                         key = item.Name as string;
                         if (string.IsNullOrEmpty(key)) continue;
                         // Strip the sheet qualifier from worksheet-scoped

--- a/addin/lambda-boss/RefactorEngine.cs
+++ b/addin/lambda-boss/RefactorEngine.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -181,8 +183,8 @@ public static class RefactorEngine
             defaultPromotables,
             promotableLookup,
             rowStates,
-            nextAutoNameIndex: nameIndex,
-            existingBindingNames: ReadOnlyEmptySet<string>.Instance);
+            nameIndex,
+            ReadOnlyEmptySet<string>.Instance);
 
         var keptRows = materialised.Where(r => r.IsIncluded).ToList();
 
@@ -304,8 +306,8 @@ public static class RefactorEngine
             defaultPromotables,
             promotableLookup,
             rowStates,
-            nextAutoNameIndex: autoNameIndex,
-            existingBindingNames: existingBindingNames);
+            autoNameIndex,
+            existingBindingNames);
 
         // Step 5 — assemble the rewrite maps and synthesise.
         var keptRows = materialised.Where(r => r.IsIncluded).ToList();
@@ -587,33 +589,27 @@ public static class RefactorEngine
         if (context is { WorkbookNames.Count: > 0 })
         {
             var nameCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            var firstSpelling = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var nameOrder = new List<string>(); // canonical (first-found) spellings
 
             foreach (var scope in identifierScopes)
-            foreach (var identifier in WalkCandidateIdentifiers(scope))
-            {
-                if (excludeBindingNames.Contains(identifier)) continue;
-                if (!context.WorkbookNames.TryGetValue(identifier, out var refersTo)) continue;
-                if (LambdaSignatureParser.IsLambdaFormula(refersTo)) continue;
-
-                if (!nameCounts.ContainsKey(identifier))
+                foreach (var identifier in WalkCandidateIdentifiers(scope))
                 {
-                    firstSpelling[identifier] = identifier;
-                    nameOrder.Add(identifier);
+                    if (excludeBindingNames.Contains(identifier)) continue;
+                    if (!context.WorkbookNames.TryGetValue(identifier, out var refersTo)) continue;
+                    if (LambdaSignatureParser.IsLambdaFormula(refersTo)) continue;
+
+                    if (!nameCounts.ContainsKey(identifier))
+                        nameOrder.Add(identifier);
+
+                    nameCounts[identifier] = nameCounts.TryGetValue(identifier, out var c) ? c + 1 : 1;
                 }
 
-                nameCounts[identifier] = nameCounts.TryGetValue(identifier, out var c) ? c + 1 : 1;
-            }
-
             foreach (var spelling in nameOrder)
-            {
                 promotables.Add(new RefactorPromotableRow(
                     BuildNamedRangeKey(spelling),
                     RefactorPromotableKind.NamedRange,
                     spelling,
                     nameCounts[spelling]));
-            }
         }
 
         // Literals — numeric / string / boolean, deduped by parsed value
@@ -624,25 +620,23 @@ public static class RefactorEngine
         var litFirstText = new Dictionary<string, string>(StringComparer.Ordinal);
         var litOrder = new List<string>(); // value keys, first-seen order
         foreach (var scope in identifierScopes)
-        foreach (var tok in WalkLiterals(scope))
-        {
-            if (!litCounts.ContainsKey(tok.ValueKey))
+            foreach (var tok in WalkLiterals(scope))
             {
-                litOrder.Add(tok.ValueKey);
-                litFirstText[tok.ValueKey] = tok.Text;
+                if (!litCounts.ContainsKey(tok.ValueKey))
+                {
+                    litOrder.Add(tok.ValueKey);
+                    litFirstText[tok.ValueKey] = tok.Text;
+                }
+
+                litCounts[tok.ValueKey] = litCounts.TryGetValue(tok.ValueKey, out var c) ? c + 1 : 1;
             }
 
-            litCounts[tok.ValueKey] = litCounts.TryGetValue(tok.ValueKey, out var c) ? c + 1 : 1;
-        }
-
         foreach (var vk in litOrder)
-        {
             promotables.Add(new RefactorPromotableRow(
                 BuildLiteralKey(vk),
                 RefactorPromotableKind.Literal,
                 litFirstText[vk],
                 litCounts[vk]));
-        }
 
         return promotables;
     }
@@ -697,7 +691,6 @@ public static class RefactorEngine
     {
         var byKey = new Dictionary<string, PromotedInfo>(StringComparer.Ordinal);
         foreach (var p in defaultPromotables)
-        {
             switch (p.Kind)
             {
                 case RefactorPromotableKind.NamedRange:
@@ -705,18 +698,14 @@ public static class RefactorEngine
                     byKey[p.Key] = new PromotedInfo(p, null);
                     break;
                 case RefactorPromotableKind.ExternalRef:
-                    var fr = externalRefs.FirstOrDefault(
-                        r => BuildExternalRefKey(r, activeSheet) == p.Key);
+                    var fr = externalRefs.FirstOrDefault(r => BuildExternalRefKey(r, activeSheet) == p.Key);
                     if (fr != null)
                         byKey[p.Key] = new PromotedInfo(p, fr);
                     break;
             }
-        }
 
         return byKey;
     }
-
-    private sealed record PromotedInfo(RefactorPromotableRow Row, FormulaRef? ExternalSource);
 
     // ---------------- materialisation (rowState → kept rows) ----------------
 
@@ -751,9 +740,11 @@ public static class RefactorEngine
             ISet<string> existingBindingNames)
     {
         if (rowStates is null)
+        {
             return (
                 defaultInputRows.Select(r => new MaterialisedRow(r, true)).ToList(),
                 defaultPromotables.ToList());
+        }
 
         var byInputKey = defaultInputRows.ToDictionary(r => r.Key, StringComparer.Ordinal);
         var ordered = new List<MaterialisedRow>(rowStates.Count);
@@ -803,7 +794,7 @@ public static class RefactorEngine
             case RefactorPromotableKind.NamedRange:
                 return new RefactorInputRow(
                     info.Row.Key,
-                    Source: null,
+                    null,
                     name,
                     info.Row.Token,
                     RefactorRowOrigin.PromotedNamedRange);
@@ -817,7 +808,7 @@ public static class RefactorEngine
             case RefactorPromotableKind.Literal:
                 return new RefactorInputRow(
                     info.Row.Key,
-                    Source: null,
+                    null,
                     name,
                     info.Row.Token,
                     RefactorRowOrigin.PromotedLiteral);
@@ -941,19 +932,6 @@ public static class RefactorEngine
         return sb.ToString();
     }
 
-    // ---------------- literal tokenizer & rewrite (PR 4) ----------------
-
-    /// <summary>
-    ///     One literal occurrence found by <see cref="WalkLiterals" />:
-    ///     its <see cref="Start" /> / <see cref="Length" /> within the
-    ///     scanned text, the original <see cref="Text" /> (preserving
-    ///     spelling), and a value-based <see cref="ValueKey" /> used to
-    ///     dedupe occurrences and to look up promotion substitutions
-    ///     (so <c>0.20</c> and <c>0.2</c> share a key).
-    /// </summary>
-    private readonly record struct LiteralToken(
-        int Start, int Length, string Text, string ValueKey);
-
     /// <summary>
     ///     Walks <paramref name="text" /> left-to-right yielding every
     ///     numeric / string / boolean literal occurrence in source order.
@@ -1004,23 +982,23 @@ public static class RefactorEngine
 
             var numeric = NumericLiteralPattern.Match(text, i);
             if (numeric.Success && numeric.Index == i
-                && !SpanTouchesMask(masked, i, numeric.Length)
-                && double.TryParse(
-                    numeric.Value,
-                    System.Globalization.NumberStyles.Float,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    out var val))
+                                && !SpanTouchesMask(masked, i, numeric.Length)
+                                && double.TryParse(
+                                    numeric.Value,
+                                    NumberStyles.Float,
+                                    CultureInfo.InvariantCulture,
+                                    out var val))
             {
                 yield return new LiteralToken(
                     i, numeric.Length, numeric.Value,
-                    "num:" + val.ToString("R", System.Globalization.CultureInfo.InvariantCulture));
+                    "num:" + val.ToString("R", CultureInfo.InvariantCulture));
                 i += numeric.Length;
                 continue;
             }
 
             var boolean = BooleanLiteralPattern.Match(text, i);
             if (boolean.Success && boolean.Index == i
-                && !SpanTouchesMask(masked, i, boolean.Length))
+                                && !SpanTouchesMask(masked, i, boolean.Length))
             {
                 var isTrue = string.Equals(boolean.Value, "TRUE", StringComparison.OrdinalIgnoreCase);
                 yield return new LiteralToken(
@@ -1280,6 +1258,24 @@ public static class RefactorEngine
         return trimmed.StartsWith("=", StringComparison.Ordinal) ? trimmed[1..] : trimmed;
     }
 
+    private sealed record PromotedInfo(RefactorPromotableRow Row, FormulaRef? ExternalSource);
+
+    // ---------------- literal tokenizer & rewrite (PR 4) ----------------
+
+    /// <summary>
+    ///     One literal occurrence found by <see cref="WalkLiterals" />:
+    ///     its <see cref="Start" /> / <see cref="Length" /> within the
+    ///     scanned text, the original <see cref="Text" /> (preserving
+    ///     spelling), and a value-based <see cref="ValueKey" /> used to
+    ///     dedupe occurrences and to look up promotion substitutions
+    ///     (so <c>0.20</c> and <c>0.2</c> share a key).
+    /// </summary>
+    private readonly record struct LiteralToken(
+        int Start,
+        int Length,
+        string Text,
+        string ValueKey);
+
     // ---------------- merge ----------------
 
     private record MergeResult(
@@ -1306,25 +1302,97 @@ public static class RefactorEngine
     private sealed class ReadOnlyEmptySet<T> : ISet<T>
     {
         public static readonly ReadOnlyEmptySet<T> Instance = new();
-        public IEnumerator<T> GetEnumerator() { yield break; }
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            yield break;
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
         public int Count => 0;
         public bool IsReadOnly => true;
-        public bool Contains(T item) => false;
-        public void CopyTo(T[] array, int arrayIndex) { }
-        public bool Add(T item) => throw new NotSupportedException();
-        void System.Collections.Generic.ICollection<T>.Add(T item) => throw new NotSupportedException();
-        public void Clear() => throw new NotSupportedException();
-        public bool Remove(T item) => throw new NotSupportedException();
-        public void ExceptWith(IEnumerable<T> other) => throw new NotSupportedException();
-        public void IntersectWith(IEnumerable<T> other) => throw new NotSupportedException();
-        public bool IsProperSubsetOf(IEnumerable<T> other) => other?.Any() ?? false;
-        public bool IsProperSupersetOf(IEnumerable<T> other) => false;
-        public bool IsSubsetOf(IEnumerable<T> other) => true;
-        public bool IsSupersetOf(IEnumerable<T> other) => !(other?.Any() ?? false);
-        public bool Overlaps(IEnumerable<T> other) => false;
-        public bool SetEquals(IEnumerable<T> other) => !(other?.Any() ?? false);
-        public void SymmetricExceptWith(IEnumerable<T> other) => throw new NotSupportedException();
-        public void UnionWith(IEnumerable<T> other) => throw new NotSupportedException();
+
+        public bool Contains(T item)
+        {
+            return false;
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+        }
+
+        public bool Add(T item)
+        {
+            throw new NotSupportedException();
+        }
+
+        void ICollection<T>.Add(T item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool Remove(T item)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void ExceptWith(IEnumerable<T> other)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void IntersectWith(IEnumerable<T> other)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool IsProperSubsetOf(IEnumerable<T> other)
+        {
+            return other.Any();
+        }
+
+        public bool IsProperSupersetOf(IEnumerable<T> other)
+        {
+            return false;
+        }
+
+        public bool IsSubsetOf(IEnumerable<T> other)
+        {
+            return true;
+        }
+
+        public bool IsSupersetOf(IEnumerable<T> other)
+        {
+            return !other.Any();
+        }
+
+        public bool Overlaps(IEnumerable<T> other)
+        {
+            return false;
+        }
+
+        public bool SetEquals(IEnumerable<T> other)
+        {
+            return !other.Any();
+        }
+
+        public void SymmetricExceptWith(IEnumerable<T> other)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void UnionWith(IEnumerable<T> other)
+        {
+            throw new NotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
Closes #151.

## Summary

When Edit Lambda expanded a call like `=EXPLODE(A1)` where the LAMBDA declared optional parameters the caller omitted (`[chunk_size]`, `[horizontal]`), the omitted parameters were never bound. The folded body still referenced them — directly and via `ISOMITTED(p)`, which is meaningless outside a LAMBDA. This produced two failure modes with the same root cause:

- **Generated lambdas** (from LET to Lambda) wrap an optional param as a binding whose name **equals** the param: `c, IF(ISOMITTED(c), 3, c)`. After folding that is a **self-referential** LET binding, which Excel rejects at formula-set time → hard `0x800A03EC` exception.
- **Library lambdas** (e.g. EXPLODE) wrap with a **different** binding name: `_size, IF(ISOMITTED(chunk_size), 1, chunk_size)`. No self-reference, so Excel accepts the string but `chunk_size` is undefined → `#NAME?`.

## Approach (agreed with Tim)

Reconstruct the plain LET the author started with before LET to Lambda — materialise every parameter to a concrete value and strip all `ISOMITTED` logic. Optionality is **not** preserved in the LET (a LET has no notion of omitted args); the author re-applies it by re-running LET to Lambda, where each binding's RHS becomes the default. This unblocks the `LET to Lambda → Edit Lambda → LET to Lambda` round-trip.

Per parameter:
- **Supplied** → the call-site argument.
- **Omitted** → the default extracted from the canonical `IF(ISOMITTED(p), default, p)` wrapper found in any folded binding or the body; `NA()` when none is discoverable (valid LET, clear `#N/A` "supply this" marker).
- A folded wrapper whose **binding name == param** is **merged in place** to the resolved value — this removes the self-reference that triggers `0x800A03EC` and reproduces the original binding exactly (`add(1,2)` → `c, 3`; `add(1,2,9)` → `c, 9`).
- For params with no wrapper of their own (EXPLODE-style), a `p, value` binding is added before the folded bindings.
- **Every** remaining `ISOMITTED(x)` is neutralised to `FALSE` (including standalone ones like `Help?, ISOMITTED(text)`), skipping string literals so help text is untouched.

### Examples

`add` = `=LAMBDA(a, b, [c], LET(c, IF(ISOMITTED(c), 3, c), a + b + c))`
- `=add(1, 2)` → `=LET(a, 1, b, 2, c, 3, a + b + c)`  *(was: 0x800A03EC)*
- `=add(1, 2, 9)` → `=LET(a, 1, b, 2, c, 9, a + b + c)`

`=EXPLODE(O13)` → valid LET binding `chunk_size, 1` and `horizontal, FALSE`, with `Help?, FALSE` and the `_size`/`_horiz` calcs left as harmless `IF(FALSE, …)`. *(was: #NAME?)*

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` — 0 errors
- [x] `dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj` — 990/990 passing
- [x] New/updated tests: generated-lambda merge (omitted → default, supplied → arg), hand-authored add-param, ISOMITTED neutralisation (incl. standalone on a supplied param), ISOMITTED inside a string literal left untouched, no-default → `NA()`, param-substring not matched, nested-IF default extraction, full-EXPLODE valid-LET.
- [x] Manual smoke test in Excel: `=LET(a,1,b,2,c,3,a+b+c)` → LET to Lambda (mark `c` optional, name `add`) → `=add(1,2)` → Edit Lambda → expect `=LET(a, 1, b, 2, c, 3, a + b + c)`, no exception, evaluates to `6`. And `=EXPLODE(O13)` → Edit Lambda → valid LET (no `#NAME?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
