### PR TITLE
Fix Windows PowerShell 5.1 parse error in publish scripts

### DIFF
--- a/scripts/build-release-bundle.ps1
+++ b/scripts/build-release-bundle.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Builds the Lambda Boss release zip: signed packed XLL + README + unblock.cmd.
 
@@ -7,7 +7,7 @@
     `release/` into a temporary folder, then zips it as
     `release/output/LambdaBoss-<version>.zip`.
 
-    The script assumes the build has already happened and the XLL is signed —
+    The script assumes the build has already happened and the XLL is signed --
     `publish-release.ps1` handles those steps and calls this script after.
 
 .PARAMETER Version
@@ -62,7 +62,7 @@ if (Test-Path $StagingDir) {
 New-Item -ItemType Directory -Force -Path $StagingDir | Out-Null
 
 # Copy in the three deliverables. Rename the XLL to drop the "-packed" suffix
-# — end users don't need to see ExcelDNA's internal naming.
+# -- end users don't need to see ExcelDNA's internal naming.
 Copy-Item $SignedXllPath "$StagingDir\lambda-boss64.xll"
 Copy-Item $readmePath "$StagingDir\README.txt"
 Copy-Item $unblockPath "$StagingDir\unblock.cmd"
@@ -74,7 +74,7 @@ if (Test-Path $zipPath) {
 
 Compress-Archive -Path "$StagingDir\*" -DestinationPath $zipPath -CompressionLevel Optimal
 
-# Clean up the staging folder — the zip is the only thing we keep
+# Clean up the staging folder -- the zip is the only thing we keep
 Remove-Item -Recurse -Force $StagingDir
 
 $zipSize = (Get-Item $zipPath).Length / 1MB

--- a/scripts/publish-release.ps1
+++ b/scripts/publish-release.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     End-to-end release publishing script for Lambda Boss.
 
@@ -355,7 +355,7 @@ try {
         "### Requirements",
         "- 64-bit Excel (Microsoft 365 or Excel 2019+)",
         "- Windows 10 / 11",
-        "- No .NET runtime install required — the add-in ships against .NET Framework 4.8, which is part of Windows.",
+        "- No .NET runtime install required -- the add-in ships against .NET Framework 4.8, which is part of Windows.",
         "",
         "### Installation",
         "Download ``$zipName``, extract, and follow the load instructions in the bundled README.txt.",


### PR DESCRIPTION
## Summary

`publish-release.ps1` (and `build-release-bundle.ps1`) had em-dash characters (U+2014) in comments and a release-notes string. Windows PowerShell 5.1 reads `.ps1` files in the system code page (windows-1252 on most installs) unless the file has a UTF-8 BOM, so the em-dashes parsed as garbage and the script failed with:

```
Unexpected token 'the' in expression or statement
```

at the line containing `-- the add-in ships against …`.

PowerShell 7 / `pwsh.exe` defaults to UTF-8 even without a BOM, so CI and pwsh-based local testing didn't catch it. Tim's local PS 5.1 did.

## Fix

ASCII-ify all dashes (`--` instead of `—`) in both scripts. Writing the files via `Set-Content -Encoding utf8` also added a UTF-8 BOM as belt-and-braces.

## Test plan

- [x] Local dry run on Windows PowerShell 5.1 now gets past the parse stage (parser-error gone; only the legitimate preflight checks then run).
- [x] Tim re-runs `.\scripts\publish-release.ps1 -DryRun -SkipSign` from a clean `main` after this lands.