### PR TITLE
CELLTOPOS: accept A1 address string instead of cell reference

### DIFF
--- a/lambdas/maps/CELLTOPOS.lambda
+++ b/lambdas/maps/CELLTOPOS.lambda
@@ -1,7 +1,8 @@
 /*  FUNCTION NAME:      CELLTOPOS
-    DESCRIPTION:*//**Encodes a cell reference as a single integer (ROW * mult + COLUMN) for grid arithmetic.*/
+    DESCRIPTION:*//**Encodes an A1-style cell address string as a single integer (ROW * mult + COLUMN) for grid arithmetic.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-15  Claude      Initial version
+                        2026-05-14  Claude      Switch to string input; parse address directly (non-volatile, no INDIRECT)
 */
 CELLTOPOS = LAMBDA(
 //  Parameter Declarations
@@ -10,13 +11,13 @@ CELLTOPOS = LAMBDA(
 //  Help
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →CELLTOPOS(cell, [mult])¶" &
-                "DESCRIPTION:   →Encodes a cell reference as a single integer (ROW * mult + COLUMN) for grid arithmetic.¶" &
-                "VERSION:       →Apr 15 2026¶" &
+                "DESCRIPTION:   →Encodes an A1-style cell address string as a single integer (ROW * mult + COLUMN) for grid arithmetic.¶" &
+                "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   cell           →(Required) A cell reference to encode.¶" &
+                "   cell           →(Required) Cell address as a string (e.g. ""E5""), or a cell containing one. Sheet prefixes and ranges are tolerated; the first cell of a range is used.¶" &
                 "   mult           →(Optional) Multiplier for the row component. Default: 1000. Must exceed the maximum column number used.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=CELLTOPOS(E5)¶" &
+                "Formula        →=CELLTOPOS(""E5"")¶" &
                 "Result         →5005",
                 "→", "¶"
                 ),
@@ -24,7 +25,14 @@ CELLTOPOS = LAMBDA(
         Help?, ISOMITTED(cell),
     //  Procedure
         m, IF(ISOMITTED(mult), 1000, mult),
-        result, ROW(cell) * m + COLUMN(cell),
+        afterSheet, IFERROR(TEXTAFTER(cell, "!", -1), cell),
+        firstCell, IFERROR(TEXTBEFORE(afterSheet, ":"), afterSheet),
+        upper, UPPER(firstCell),
+        letters, REGEXEXTRACT(upper, "[A-Z]+"),
+        rowNum, --REGEXEXTRACT(upper, "\d+"),
+        n, LEN(letters),
+        colNum, SUMPRODUCT((CODE(MID(letters, SEQUENCE(n), 1)) - 64) * 26^(n - SEQUENCE(n))),
+        result, rowNum * m + colNum,
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/maps/CELLTOPOS.tests.yaml
+++ b/lambdas/maps/CELLTOPOS.tests.yaml
@@ -1,23 +1,59 @@
 tests:
-  - name: default mult E5
-    args: ["=E5"]
+  - name: literal string E5
+    args: ["E5"]
     expected: 5005
 
-  - name: default mult C3
-    args: ["=C3"]
+  - name: literal string C3
+    args: ["C3"]
     expected: 3003
 
-  - name: default mult L12
-    args: ["=L12"]
+  - name: literal string L12
+    args: ["L12"]
     expected: 12012
 
+  - name: lowercase address
+    args: ["e5"]
+    expected: 5005
+
+  - name: absolute reference dollars stripped
+    args: ["$E$5"]
+    expected: 5005
+
+  - name: range collapses to first cell
+    args: ["E5:F6"]
+    expected: 5005
+
+  - name: sheet-prefixed address
+    args: ["Sheet1!E5"]
+    expected: 5005
+
+  - name: sheet prefix with range
+    args: ["Sheet1!E5:F6"]
+    expected: 5005
+
+  - name: quoted sheet name with space
+    args: ["'My Sheet'!E5"]
+    expected: 5005
+
+  - name: multi-letter column AB12
+    args: ["AB12"]
+    expected: 12028
+
   - name: custom mult A1
-    args: ["=A1", "=100"]
+    args: ["A1", "=100"]
     expected: 101
 
   - name: custom mult Z10 with mult 50
-    args: ["=Z10", "=50"]
+    args: ["Z10", "=50"]
     expected: 526
+
+  - name: cell containing address string
+    setup:
+      cells:
+        - address: "C3"
+          values: "E5"
+    args: ["=C3"]
+    expected: 5005
 
   - name: help text
     args: []


### PR DESCRIPTION
## Summary

- Changes `CELLTOPOS` to take an A1 address as a **string** (e.g. `"E5"`) rather than a cell reference. A bare ref like `=CELLTOPOS(A1)` still works as long as `A1` contains the address string — which is the actual common usage in this library.
- Parses the address directly with `REGEXEXTRACT` + base-26 column decode, so the formula stays **non-volatile** (no `INDIRECT`).
- Pre-strips an optional sheet prefix (`TEXTAFTER(..., "!", -1)`) and any range tail (`TEXTBEFORE(..., ":")`), so absolute refs, lowercase, ranges, and sheet-qualified addresses all parse correctly.

## Why

- Restores symmetry with `POSTOCELL`, which already returns an A1 string — round-trips now compose cleanly.
- No internal callers depend on the old reference-form contract (grep confirmed only `POSTOCELL.lambda` even mentions `CELLTOPOS`, and that's just in a doc comment).

## Test plan

- [x] Format validation: `dotnet test ... LambdaFormatTests` — 376/376 pass
- [x] Excel harness: 14 new/updated CELLTOPOS test cases all pass, covering:
  - Literal strings (`"E5"`, `"C3"`, `"L12"`)
  - Lowercase (`"e5"`)
  - Absolute refs (`"$E$5"`)
  - Range tail (`"E5:F6"`)
  - Sheet prefix (`"Sheet1!E5"`)
  - Sheet prefix + range (`"Sheet1!E5:F6"`)
  - Quoted sheet name with space (`"'My Sheet'!E5"`)
  - Multi-letter column (`"AB12"` → 12028)
  - Custom `mult` parameter (small grids)
  - Cell containing the address string (via `setup.cells` — the original motivating use case)
  - Help text
- [x] Full harness suite: 355/355 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)