### PR TITLE
Add stock Mazelams: MAZELAM_DIAG and MAZELAM_ELEV

### DIFF
--- a/lambdas/maps/MAZE.tests.yaml
+++ b/lambdas/maps/MAZE.tests.yaml
@@ -76,7 +76,7 @@ tests:
     args: ["=theMap", '="C3"', "=costArr", '="E5"', "=FALSE", "=", "=TRUE"]
     expected: 4
 
-  - name: custom Mazelam — diagonals cost 1.5x
+  - name: custom Mazelam — inline LAMBDA, diagonals cost 1.5x
     setup:
       cells:
         - address: "C3:E5"
@@ -87,6 +87,19 @@ tests:
       names:
         - { name: "theMap", refers_to: "C3:E5" }
     args: ["=theMap", '="C3"', "=", '="E5"', "=FALSE", "=", "=", "=", "=LAMBDA(costFrom,costTo,rowFrom,colFrom,rowTo,colTo,distFrom,dirDelta,prevDir,IF((rowFrom<>rowTo)*(colFrom<>colTo)=1,costTo*1.5,costTo))"]
+    expected: 3
+
+  - name: stock MAZELAM_DIAG passed by name gives same result as the inline LAMBDA
+    setup:
+      cells:
+        - address: "C3:E5"
+          values:
+            - [0, 0, 0]
+            - [0, 0, 0]
+            - [0, 0, 0]
+      names:
+        - { name: "theMap", refers_to: "C3:E5" }
+    args: ["=theMap", '="C3"', "=", '="E5"', "=FALSE", "=", "=", "=", "=MAZELAM_DIAG"]
     expected: 3
 
   - name: help text

