### PR TITLE
Audit existing LAMBDAs for array-lifting support

### DIFF
--- a/lambdas/array/CONTAINS.tests.yaml
+++ b/lambdas/array/CONTAINS.tests.yaml
@@ -15,6 +15,10 @@ tests:
     args: ["=7", "={10,42,99}"]
     expected: False
 
+  - name: vertical array of values lifts (XMATCH naturally lifts on lookup_value)
+    args: ['={"Podcast";"Video";"Music"}', '={"Podcast","Music","News"}']
+    expected: [[True], [False], [True]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/array/NTH.lambda
+++ b/lambdas/array/NTH.lambda
@@ -2,6 +2,7 @@
     DESCRIPTION:*//**Returns the Nth element of an array (flattened), with negative N counting from the end.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-21  Claude      Initial version
+                        2026-05-14  Claude      Array-lift on n via dispatcher: MAP over multi-index input, otherwise scalar body unchanged
 */
 NTH = LAMBDA(
 //  Parameter Declarations
@@ -11,10 +12,10 @@ NTH = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →NTH(arr, n)¶" &
                 "DESCRIPTION:   →Returns the Nth element of an array (flattened), with negative N counting from the end.¶" &
-                "VERSION:       →Apr 21 2026¶" &
+                "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   arr            →(Required) Any array or range — 1D, 2D, vertical, or horizontal.¶" &
-                "   n              →(Required) 1-based position into the flattened array; negative counts from the end (-1 = last).¶" &
+                "   n              →(Required) 1-based position into the flattened array; negative counts from the end (-1 = last). Also accepts an array of indices — result lifts element-wise.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=NTH({""a"",""b"",""c""}, -1)¶" &
                 "Result         →""c""",
@@ -24,8 +25,12 @@ NTH = LAMBDA(
         Help?, ISOMITTED(arr),
     //  Procedure
         flat, TOCOL(arr),
-        idx, IF(n < 0, ROWS(flat) + n + 1, n),
-        result, IF(idx < 1, NA(), @INDEX(flat, idx, 1)),
+        scalar, LAMBDA(ni,
+                  LET(idx, IF(ni < 0, ROWS(flat) + ni + 1, ni),
+                      IF(idx < 1, NA(), @INDEX(flat, idx, 1)))),
+        result, IF(OR(ROWS(n) > 1, COLUMNS(n) > 1),
+                    MAP(n, scalar),
+                    scalar(n)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/array/NTH.tests.yaml
+++ b/lambdas/array/NTH.tests.yaml
@@ -35,6 +35,14 @@ tests:
     args: ['={10,20,30,40}', "=-5"]
     expected: -2146826246
 
+  - name: vertical array of indices lifts
+    args: ['={10,20,30,40}', '={1;3;-1}']
+    expected: [[10], [30], [40]]
+
+  - name: horizontal array of indices lifts
+    args: ['={10,20,30,40}', '={1,2,-1}']
+    expected: [[10, 20, 40]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/lookup/TLOOKUP.lambda
+++ b/lambdas/lookup/TLOOKUP.lambda
@@ -2,6 +2,7 @@
     DESCRIPTION:*//**Looks up a value from a header-row table by matching a row key in one column and returning the value under a named header.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-05-07  Claude      Initial version
+                        2026-05-14  Claude      Array-lift on Item via dispatcher: MAP over multi-item input, otherwise scalar body unchanged
 */
 TLOOKUP = LAMBDA(
 //  Parameter Declarations
@@ -14,10 +15,10 @@ TLOOKUP = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →TLOOKUP(Table, Item, LookupCol, HeaderName, [If_not_found])¶" &
                 "DESCRIPTION:   →Looks up a value from a header-row table by matching a row key in one column and returning the value under a named header.¶" &
-                "VERSION:       →May 07 2026¶" &
+                "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   Table          →(Required) Full table including its header row (e.g. tblData[#All]).¶" &
-                "   Item           →(Required) Value to find in LookupCol to identify the row.¶" &
+                "   Item           →(Required) Value to find in LookupCol to identify the row. Also accepts an array of items — result lifts element-wise.¶" &
                 "   LookupCol      →(Required) Column to search for Item (e.g. tblData[Person]). Excluding headers.¶" &
                 "   HeaderName     →(Required) Header text identifying the column whose value should be returned.¶" &
                 "   If_not_found   →(Optional) Value to return when Item or HeaderName is not found. Defaults to #N/A.¶" &
@@ -29,14 +30,19 @@ TLOOKUP = LAMBDA(
     //  Check inputs
         Help?, ISOMITTED(Table),
     //  Procedure
-        result, IFERROR(
+        notFound, IF(ISOMITTED(If_not_found), NA(), If_not_found),
+        scalar, LAMBDA(it,
+                  IFERROR(
                     INDEX(
                         Table,
-                        MATCH(Item, LookupCol, 0) + 1,
+                        MATCH(it, LookupCol, 0) + 1,
                         MATCH(HeaderName, INDEX(Table, 1, ), 0)
                     ),
-                    IF(ISOMITTED(If_not_found), NA(), If_not_found)
-                ),
+                    notFound
+                  )),
+        result, IF(OR(ROWS(Item) > 1, COLUMNS(Item) > 1),
+                    MAP(Item, scalar),
+                    scalar(Item)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/lookup/TLOOKUP.tests.yaml
+++ b/lambdas/lookup/TLOOKUP.tests.yaml
@@ -104,6 +104,36 @@ tests:
     args: ["=tblAll", "Tim", "=tblPerson", "Salary", "=0"]
     expected: 0
 
+  - name: vertical array of items lifts
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+        - { name: "tblPerson", refers_to: "C4:C6" }
+    args: ["=tblAll", '={"Tim";"Sam";"Alex"}', "=tblPerson", "Age"]
+    expected: [[42], [30], [25]]
+
+  - name: array of items with one missing uses fallback
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+        - { name: "tblPerson", refers_to: "C4:C6" }
+    args: ["=tblAll", '={"Tim";"Jordan";"Alex"}', "=tblPerson", "Age", "=-1"]
+    expected: [[42], [-1], [25]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/maps/CELLTOPOS.lambda
+++ b/lambdas/maps/CELLTOPOS.lambda
@@ -4,6 +4,7 @@
                         2026-04-15  Claude      Initial version
                         2026-05-14  Claude      Switch to string input; parse address directly (non-volatile, no INDIRECT)
                         2026-05-14  Claude      Default mult bumped from 1000 to 100000 — safe for any Excel column (max XFD=16384) while keeping the trailing 5 digits readable
+                        2026-05-14  Claude      Array-lift via dispatcher: MAP over multi-cell input, otherwise scalar body unchanged
 */
 CELLTOPOS = LAMBDA(
 //  Parameter Declarations
@@ -15,7 +16,7 @@ CELLTOPOS = LAMBDA(
                 "DESCRIPTION:   →Encodes an A1-style cell address string as a single integer (ROW * mult + COLUMN) for grid arithmetic.¶" &
                 "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   cell           →(Required) Cell address as a string (e.g. ""E5""), or a cell containing one. Sheet prefixes and ranges are tolerated; the first cell of a range is used.¶" &
+                "   cell           →(Required) Cell address as a string (e.g. ""E5""), or a cell containing one. Sheet prefixes and ranges are tolerated; the first cell of a range is used. Also accepts an array/range of addresses — result lifts element-wise.¶" &
                 "   mult           →(Optional) Multiplier for the row component. Default: 100000 — safe for any Excel column (max XFD=16384) and keeps the trailing 5 digits readable as the column.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=CELLTOPOS(""E5"")¶" &
@@ -26,14 +27,20 @@ CELLTOPOS = LAMBDA(
         Help?, ISOMITTED(cell),
     //  Procedure
         m, IF(ISOMITTED(mult), 100000, mult),
-        afterSheet, IFERROR(TEXTAFTER(cell, "!", -1), cell),
-        firstCell, IFERROR(TEXTBEFORE(afterSheet, ":"), afterSheet),
-        upper, UPPER(firstCell),
-        letters, REGEXEXTRACT(upper, "[A-Z]+"),
-        rowNum, --REGEXEXTRACT(upper, "\d+"),
-        n, LEN(letters),
-        colNum, SUMPRODUCT((CODE(MID(letters, SEQUENCE(n), 1)) - 64) * 26^(n - SEQUENCE(n))),
-        result, rowNum * m + colNum,
+        scalar, LAMBDA(c,
+                  LET(
+                    afterSheet, IFERROR(TEXTAFTER(c, "!", -1), c),
+                    firstCell, IFERROR(TEXTBEFORE(afterSheet, ":"), afterSheet),
+                    upper, UPPER(firstCell),
+                    letters, REGEXEXTRACT(upper, "[A-Z]+"),
+                    rowNum, --REGEXEXTRACT(upper, "\d+"),
+                    n, LEN(letters),
+                    colNum, SUMPRODUCT((CODE(MID(letters, SEQUENCE(n), 1)) - 64) * 26^(n - SEQUENCE(n))),
+                    rowNum * m + colNum
+                  )),
+        result, IF(OR(ROWS(cell) > 1, COLUMNS(cell) > 1),
+                    MAP(cell, scalar),
+                    scalar(cell)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/maps/CELLTOPOS.tests.yaml
+++ b/lambdas/maps/CELLTOPOS.tests.yaml
@@ -55,6 +55,26 @@ tests:
     args: ["=C3"]
     expected: 500005
 
+  - name: vertical array of addresses lifts
+    args: ['={"E5";"C3"}']
+    expected: [[500005], [300003]]
+
+  - name: horizontal array of addresses lifts
+    args: ['={"E5","C3"}']
+    expected: [[500005, 300003]]
+
+  - name: 2D array of addresses lifts
+    args: ['={"E5","F6";"C3","D4"}']
+    expected: [[500005, 600006], [300003, 400004]]
+
+  - name: range of cells containing addresses lifts
+    setup:
+      cells:
+        - address: "D2:E2"
+          values: [["E5", "F6"]]
+    args: ["=D2:E2"]
+    expected: [[500005, 600006]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/maps/GRIDLOOKUP.lambda
+++ b/lambdas/maps/GRIDLOOKUP.lambda
@@ -5,6 +5,7 @@
                         2026-04-15  Claude      Switch to XMATCH; add match_mode parameter
                         2026-05-14  Claude      Reverse branch parses address via CELLTOPOS instead of volatile INDIRECT
                         2026-05-14  Claude      Replace inline 20000 with named safeMult (XFD+1 = 16385)
+                        2026-05-14  Claude      Array-lift on value via dispatcher: MAP over multi-cell input, otherwise scalar body unchanged
 */
 GRIDLOOKUP = LAMBDA(
 //  Parameter Declarations
@@ -18,7 +19,7 @@ GRIDLOOKUP = LAMBDA(
                 "DESCRIPTION:   →Bidirectional grid lookup: returns a cell address for a value, or the value at a given cell address.¶" &
                 "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   value         →(Required) Value to find in grid. When return_Value is TRUE, a cell address text (e.g. ""E5"") to look up.¶" &
+                "   value         →(Required) Value to find in grid. When return_Value is TRUE, a cell address text (e.g. ""E5"") to look up. Also accepts an array/range of values or addresses — result lifts element-wise.¶" &
                 "   grid          →(Required) The grid range to search (e.g. M!C3:L12).¶" &
                 "   return_Value  →(Optional) FALSE (default) returns a cell address for the value. TRUE treats value as an address and returns the cell's value.¶" &
                 "   match_mode    →(Optional) Forwarded to XMATCH: 0 exact (default), -1 exact or next smaller, 1 exact or next larger, 2 wildcard. Ignored when return_Value is TRUE.¶" &
@@ -35,15 +36,19 @@ GRIDLOOKUP = LAMBDA(
         safeMult, 16385,
         baseRow, IFERROR(MIN(ROW(grid)), 1),
         baseCol, IFERROR(MIN(COLUMN(grid)), 1),
-        result, IF(reverse,
-                    LET(pos, CELLTOPOS(value, safeMult),
-                        INDEX(grid,
-                              INT(pos / safeMult) - baseRow + 1,
-                              MOD(pos, safeMult) - baseCol + 1)),
-                    LET(p, XMATCH(value, TOCOL(grid), mMode),
-                        cols, COLUMNS(grid),
-                        ADDRESS(baseRow + INT((p - 1) / cols),
-                                baseCol + MOD(p - 1, cols), 4))),
+        scalar, LAMBDA(v,
+                  IF(reverse,
+                     LET(pos, CELLTOPOS(v, safeMult),
+                         INDEX(grid,
+                               INT(pos / safeMult) - baseRow + 1,
+                               MOD(pos, safeMult) - baseCol + 1)),
+                     LET(p, XMATCH(v, TOCOL(grid), mMode),
+                         cols, COLUMNS(grid),
+                         ADDRESS(baseRow + INT((p - 1) / cols),
+                                 baseCol + MOD(p - 1, cols), 4)))),
+        result, IF(OR(ROWS(value) > 1, COLUMNS(value) > 1),
+                    MAP(value, scalar),
+                    scalar(value)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/maps/GRIDLOOKUP.tests.yaml
+++ b/lambdas/maps/GRIDLOOKUP.tests.yaml
@@ -51,6 +51,14 @@ tests:
     args: ["=9999", "=SEQUENCE(10,10)", "=FALSE", "=-1"]
     expected: "J10"
 
+  - name: forward lookup lifts over vertical array of values
+    args: ['={1;41;100}', "=SEQUENCE(10,10)"]
+    expected: [["A1"], ["A5"], ["J10"]]
+
+  - name: reverse lookup lifts over vertical array of addresses
+    args: ['={"A1";"A5";"J10"}', "=SEQUENCE(10,10)", "=TRUE"]
+    expected: [[1], [41], [100]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/maps/INCEL.lambda
+++ b/lambdas/maps/INCEL.lambda
@@ -3,6 +3,7 @@
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-30  Claude      Initial version
                         2026-05-14  Claude      Document INDIRECT volatility in Help
+                        2026-05-14  Claude      Array-lift via dispatcher: MAP over multi-address input, otherwise scalar body unchanged
 */
 INCEL = LAMBDA(
 //  Parameter Declarations
@@ -14,7 +15,7 @@ INCEL = LAMBDA(
                 "DESCRIPTION:   →Shorthand for INDIRECT — resolves a text address (optionally on another sheet) to its cell or range reference.¶" &
                 "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   address       →(Required) Cell or range address text (e.g. ""A1"" or ""B2:D5"").¶" &
+                "   address       →(Required) Cell or range address text (e.g. ""A1"" or ""B2:D5""). Also accepts an array/range of single-cell addresses — result lifts element-wise. Passing range-style addresses (e.g. ""A1:B2"") inside an array is not supported and will collapse each range to a single cell.¶" &
                 "   sheet         →(Optional) Sheet name. If omitted, the address resolves on the current sheet.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=INCEL(""A1"", ""Data"")¶" &
@@ -25,7 +26,10 @@ INCEL = LAMBDA(
     //  Check inputs
         Help?, ISOMITTED(address),
     //  Procedure
-        result, INDIRECT(IF(ISOMITTED(sheet), address, "'" & sheet & "'!" & address)),
+        scalar, LAMBDA(a, INDIRECT(IF(ISOMITTED(sheet), a, "'" & sheet & "'!" & a))),
+        result, IF(OR(ROWS(address) > 1, COLUMNS(address) > 1),
+                    MAP(address, scalar),
+                    scalar(address)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/maps/INCEL.tests.yaml
+++ b/lambdas/maps/INCEL.tests.yaml
@@ -23,6 +23,26 @@ tests:
     args: ['="C5:E5"']
     expected: [[1, 2, 3]]
 
+  - name: vertical array of single-cell addresses lifts
+    setup:
+      cells:
+        - address: "A5"
+          values: 42
+        - address: "B3"
+          values: 99
+    args: ['={"A5";"B3"}']
+    expected: [[42], [99]]
+
+  - name: horizontal array of single-cell addresses lifts
+    setup:
+      cells:
+        - address: "A5"
+          values: 42
+        - address: "B3"
+          values: 99
+    args: ['={"A5","B3"}']
+    expected: [[42, 99]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/maps/MOVECELL.lambda
+++ b/lambdas/maps/MOVECELL.lambda
@@ -4,6 +4,7 @@
                         2026-04-15  Claude      Initial version
                         2026-05-14  Claude      cell now an address string; parse via CELLTOPOS instead of volatile INDIRECT
                         2026-05-14  Claude      Replace inline 20000 with named safeMult (XFD+1 = 16385)
+                        2026-05-14  Claude      Array-lift on cell via dispatcher: MAP over multi-cell input, otherwise scalar body unchanged
 */
 MOVECELL = LAMBDA(
 //  Parameter Declarations
@@ -16,8 +17,8 @@ MOVECELL = LAMBDA(
                 "DESCRIPTION:   →Returns the A1 address of the cell offset from cell by the direction dir, using a moves table of {glyph, dRow, dCol}.¶" &
                 "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   cell           →(Required) Cell address as a string (e.g. ""E5""), or a cell containing one. Output of MOVECELL itself can be fed back in.¶" &
-                "   dir            →(Required) Direction glyph matching a value in the first column of moves.¶" &
+                "   cell           →(Required) Cell address as a string (e.g. ""E5""), or a cell containing one. Output of MOVECELL itself can be fed back in. Also accepts an array/range of addresses — result lifts element-wise.¶" &
+                "   dir            →(Required) Direction glyph matching a value in the first column of moves. Treated as a scalar (single direction applied to every cell in array input).¶" &
                 "   moves          →(Optional) 3-column table: {glyph, dRow, dCol}. Defaults to ARROWMOVES(). Use HSTACK(customGlyphs, KNIGHTDELTAS()) for knight moves.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=MOVECELL(""E5"", ""↖"")¶" &
@@ -32,10 +33,14 @@ MOVECELL = LAMBDA(
         idx, XMATCH(dir, CHOOSECOLS(m, 1)),
         dR, INDEX(m, idx, 2),
         dC, INDEX(m, idx, 3),
-        pos, CELLTOPOS(cell, safeMult),
-        curRow, INT(pos / safeMult),
-        curCol, MOD(pos, safeMult),
-        result, ADDRESS(curRow + dR, curCol + dC, 4),
+        scalar, LAMBDA(c,
+                  LET(pos, CELLTOPOS(c, safeMult),
+                      curRow, INT(pos / safeMult),
+                      curCol, MOD(pos, safeMult),
+                      ADDRESS(curRow + dR, curCol + dC, 4))),
+        result, IF(OR(ROWS(cell) > 1, COLUMNS(cell) > 1),
+                    MAP(cell, scalar),
+                    scalar(cell)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/maps/MOVECELL.tests.yaml
+++ b/lambdas/maps/MOVECELL.tests.yaml
@@ -43,6 +43,14 @@ tests:
     args: ['=MOVECELL("E5", "↖")', '="↘"']
     expected: "E5"
 
+  - name: vertical array of cells lifts with single direction
+    args: ['={"E5";"F3";"B2"}', '="↖"']
+    expected: [["D4"], ["E2"], ["A1"]]
+
+  - name: horizontal array of cells lifts with single direction
+    args: ['={"E5","F3","B2"}', '="↘"']
+    expected: [["F6", "G4", "C3"]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/maps/POSTOCELL.lambda
+++ b/lambdas/maps/POSTOCELL.lambda
@@ -3,6 +3,7 @@
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-15  Claude      Initial version
                         2026-05-14  Claude      Default mult bumped from 1000 to 100000 to match CELLTOPOS
+                        2026-05-14  Claude      Array-lift via dispatcher: MAP over multi-cell input, otherwise scalar body unchanged
 */
 POSTOCELL = LAMBDA(
 //  Parameter Declarations
@@ -14,7 +15,7 @@ POSTOCELL = LAMBDA(
                 "DESCRIPTION:   →Decodes an integer position (from CELLTOPOS) back to an A1-style cell address string.¶" &
                 "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   pos            →(Required) Integer position to decode.¶" &
+                "   pos            →(Required) Integer position to decode. Also accepts an array/range of positions — result lifts element-wise.¶" &
                 "   mult           →(Optional) Multiplier used during encoding. Default: 100000 (matches CELLTOPOS). Must match the mult used by CELLTOPOS.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=POSTOCELL(500005)¶" &
@@ -25,7 +26,10 @@ POSTOCELL = LAMBDA(
         Help?, ISOMITTED(pos),
     //  Procedure
         m, IF(ISOMITTED(mult), 100000, mult),
-        result, ADDRESS(ROUNDDOWN(pos / m, 0), MOD(pos, m), 4),
+        scalar, LAMBDA(p, ADDRESS(ROUNDDOWN(p / m, 0), MOD(p, m), 4)),
+        result, IF(OR(ROWS(pos) > 1, COLUMNS(pos) > 1),
+                    MAP(pos, scalar),
+                    scalar(pos)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/maps/POSTOCELL.tests.yaml
+++ b/lambdas/maps/POSTOCELL.tests.yaml
@@ -23,6 +23,14 @@ tests:
     args: ["=526", "=50"]
     expected: "Z10"
 
+  - name: vertical array of positions lifts
+    args: ['={500005;300003}']
+    expected: [["E5"], ["C3"]]
+
+  - name: horizontal array of positions lifts
+    args: ['={500005,300003}']
+    expected: [["E5", "C3"]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/math/CIRCPOS.tests.yaml
+++ b/lambdas/math/CIRCPOS.tests.yaml
@@ -23,6 +23,14 @@ tests:
     args: ["=19", "=19", "=3"]
     expected: 3
 
+  - name: vertical array of moves lifts (MOD naturally lifts)
+    args: ['={1;5;-2}', "=19"]
+    expected: [[2], [6], [18]]
+
+  - name: vertical array of starts lifts
+    args: ["=0", "=19", '={1;5;19}']
+    expected: [[1], [5], [19]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/string/CHARQ.lambda
+++ b/lambdas/string/CHARQ.lambda
@@ -3,6 +3,7 @@
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-13  Claude      Initial version
                         2026-04-13  Claude      Add Regex parameter
+                        2026-05-14  Claude      Array-lift on Text via dispatcher: MAP over multi-text input, otherwise scalar body unchanged. Regex branch needs per-element evaluation because REGEXEXTRACT mode 1 returns an array per Text.
 */
 CHARQ = LAMBDA(
 //  Parameter Declarations
@@ -13,9 +14,9 @@ CHARQ = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →CHARQ(Text, Char, Regex)¶" &
                 "DESCRIPTION:   →Counts non-overlapping occurrences of a substring within a string.¶" &
-                "VERSION:       →Apr 13 2026¶" &
+                "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   Text           →(Required) The string to search within.¶" &
+                "   Text           →(Required) The string to search within. Also accepts an array of strings — result lifts element-wise.¶" &
                 "   Char           →(Required) The character(s) to count, or a regex pattern if Regex is TRUE.¶" &
                 "   Regex          →(Optional) If TRUE, treat Char as a regex pattern. Default: FALSE.¶" &
                 "EXAMPLE:       →¶" &
@@ -27,9 +28,13 @@ CHARQ = LAMBDA(
         Help?, ISOMITTED(Text),
         _regex, IF(ISOMITTED(Regex), FALSE, Regex),
     //  Procedure
-        result, IF(_regex,
-                    IFERROR(COLUMNS(REGEXEXTRACT(Text, Char, 1)), 0),
-                    (LEN(Text) - LEN(SUBSTITUTE(Text, Char, ""))) / LEN(Char)),
+        scalar, LAMBDA(t,
+                  IF(_regex,
+                     IFERROR(COLUMNS(REGEXEXTRACT(t, Char, 1)), 0),
+                     (LEN(t) - LEN(SUBSTITUTE(t, Char, ""))) / LEN(Char))),
+        result, IF(OR(ROWS(Text) > 1, COLUMNS(Text) > 1),
+                    MAP(Text, scalar),
+                    scalar(Text)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/string/CHARQ.tests.yaml
+++ b/lambdas/string/CHARQ.tests.yaml
@@ -31,6 +31,14 @@ tests:
     args: ["MASSAGE", "S", true]
     expected: 2
 
+  - name: vertical array of texts lifts (literal mode)
+    args: ['={"MASSAGE";"HELLO";"abcabc"}', "S"]
+    expected: [[2], [0], [0]]
+
+  - name: vertical array of texts lifts (regex mode)
+    args: ['={"abc123def456";"abcdef";"1a2b3c"}', "[0-9]+", true]
+    expected: [[2], [0], [3]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/string/REVERSESTRING.lambda
+++ b/lambdas/string/REVERSESTRING.lambda
@@ -2,6 +2,7 @@
     DESCRIPTION:*//**Reverses the characters in a text string.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-16  Claude      Initial version
+                        2026-05-14  Claude      Array-lift on text via dispatcher: MAP over multi-text input, otherwise scalar body unchanged. SEQUENCE(LEN(text), ...) requires a scalar length.
 */
 REVERSESTRING = LAMBDA(
 //  Parameter Declarations
@@ -10,9 +11,9 @@ REVERSESTRING = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →REVERSESTRING(text)¶" &
                 "DESCRIPTION:   →Reverses the characters in a text string.¶" &
-                "VERSION:       →Apr 16 2026¶" &
+                "VERSION:       →May 14 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   text          →(Required) The string to reverse.¶" &
+                "   text          →(Required) The string to reverse. Also accepts an array of strings — result lifts element-wise.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=REVERSESTRING(""863FOVW595"")¶" &
                 "Result         →595WVOF368",
@@ -21,7 +22,10 @@ REVERSESTRING = LAMBDA(
     //  Check inputs
         Help?, ISOMITTED(text),
     //  Procedure
-        result, CONCAT(MID(text, SEQUENCE(LEN(text),,LEN(text),-1), 1)),
+        scalar, LAMBDA(t, CONCAT(MID(t, SEQUENCE(LEN(t),,LEN(t),-1), 1))),
+        result, IF(OR(ROWS(text) > 1, COLUMNS(text) > 1),
+                    MAP(text, scalar),
+                    scalar(text)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/string/REVERSESTRING.tests.yaml
+++ b/lambdas/string/REVERSESTRING.tests.yaml
@@ -15,6 +15,14 @@ tests:
     args: ["X"]
     expected: "X"
 
+  - name: vertical array of strings lifts
+    args: ['={"hello";"world";"abc"}']
+    expected: [["olleh"], ["dlrow"], ["cba"]]
+
+  - name: horizontal array of strings lifts
+    args: ['={"hello","world","abc"}']
+    expected: [["olleh", "dlrow", "cba"]]
+
   - name: help text
     args: []
     expected_type: array


### PR DESCRIPTION
## Summary

Per #179, audit every LAMBDA in the library for array-lifting support. Apply the dispatcher pattern wherever a scalar-input/scalar-output LAMBDA silently collapses or errors on array input.

### Upgrades (⚠️ dispatcher added)

| LAMBDA | Lift on | Reason |
|---|---|---|
| `CELLTOPOS` | `cell` | `SUMPRODUCT(...SEQUENCE(LEN(letters))...)` collapses arrays of addresses |
| `POSTOCELL` | `pos` | defensive; ADDRESS may lift naturally, dispatcher makes it explicit |
| `MOVECELL` | `cell` | calls CELLTOPOS internally |
| `GRIDLOOKUP` | `value` | forward (XMATCH) and reverse (CELLTOPOS) branches |
| `INCEL` | `address` | INDIRECT doesn't lift over arrays of addresses |
| `NTH` | `n` | `@INDEX(flat, idx, 1)` collapses to first when idx is array |
| `CHARQ` | `Text` | regex branch's `COLUMNS(REGEXEXTRACT(...))` returns one array per Text, doesn't compose |
| `REVERSESTRING` | `text` | `SEQUENCE(LEN(text), ...)` errors when text is array |
| `TLOOKUP` | `Item` | defensive; MATCH may lift in modern Excel, dispatcher makes it explicit |

### Already lifts (✅ no change — confirmation tests added where relevant)

- `CONTAINS` — XMATCH lifts on `value`
- `CIRCPOS` — MOD lifts on `moves` and `start` (help already advertised this)
- `GetVar` / `GetVarAt` / `SplitState` — already MAP over a column of states

### Skip (➖ no scalar input, or output inherently an array)

`GRIDAREA`, `ARROWMOVES`, `DEFAULTARROWS`, `DEFAULTMOVEDELTAS`, `KNIGHTDELTAS`, `BICOL`, `BIROW`, `MAXOF`, `MINOF`, `NTHOCCURRENCE`, `CUMSUMGRID`, `MAXOCCUR`, `MINOCCUR`, `EXPANDDIMENSIONS`, `SNAQUENCE`, `WRITEAT`, `INSERTAT`, `REVERSEARRAY`, `ROTATE`, `EXPLODE`, `CONSECGROUPS`, `COMBINATIONS`, `COMBININDICES`, `SetVar`, `SetVars`, `SetState`, `NewState`, `FINDFIRST`, `FINDALL`, `REDUCEUNTIL`, `REDUCEWHILE`, `SCANUNTIL`, `SCANWHILE`.

### Dispatcher shape

The scalar body is preserved inline as a LAMBDA inside `LET` (rather than a separate `<NAME>_SCALAR` workbook name) — this keeps the namespace tidy and the logic in one file:

```
scalar, LAMBDA(c, LET(... scalar body ..., scalar result)),
result, IF(OR(ROWS(arg) > 1, COLUMNS(arg) > 1),
            MAP(arg, scalar),
            scalar(arg)),
IF(Help?, Help, result)
```

The dispatcher sits **after** the `ISOMITTED(...)` → `ShowHelp` branch, so `=CELLTOPOS()` etc. still return help text. Scalar callers are unaffected.

## Test plan

- [x] All existing scalar tests still pass (no regressions).
- [x] 23 new tests added covering vertical, horizontal, and where useful 2D / range-of-cells inputs:
  - maps: CELLTOPOS (4), POSTOCELL (2), MOVECELL (2), GRIDLOOKUP (2), INCEL (2)
  - array: NTH (2), CONTAINS (1)
  - string: CHARQ (2), REVERSESTRING (2)
  - lookup: TLOOKUP (2)
  - math: CIRCPOS (2)
- [x] `dotnet test addin/lambda-boss.AddinTests` — 382 pass (was 359 pre-change).
- [x] `dotnet test addin/lambda-boss.Tests` — 828 pass.

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)