### PR TITLE
Add ROTATE lambda — rotate a 2D array by N quarter-turns

### DIFF
--- a/lambdas/array/ROTATE.lambda
+++ b/lambdas/array/ROTATE.lambda
@@ -1,0 +1,37 @@
+/*  FUNCTION NAME:      ROTATE
+    DESCRIPTION:*//**Rotates a 2D array by N quarter-turns (90 degrees), clockwise by default.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-05-12  Claude      Initial version
+*/
+ROTATE = LAMBDA(
+//  Parameter Declarations
+    [array],
+    [turns],
+    [clockwise],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →ROTATE(array, [turns], [clockwise])¶" &
+                "DESCRIPTION:   →Rotates a 2D array by N quarter-turns (90 degrees), clockwise by default.¶" &
+                "VERSION:       →May 12 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   array         →(Required) A 2D array to rotate.¶" &
+                "   turns         →(Optional) Number of 90-degree rotations. Default 1. Normalised via MOD(turns, 4).¶" &
+                "   clockwise     →(Optional) TRUE for clockwise (default), FALSE for anticlockwise.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=ROTATE({1,2,3;4,5,6})¶" &
+                "Result         →{4,1;5,2;6,3}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(array),
+    //  Procedure
+        nTurns, IF(ISOMITTED(turns), 1, turns),
+        cw, IF(ISOMITTED(clockwise), TRUE, clockwise),
+        n, MOD(nTurns, 4),
+        result, IF(n=0, array,
+                    IF(cw,
+                        REDUCE(array, SEQUENCE(n), LAMBDA(acc, iter, TRANSPOSE(REVERSEARRAY(acc, 2)))),
+                        REDUCE(array, SEQUENCE(n), LAMBDA(acc, iter, REVERSEARRAY(TRANSPOSE(acc), 2))))),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/ROTATE.tests.yaml
+++ b/lambdas/array/ROTATE.tests.yaml
@@ -1,0 +1,60 @@
+tests:
+  - name: default single clockwise turn 2x3
+    args: ["={1,2,3;4,5,6}"]
+    expected: [[4, 1], [5, 2], [6, 3]]
+
+  - name: two turns 180 degrees 2x3
+    args: ["={1,2,3;4,5,6}", "=2"]
+    expected: [[6, 5, 4], [3, 2, 1]]
+
+  - name: four turns identity (MOD normalises to 0)
+    args: ["={1,2,3;4,5,6}", "=4"]
+    expected: [[1, 2, 3], [4, 5, 6]]
+
+  - name: hundred turns identity (MOD 100 4 = 0)
+    args: ["={1,2,3;4,5,6}", "=100"]
+    expected: [[1, 2, 3], [4, 5, 6]]
+
+  - name: one anticlockwise turn 2x3
+    args: ["={1,2,3;4,5,6}", "=1", "=FALSE"]
+    expected: [[3, 6], [2, 5], [1, 4]]
+
+  - name: three clockwise = one anticlockwise
+    args: ["={1,2,3;4,5,6}", "=3"]
+    expected: [[3, 6], [2, 5], [1, 4]]
+
+  - name: three anticlockwise = one clockwise
+    args: ["={1,2,3;4,5,6}", "=3", "=FALSE"]
+    expected: [[4, 1], [5, 2], [6, 3]]
+
+  - name: negative turns wrap via MOD
+    args: ["={1,2,3;4,5,6}", "=-1"]
+    expected: [[3, 6], [2, 5], [1, 4]]
+
+  - name: zero turns identity
+    args: ["={1,2,3;4,5,6}", "=0"]
+    expected: [[1, 2, 3], [4, 5, 6]]
+
+  - name: 3x3 single clockwise
+    args: ["={1,2,3;4,5,6;7,8,9}"]
+    expected: [[7, 4, 1], [8, 5, 2], [9, 6, 3]]
+
+  - name: 3x3 180 degrees
+    args: ["={1,2,3;4,5,6;7,8,9}", "=2"]
+    expected: [[9, 8, 7], [6, 5, 4], [3, 2, 1]]
+
+  - name: 3x3 single anticlockwise
+    args: ["={1,2,3;4,5,6;7,8,9}", "=1", "=FALSE"]
+    expected: [[3, 6, 9], [2, 5, 8], [1, 4, 7]]
+
+  - name: string array clockwise
+    args: ['={"a","b";"c","d"}']
+    expected: [["c", "a"], ["d", "b"]]
+
+  - name: 1D row becomes column (clockwise)
+    args: ["={1,2,3}"]
+    expected: [[1], [2], [3]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
Closes #175.

## Summary

- New `ROTATE(array, [turns], [clockwise])` lambda in `lambdas/array/`.
- Rotates a 2D (or 1D) array by N quarter-turns. `turns` defaults to 1, `clockwise` defaults to TRUE.
- `turns` is normalised via `MOD(turns, 4)`, so any integer (including negatives) collapses to 0–3 rotations. `n=0` short-circuits to return the input unchanged.
- Single-step rotation = `TRANSPOSE` + `REVERSEARRAY` (axis 2). Direction toggles which side gets the transpose/flip.

## Test plan

- [x] Format validation tests pass (`LambdaFormatTests`, 376 total).
- [x] Functional harness tests pass — 15 cases covering 1-turn / 180° / 4-turn identity / large turns / anticlockwise / 3-clockwise = 1-anticlockwise / negative turns / zero turns / 3×3 grids / string array / 1D row → column / help text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)