--- a/lambdas/maps/MAZELAM_DIAG.lambda
+++ b/lambdas/maps/MAZELAM_DIAG.lambda
@@ -1,0 +1,44 @@
+/*  FUNCTION NAME:      MAZELAM_DIAG
+    DESCRIPTION:*//**Stock Mazelam for MAZE: diagonal steps cost 1.5x the destination cell's Cost; cardinal steps cost 1x. Produces realistic Euclidean-ish distance over a uniform map.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-05-20  Claude      Initial version
+*/
+MAZELAM_DIAG = LAMBDA(
+//  Parameter Declarations
+    [costFrom],
+    [costTo],
+    [rowFrom],
+    [colFrom],
+    [rowTo],
+    [colTo],
+    [distFrom],
+    [dirDelta],
+    [prevDir],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →MAZELAM_DIAG(costFrom, costTo, rowFrom, colFrom, rowTo, colTo, distFrom, dirDelta, prevDir)¶" &
+                "DESCRIPTION:   →Stock Mazelam for MAZE: diagonal steps cost 1.5x the destination cell's Cost; cardinal steps cost 1x. Pass by name to MAZE: =MAZE(mp, ""C3"", , , , , , , MAZELAM_DIAG).¶" &
+                "VERSION:       →May 20 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   costFrom       →(Required) Cost at the source cell. (Unused by this Mazelam.)¶" &
+                "   costTo         →(Required) Cost at the destination cell. Multiplied by 1.5 on diagonals.¶" &
+                "   rowFrom        →(Required) Absolute row of source cell.¶" &
+                "   colFrom        →(Required) Absolute column of source cell.¶" &
+                "   rowTo          →(Required) Absolute row of destination cell.¶" &
+                "   colTo          →(Required) Absolute column of destination cell.¶" &
+                "   distFrom       →(Required) Cumulative cost to reach source. (Unused by this Mazelam.)¶" &
+                "   dirDelta       →(Required) This step's direction, encoded row*100000+col. (Unused.)¶" &
+                "   prevDir        →(Required) Previous direction. (Unused.)¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=MAZE(myMap, ""A1"", , , , , , , MAZELAM_DIAG)¶" &
+                "Result         →Distance grid where diagonal moves cost 1.5x and cardinals cost 1x",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(costFrom),
+    //  Procedure
+        diagonal, (rowFrom <> rowTo) * (colFrom <> colTo),
+        result, IF(diagonal = 1, costTo * 1.5, costTo),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/MAZELAM_DIAG.tests.yaml
+++ b/lambdas/maps/MAZELAM_DIAG.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: diagonal step costs 1.5x destination
+    args: ["=1", "=2", "=3", "=3", "=4", "=4", "=0", "=100001", "=0"]
+    expected: 3
+
+  - name: horizontal step costs 1x destination
+    args: ["=1", "=2", "=3", "=3", "=3", "=4", "=0", "=1", "=0"]
+    expected: 2
+
+  - name: vertical step costs 1x destination
+    args: ["=1", "=2", "=3", "=3", "=4", "=3", "=0", "=100000", "=0"]
+    expected: 2
+
+  - name: anti-diagonal step also costs 1.5x destination
+    args: ["=1", "=4", "=5", "=5", "=4", "=6", "=0", "=-99999", "=0"]
+    expected: 6
+
+  - name: array of destination costs lifts element-wise (vertical)
+    args: ['=1', '={1;2;3}', "=3", "=3", "=4", "=4", "=0", "=100001", "=0"]
+    expected: [[1.5], [3], [4.5]]
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/maps/MAZELAM_ELEV.lambda
+++ b/lambdas/maps/MAZELAM_ELEV.lambda
@@ -1,0 +1,44 @@
+/*  FUNCTION NAME:      MAZELAM_ELEV
+    DESCRIPTION:*//**Stock Mazelam for MAZE: treats Cost as elevation. Uphill steps cost 1 + 2x the rise; downhill steps cost 1 + 0.5x the drop (negative); flat steps cost 1.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-05-20  Claude      Initial version
+*/
+MAZELAM_ELEV = LAMBDA(
+//  Parameter Declarations
+    [costFrom],
+    [costTo],
+    [rowFrom],
+    [colFrom],
+    [rowTo],
+    [colTo],
+    [distFrom],
+    [dirDelta],
+    [prevDir],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →MAZELAM_ELEV(costFrom, costTo, rowFrom, colFrom, rowTo, colTo, distFrom, dirDelta, prevDir)¶" &
+                "DESCRIPTION:   →Stock Mazelam for MAZE that treats Cost as elevation. Cost of a step = 1 + 2*rise for uphill, 1 + 0.5*drop for downhill (drop is negative, so the step is cheaper than 1), and 1 for flat.¶" &
+                "VERSION:       →May 20 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   costFrom       →(Required) Elevation at source cell.¶" &
+                "   costTo         →(Required) Elevation at destination cell.¶" &
+                "   rowFrom        →(Required) Absolute row of source. (Unused by this Mazelam.)¶" &
+                "   colFrom        →(Required) Absolute column of source. (Unused.)¶" &
+                "   rowTo          →(Required) Absolute row of destination. (Unused.)¶" &
+                "   colTo          →(Required) Absolute column of destination. (Unused.)¶" &
+                "   distFrom       →(Required) Cumulative cost to reach source. (Unused.)¶" &
+                "   dirDelta       →(Required) This step's direction. (Unused.)¶" &
+                "   prevDir        →(Required) Previous direction. (Unused.)¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=MAZE(elevationMap, ""A1"", elevationMap, , , , , , MAZELAM_ELEV)¶" &
+                "Result         →Distance grid where uphill is penalised 2x and downhill is rewarded 0.5x",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(costFrom),
+    //  Procedure
+        delta, costTo - costFrom,
+        result, 1 + IF(delta > 0, delta * 2, delta * 0.5),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/MAZELAM_ELEV.tests.yaml
+++ b/lambdas/maps/MAZELAM_ELEV.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: uphill +3 elevation costs 1 + 3*2 = 7
+    args: ["=5", "=8", "=3", "=3", "=4", "=4", "=0", "=100001", "=0"]
+    expected: 7
+
+  - name: downhill -3 elevation costs 1 + (-3)*0.5 = -0.5
+    args: ["=8", "=5", "=3", "=3", "=4", "=4", "=0", "=100001", "=0"]
+    expected: -0.5
+
+  - name: flat step costs 1
+    args: ["=5", "=5", "=3", "=3", "=3", "=4", "=0", "=1", "=0"]
+    expected: 1
+
+  - name: small uphill +0.5 costs 1 + 0.5*2 = 2
+    args: ["=2", "=2.5", "=3", "=3", "=4", "=4", "=0", "=100001", "=0"]
+    expected: 2
+
+  - name: array of destination elevations lifts element-wise
+    args: ['=5', '={2;5;10}', "=3", "=3", "=4", "=4", "=0", "=100001", "=0"]
+    expected: [[-0.5], [1], [11]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Two ready-to-use callbacks for `MAZE`'s `Mazelam` slot:

- **`MAZELAM_DIAG`** — diagonals cost 1.5× the destination's Cost, cardinals cost 1×. The canonical "realistic distance over a uniform map" callback from #184.
- **`MAZELAM_ELEV`** — treats Cost as elevation. Uphill steps cost `1 + 2·rise`; downhill `1 + 0.5·drop` (drop is negative, so downhill is cheaper than flat); flat steps cost 1.

Both ship as direct 9-arg LAMBDAs (not factories), so usage is a single name reference:

```
=MAZE(mp, "C3", , , , , , , MAZELAM_DIAG)
=MAZE(elevation, "C3", elevation, , , , , , MAZELAM_ELEV)
```

### Two purposes (per the user spec)

1. **Directly useful** — both ship with sensible defaults (1.5× and 2×/0.5× respectively) drawn from the issue prose.
2. **Copy-and-edit templates** — bodies are small, the 9-arg Mazelam contract is pre-wired with the correct param names, and constants are obvious to tweak. Drop a copy in your own library and edit the inner formula.

### Scope note

Four of the six patterns in #184 (turn penalty +5, budget=50, blockrow=15, fatigue=0.05) were omitted by design — their hard-coded constants are too case-specific to be "directly useful" on purpose 1, and the two shipped here demonstrate the contract well enough to serve as copy templates for the others.

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` — succeeded
- [x] `dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj --filter "FullyQualifiedName~LambdaFormatTests"` — 448/448 passed (16 new format-test cases for the two Mazelams)
- [x] `dotnet test addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj --filter "FullyQualifiedName~LambdaHarnessTests.LambdaTest"` — 472/472 passed (13 new harness tests)
- [x] Integration test: `MAZE(theMap, "C3", , "E5", FALSE, , , , MAZELAM_DIAG)` returns `3`, matching the existing inline-LAMBDA case
- [x] Array-lift confirmation: passing `={1;2;3}` as `costTo` to either Mazelam returns the expected vertical 3-element result via the calc engine's natural broadcasting (no dispatcher needed)
- [x] Tim to spot-check in Excel that the named-reference call style feels right

Related: #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)