### PR TITLE
Refactor to LET — PR 1: tracer (spec 0008)

### DIFF
--- a/addin/lambda-boss.Tests/CellRefExtractorSpillTests.cs
+++ b/addin/lambda-boss.Tests/CellRefExtractorSpillTests.cs
@@ -1,0 +1,103 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+/// <summary>
+///     Spec 0008 / PR 1 — focused tests for the new
+///     <see cref="FormulaRef.IsSpilled" /> flag and its propagation
+///     through <see cref="CellRefExtractor" />. Complements the broader
+///     <see cref="CellRefExtractorTests" /> spill coverage.
+/// </summary>
+public class CellRefExtractorSpillTests
+{
+    private const string Sheet = "Sheet1";
+
+    [Fact]
+    public void Extract_SpillRef_IsSpilledTrue()
+    {
+        var refs = CellRefExtractor.Extract("=SUM(A1#)", Sheet);
+
+        Assert.Single(refs);
+        Assert.True(refs[0].IsSpilled);
+        Assert.Equal("A1", refs[0].A1Address);
+    }
+
+    [Fact]
+    public void Extract_PlainRef_IsSpilledFalse()
+    {
+        var refs = CellRefExtractor.Extract("=A1+B1", Sheet);
+
+        Assert.Equal(2, refs.Count);
+        Assert.All(refs, r => Assert.False(r.IsSpilled));
+    }
+
+    [Fact]
+    public void Extract_Range_IsSpilledFalse()
+    {
+        // Excel has no A1:B5# syntax; the regex's range alternative is
+        // mutually exclusive with the spill alternative.
+        var refs = CellRefExtractor.Extract("=SUM(A1:B5)", Sheet);
+
+        Assert.Single(refs);
+        Assert.True(refs[0].IsRange);
+        Assert.False(refs[0].IsSpilled);
+    }
+
+    [Fact]
+    public void FormulaRef_Equality_DistinguishesSpilled()
+    {
+        var anchor = new FormulaRef(new CellRef(Sheet, 1, 1));
+        var spilled = new FormulaRef(new CellRef(Sheet, 1, 1), IsSpilled: true);
+
+        Assert.NotEqual(anchor, spilled);
+        Assert.NotEqual(anchor.GetHashCode(), spilled.GetHashCode());
+    }
+
+    [Fact]
+    public void FormulaRef_DisplayAddress_AppendsHashForSpilled()
+    {
+        var spilled = new FormulaRef(new CellRef(Sheet, 1, 1), IsSpilled: true);
+
+        Assert.Equal("A1#", spilled.DisplayAddress(Sheet));
+    }
+
+    [Fact]
+    public void FormulaRef_DisplayAddress_CrossSheetSpilled_QualifiesAndAppendsHash()
+    {
+        var spilled = new FormulaRef(new CellRef("Other", 1, 1), IsSpilled: true);
+
+        Assert.Equal("Other!A1#", spilled.DisplayAddress(Sheet));
+    }
+
+    [Fact]
+    public void Rewrite_SpilledLookupWins_OverNonSpilled()
+    {
+        // Both keys present — A1 maps to "scalar", A1# maps to "array".
+        // Tokens rewrite to their own binding name.
+        var lookup = new Dictionary<FormulaRef, string>
+        {
+            [new FormulaRef(new CellRef(Sheet, 1, 1))] = "scalar",
+            [new FormulaRef(new CellRef(Sheet, 1, 1), IsSpilled: true)] = "array"
+        };
+
+        var rewritten = CellRefExtractor.Rewrite("=A1+SUM(A1#)", Sheet, lookup);
+
+        Assert.Equal("=scalar+SUM(array)", rewritten);
+    }
+
+    [Fact]
+    public void Rewrite_OnlyNonSpilledKey_StillCollapsesSpillToken()
+    {
+        // /Gather's PR 5 behaviour: A1# falls back to the non-spilled
+        // binding name. No trailing '#' in the rewrite — the binding IS
+        // the array.
+        var lookup = new Dictionary<FormulaRef, string>
+        {
+            [new FormulaRef(new CellRef(Sheet, 1, 1))] = "numbers"
+        };
+
+        var rewritten = CellRefExtractor.Rewrite("=SUM(A1#)", Sheet, lookup);
+
+        Assert.Equal("=SUM(numbers)", rewritten);
+    }
+}

--- a/addin/lambda-boss.Tests/CellRefExtractorTests.cs
+++ b/addin/lambda-boss.Tests/CellRefExtractorTests.cs
@@ -200,28 +200,35 @@ public class CellRefExtractorTests
     }
 
     [Fact]
-    public void Extract_SpillRef_ResolvesToAnchorCell()
+    public void Extract_SpillRef_ResolvesToAnchorCellWithSpillFlag()
     {
-        // PR 5: A1# is recognised as a ref to the anchor cell A1. The
-        // returned FormulaRef collapses spill onto the anchor (no separate
-        // flag) — the engine learns spill-ness from ICellSource.HasSpill.
+        // A1# is a ref to the anchor cell A1 with IsSpilled=true (spec
+        // 0008). /Gather still treats it the same as A1 via
+        // CellGraphWalker's spill-flag normalisation; /Refactor uses the
+        // flag to bind A1 and A1# as distinct inputs.
         var refs = CellRefExtractor.Extract("=SUM(A1#)+B1", Sheet);
 
         Assert.Equal(2, refs.Count);
         Assert.Equal("A1", refs[0].A1Address);
+        Assert.True(refs[0].IsSpilled);
         Assert.False(refs[0].IsRange);
         Assert.Equal("B1", refs[1].A1Address);
+        Assert.False(refs[1].IsSpilled);
     }
 
     [Fact]
-    public void Extract_BareRefAndSpillRefOnSameCell_DedupedToOneRef()
+    public void Extract_BareRefAndSpillRefOnSameCell_ProduceTwoDistinctRefs()
     {
-        // A1 and A1# resolve to the same FormulaRef key (the anchor cell).
-        // The dedupe in Extract drops the second occurrence.
+        // Spec 0008 (/Refactor): A1 and A1# are distinct FormulaRefs so
+        // each can become its own LET binding. The non-spilled ref comes
+        // first because that's its first-seen position in the formula.
         var refs = CellRefExtractor.Extract("=A1+SUM(A1#)", Sheet);
 
-        Assert.Single(refs);
+        Assert.Equal(2, refs.Count);
         Assert.Equal("A1", refs[0].A1Address);
+        Assert.False(refs[0].IsSpilled);
+        Assert.Equal("A1", refs[1].A1Address);
+        Assert.True(refs[1].IsSpilled);
     }
 
     [Fact]

--- a/addin/lambda-boss.Tests/RefactorEngineTests.cs
+++ b/addin/lambda-boss.Tests/RefactorEngineTests.cs
@@ -1,0 +1,220 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+/// <summary>
+///     Spec 0008 / PR 1 — the tracer slice's engine tests. Covers the
+///     happy path (refs, ranges, spill-distinct, sheet-qualifier
+///     dedupe), the rename path, the Include-drop path, and round-trip
+///     safety via <see cref="LetParser" /> + <see cref="LetToLambdaBuilder" />.
+/// </summary>
+public class RefactorEngineTests
+{
+    private const string Sheet = "Sheet1";
+
+    [Fact]
+    public void Refactor_SingleCellRef_BindsToInput1()
+    {
+        var result = RefactorEngine.Refactor("=A1*2", Sheet);
+
+        Assert.Null(result.Diagnostic);
+        var row = Assert.Single(result.Inputs);
+        Assert.Equal("input1", row.Name);
+        Assert.Equal("A1", row.Rhs);
+        Assert.Contains("input1*2", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_MultipleRefsDeduped_OneBindingPerUniqueRef()
+    {
+        // A1 appears twice, B2 once → two bindings, two rewrites of A1.
+        var result = RefactorEngine.Refactor("=A1+B2+A1", Sheet);
+
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Equal("input1", result.Inputs[0].Name);
+        Assert.Equal("A1", result.Inputs[0].Rhs);
+        Assert.Equal("input2", result.Inputs[1].Name);
+        Assert.Equal("B2", result.Inputs[1].Rhs);
+        Assert.Contains("input1+input2+input1", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_Range_BindsAsSingleInput()
+    {
+        var result = RefactorEngine.Refactor("=SUM(A1:B5)", Sheet);
+
+        var row = Assert.Single(result.Inputs);
+        Assert.Equal("input1", row.Name);
+        Assert.Equal("A1:B5", row.Rhs);
+        Assert.Contains("SUM(input1)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_SpillRefAndAnchor_BindAsTwoDistinctInputs()
+    {
+        // Spec 0008 dedupe rule: A1 and A1# get distinct bindings.
+        var result = RefactorEngine.Refactor("=A1+SUM(A1#)", Sheet);
+
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Equal("A1", result.Inputs[0].Rhs);
+        Assert.Equal("A1#", result.Inputs[1].Rhs);
+        Assert.Contains("input1+SUM(input2)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_SheetQualifiedRefMatchingActiveSheet_CollapsesToBareForm()
+    {
+        // Sheet1!A1 with active sheet Sheet1 should dedupe with A1.
+        var result = RefactorEngine.Refactor("=A1+Sheet1!A1", Sheet);
+
+        var row = Assert.Single(result.Inputs);
+        Assert.Equal("A1", row.Rhs);
+        Assert.Contains("input1+input1", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_CrossSheetRef_StaysDistinct()
+    {
+        // Sheet2!A1 from Sheet1 stays cross-sheet; the binding RHS is
+        // sheet-qualified so the LET resolves correctly when the cell
+        // lives on Sheet1.
+        var result = RefactorEngine.Refactor("=A1+Sheet2!A1", Sheet);
+
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Equal("A1", result.Inputs[0].Rhs);
+        Assert.Equal("Sheet2!A1", result.Inputs[1].Rhs);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_Refused()
+    {
+        var result = RefactorEngine.Refactor("=LET(x, A1, x + 1)", Sheet);
+
+        Assert.NotNull(result.Diagnostic);
+        Assert.Equal(RefactorDiagnosticKind.ExistingLet, result.Diagnostic.Kind);
+        Assert.Empty(result.Inputs);
+        Assert.Equal("=LET(x, A1, x + 1)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_NoRefs_LiteralFormulaReturnedVerbatim()
+    {
+        var result = RefactorEngine.Refactor("=1+2", Sheet);
+
+        Assert.Empty(result.Inputs);
+        Assert.Equal("=1+2", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_Renamed_RewritesBodyWithNewName()
+    {
+        var initial = RefactorEngine.Refactor("=IF(A1<10, A1*2, 0)", Sheet);
+        var row = initial.Inputs[0];
+
+        var renamed = new[] { new RefactorRowState(row.Source, "count") };
+        var result = RefactorEngine.Recompute("=IF(A1<10, A1*2, 0)", Sheet, renamed);
+
+        Assert.Single(result.Inputs);
+        Assert.Equal("count", result.Inputs[0].Name);
+        Assert.Contains("IF(count<10, count*2, 0)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_DroppedRow_LeavesTokenInBody()
+    {
+        // Worked example from the spec: drop A1 → "IF(A1<10, ...)" stays.
+        var initial = RefactorEngine.Refactor("=IF(A1<10, A1*2, B1)", Sheet);
+        var rows = initial.Inputs
+            .Select(r => new RefactorRowState(
+                r.Source,
+                r.Name,
+                Include: r.Rhs != "A1"))
+            .ToArray();
+
+        var result = RefactorEngine.Recompute(
+            "=IF(A1<10, A1*2, B1)", Sheet, rows);
+
+        Assert.Single(result.Inputs);
+        Assert.Equal("B1", result.Inputs[0].Rhs);
+        // A1 stays as A1 because its binding was dropped.
+        Assert.Contains("IF(A1<10, A1*2, input2)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_Reordered_BindingOrderMatchesRowOrder()
+    {
+        var initial = RefactorEngine.Refactor("=A1+B2", Sheet);
+        // Swap order: B2 first, A1 second.
+        var swapped = new[]
+        {
+            new RefactorRowState(initial.Inputs[1].Source, initial.Inputs[1].Name),
+            new RefactorRowState(initial.Inputs[0].Source, initial.Inputs[0].Name),
+        };
+
+        var result = RefactorEngine.Recompute("=A1+B2", Sheet, swapped);
+
+        Assert.Equal("B2", result.Inputs[0].Rhs);
+        Assert.Equal("A1", result.Inputs[1].Rhs);
+        // Synthesised LET emits bindings in dialog order — B2 first.
+        var b2Pos = result.SynthesisedLet.IndexOf("B2", StringComparison.Ordinal);
+        var a1Pos = result.SynthesisedLet.IndexOf(" A1,", StringComparison.Ordinal);
+        Assert.True(b2Pos < a1Pos, "B2 binding should precede A1 binding");
+    }
+
+    [Fact]
+    public void Refactor_SpecWorkedExample_ProducesRoundTrippableLet()
+    {
+        // The worked example from the spec.
+        var formula = "=IF(A1<10, IF(A1>2, SUM(B1:B5), 0), SUM(B2:B6))";
+        var result = RefactorEngine.Refactor(formula, Sheet);
+
+        Assert.Null(result.Diagnostic);
+        Assert.Equal(3, result.Inputs.Count);
+        Assert.Equal("A1", result.Inputs[0].Rhs);
+        Assert.Equal("B1:B5", result.Inputs[1].Rhs);
+        Assert.Equal("B2:B6", result.Inputs[2].Rhs);
+
+        // Round-trip safety.
+        AssertRoundTrips(result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_RoundTripsViaLetParserAndBuilder_ForCommonShapes()
+    {
+        var formulas = new[]
+        {
+            "=A1*2",
+            "=A1+B2+C3",
+            "=SUM(A1:A10)*B1",
+            "=IF(A1=0, B1, C1/A1)",
+            "=A1+SUM(A1#)",
+            "=Sheet2!A1 + A1",
+        };
+
+        foreach (var formula in formulas)
+        {
+            var result = RefactorEngine.Refactor(formula, Sheet);
+            Assert.Null(result.Diagnostic);
+            AssertRoundTrips(result.SynthesisedLet);
+        }
+    }
+
+    /// <summary>
+    ///     Confirms the synthesised LET parses via <see cref="LetParser.Parse" />
+    ///     AND feeds cleanly through <see cref="LetToLambdaBuilder.Build" />
+    ///     with a default request keeping all inputs. Catches both
+    ///     malformed-LET output and LET-that-LetToLambdaBuilder-rejects
+    ///     output early.
+    /// </summary>
+    private static void AssertRoundTrips(string synthesisedLet)
+    {
+        var parsed = LetParser.Parse(synthesisedLet);
+        var inputs = parsed.Bindings
+            .Where(b => !b.IsCalculation)
+            .Select(b => new InputChoice(b.Name, b.Name, Keep: true))
+            .ToList();
+        var request = new LambdaGenerationRequest("RoundTrip", parsed, inputs);
+        var lambdaText = LetToLambdaBuilder.Build(request);
+        Assert.StartsWith("=LAMBDA(", lambdaText);
+    }
+}

--- a/addin/lambda-boss/CellGraphWalker.cs
+++ b/addin/lambda-boss/CellGraphWalker.cs
@@ -146,7 +146,19 @@ internal static class CellGraphWalker
                     // its OWN sheet, not the sink's — otherwise crossing into
                     // Sheet1 from a sink on Sheet2 would mis-route Sheet1's
                     // internal `B1` references back to Sheet2.
-                    precedents = CellRefExtractor.Extract(formula, cell.Sheet);
+                    //
+                    // Strip the IsSpilled flag for cell-level precedents.
+                    // /Gather has always treated A1 and A1# as the same
+                    // precedent — spill info lives on
+                    // <see cref="WalkedCell.HasSpill" />, not on the ref. The
+                    // shared FormulaRef now carries IsSpilled (spec 0008
+                    // needs it for /Refactor's distinct-binding rule), but
+                    // /Gather's downstream code keys on the non-spilled
+                    // anchor; normalising here keeps that contract intact.
+                    // Ranges are left as-is (IsSpilled is always false on
+                    // ranges).
+                    precedents = NormaliseSpillFlag(
+                        CellRefExtractor.Extract(formula, cell.Sheet));
                 }
             }
 
@@ -176,6 +188,36 @@ internal static class CellGraphWalker
         }
 
         return CycleAwareTopoSort(sink, byRef, leafRestricted);
+    }
+
+    /// <summary>
+    ///     Returns a new precedent list where every spilled single-cell
+    ///     FormulaRef is replaced by its non-spilled equivalent and
+    ///     duplicates are collapsed in first-seen order. Range refs are
+    ///     pass-through. Used so /Gather's downstream code (which keys on
+    ///     non-spilled anchors) keeps working after spec 0008 split A1
+    ///     and A1# into distinct FormulaRefs.
+    /// </summary>
+    private static IReadOnlyList<FormulaRef> NormaliseSpillFlag(
+        IReadOnlyList<FormulaRef> precedents)
+    {
+        if (precedents.Count == 0)
+            return precedents;
+        var any = false;
+        for (var i = 0; i < precedents.Count; i++)
+            if (precedents[i].IsSpilled) { any = true; break; }
+        if (!any)
+            return precedents;
+
+        var seen = new HashSet<FormulaRef>();
+        var result = new List<FormulaRef>(precedents.Count);
+        foreach (var p in precedents)
+        {
+            var normalised = p.IsSpilled ? new FormulaRef(p.Start) : p;
+            if (seen.Add(normalised))
+                result.Add(normalised);
+        }
+        return result;
     }
 
     /// <summary>

--- a/addin/lambda-boss/CellRefExtractor.cs
+++ b/addin/lambda-boss/CellRefExtractor.cs
@@ -126,6 +126,16 @@ internal static class CellRefExtractor
     ///     collapses to one binding name even when its endpoints alone are
     ///     also bound elsewhere. The default-sheet rule matches
     ///     <see cref="Extract" />.
+    ///
+    ///     Spill refs (<c>A1#</c>) match in priority order: first the
+    ///     spilled key, then the non-spilled equivalent. <c>/Gather</c>
+    ///     only registers non-spilled keys for spilling anchor cells (the
+    ///     binding RHS is built as <c>A1#</c> directly by the engine), so
+    ///     the fallback path keeps its PR 5 behaviour of collapsing the
+    ///     whole <c>A1#</c> token to the binding name with no trailing
+    ///     <c>#</c>. <c>/Refactor</c> (spec 0008) registers both keys
+    ///     independently — the spilled lookup wins for the <c>A1#</c>
+    ///     token, the non-spilled lookup for plain <c>A1</c>.
     /// </summary>
     public static string Rewrite(
         string formula,
@@ -153,7 +163,19 @@ internal static class CellRefExtractor
             var rewritten = CellRefPattern.Replace(segment, m =>
             {
                 var key = BuildFormulaRef(m, defaultSheet);
-                return lookup.TryGetValue(key, out var name) ? name : m.Value;
+                if (lookup.TryGetValue(key, out var name))
+                    return name;
+                // Spilled-key miss: try the non-spilled equivalent so a
+                // legacy /Gather lookup keyed only on the anchor still
+                // collapses an A1# token. Ranges never reach this branch
+                // (IsSpilled is always false on ranges).
+                if (key.IsSpilled)
+                {
+                    var fallback = new FormulaRef(key.Start);
+                    if (lookup.TryGetValue(fallback, out name))
+                        return name;
+                }
+                return m.Value;
             });
             result.Append(rewritten);
             i = segEnd;
@@ -164,15 +186,19 @@ internal static class CellRefExtractor
     private static FormulaRef BuildFormulaRef(Match m, string defaultSheet)
     {
         var start = BuildCellRef(m, defaultSheet);
-        if (!m.Groups["col2"].Success)
-            return new FormulaRef(start);
+        if (m.Groups["col2"].Success)
+        {
+            // Range tail: End shares the sheet/workbook of Start (Excel
+            // disallows cross-sheet ranges), so we don't reparse the
+            // qualifier. Ranges never carry a spill marker.
+            var endCol = CellRef.LettersToColumn(m.Groups["col2"].Value);
+            var endRow = int.Parse(m.Groups["row2"].Value);
+            var end = new CellRef(start.Sheet, endCol, endRow, start.ExternalWorkbook);
+            return new FormulaRef(start, end);
+        }
 
-        // Range tail: End shares the sheet/workbook of Start (Excel
-        // disallows cross-sheet ranges), so we don't reparse the qualifier.
-        var endCol = CellRef.LettersToColumn(m.Groups["col2"].Value);
-        var endRow = int.Parse(m.Groups["row2"].Value);
-        var end = new CellRef(start.Sheet, endCol, endRow, start.ExternalWorkbook);
-        return new FormulaRef(start, end);
+        var isSpilled = m.Groups["spill"].Success;
+        return new FormulaRef(start, IsSpilled: isSpilled);
     }
 
     private static CellRef BuildCellRef(Match m, string defaultSheet)

--- a/addin/lambda-boss/Commands/EditLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/EditLambdaCommand.cs
@@ -1,8 +1,8 @@
 using ExcelDna.Integration;
+using LambdaBoss.Common;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
-using LambdaBoss.Common;
 
 namespace LambdaBoss.Commands;
 
@@ -120,7 +120,7 @@ internal static class EditLambdaCommand
         if (closeParen < 0)
             return null;
 
-        for (var i = closeParen + 1; i < formula.Length; i++)
+        for (var i = closeParen + 1; i < formula!.Length; i++)
             if (!char.IsWhiteSpace(formula[i]))
                 return null;
 

--- a/addin/lambda-boss/Commands/EditLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/EditLambdaCommand.cs
@@ -113,7 +113,10 @@ internal static class EditLambdaCommand
 
         var name = match.Groups[1].Value;
         var openParen = match.Index + match.Length - 1;
-        var closeParen = LetParser.FindMatchingClose(formula, openParen);
+        // formula is non-null after IsNullOrEmpty guard; net48's BCL
+        // doesn't annotate IsNullOrEmpty with [NotNullWhen(false)], so
+        // the analyzer can't narrow on its own.
+        var closeParen = LetParser.FindMatchingClose(formula!, openParen);
         if (closeParen < 0)
             return null;
 

--- a/addin/lambda-boss/Commands/RefactorCommand.cs
+++ b/addin/lambda-boss/Commands/RefactorCommand.cs
@@ -1,0 +1,131 @@
+using System.Windows;
+using System.Windows.Interop;
+
+using ExcelDna.Integration;
+
+using LambdaBoss.UI;
+
+using LambdaBoss.Common;
+
+namespace LambdaBoss.Commands;
+
+/// <summary>
+///     Spec 0008 / PR 1 — slash-command handler for <c>/Refactor</c>.
+///     Reads the active cell's formula, runs <see cref="RefactorEngine" />,
+///     opens <see cref="RefactorToLetWindow" /> on the popup's UI thread,
+///     and on Save writes the synthesised LET back via
+///     <c>activeCell.Formula2</c>. Existing-LET diagnostics surface via
+///     <see cref="MessageBox" />; empty/literal active cells close the
+///     popup silently (mirrors <c>/Gather</c>'s pattern).
+/// </summary>
+internal static class RefactorCommand
+{
+    public static void Run()
+    {
+        try
+        {
+            dynamic app = ExcelDnaUtil.Application;
+            dynamic workbook = app.ActiveWorkbook;
+            if (workbook == null)
+                return;
+
+            dynamic activeCell = app.ActiveCell;
+            if (activeCell == null)
+                return;
+
+            dynamic worksheet = activeCell.Worksheet;
+            string sheetName = (string)worksheet.Name;
+
+            bool hasFormula = (bool)activeCell.HasFormula;
+            if (!hasFormula)
+                return;
+
+            // Formula2 is the dynamic-array-aware reader — the legacy
+            // Formula property returns `@`-prefixed text for spill-shaped
+            // cells, which would corrupt our refactor.
+            string formula = (string)activeCell.Formula2;
+
+            RefactorResult result;
+            try
+            {
+                result = RefactorEngine.Refactor(formula, sheetName);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Refactor/Engine", ex);
+                ShowError($"Failed to refactor: {ex.Message}");
+                return;
+            }
+
+            if (result.Diagnostic != null)
+            {
+                Logger.Info($"Refactor: refused — {result.Diagnostic.Kind}");
+                ShowError(result.Diagnostic.Message);
+                return;
+            }
+
+            var excelHwnd = new IntPtr(app.Hwnd);
+
+            ShowLambdaPopupCommand.InvokeOnWindowThread(dispatcher =>
+            {
+                string? saved = null;
+
+                dispatcher.Invoke(() =>
+                {
+                    RefactorResult Recompute(IReadOnlyList<RefactorRowState> rows)
+                    {
+                        try
+                        {
+                            return RefactorEngine.Recompute(formula, sheetName, rows);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error("Refactor/Recompute", ex);
+                            // Return the original result so the dialog can
+                            // keep its last-known-good preview rather than
+                            // tearing itself down on a transient error.
+                            return result;
+                        }
+                    }
+
+                    var window = new RefactorToLetWindow(result, sheetName, Recompute);
+                    var wpfHwnd = new WindowInteropHelper(window).EnsureHandle();
+                    WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
+
+                    if (window.ShowDialog() == true)
+                        saved = window.SavedFormula;
+                });
+
+                if (saved == null) return;
+
+                try
+                {
+                    activeCell.Formula2 = saved;
+                    Logger.Info("Refactor: Wrote LET into active cell");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("Refactor/SetFormula", ex);
+                    ShowError($"Failed to update cell: {ex.Message}");
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Refactor", ex);
+            ShowError($"Unexpected error: {ex.Message}");
+        }
+    }
+
+    private static void ShowError(string message)
+    {
+        try
+        {
+            MessageBox.Show(message, "Lambda Boss", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch
+        {
+            Logger.Info($"ShowError: {message}");
+        }
+    }
+}

--- a/addin/lambda-boss/Commands/RefactorCommand.cs
+++ b/addin/lambda-boss/Commands/RefactorCommand.cs
@@ -88,7 +88,7 @@ internal static class RefactorCommand
                         }
                     }
 
-                    var window = new RefactorToLetWindow(result, sheetName, Recompute);
+                    var window = new RefactorToLetWindow(result, Recompute);
                     var wpfHwnd = new WindowInteropHelper(window).EnsureHandle();
                     WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
 

--- a/addin/lambda-boss/Common/NetFrameworkPolyfills.cs
+++ b/addin/lambda-boss/Common/NetFrameworkPolyfills.cs
@@ -1,7 +1,13 @@
 // Polyfills for .NET Framework 4.8 — types/methods present on net6+ but missing on net48.
 // PolySharp handles type-level polyfills (Index, Range, IsExternalInit); this file handles
 // the rest (instance methods that can't be polyfilled by PolySharp).
+//
+// The namespace deliberately lives outside this file's folder so the extension method is
+// discoverable wherever `System.Collections.Generic` is in scope (which is everywhere via
+// Directory.Build.props's <Using> items) — without forcing every consumer to add a
+// `using LambdaBoss.Common;`.
 
+// ReSharper disable once CheckNamespace
 namespace System.Collections.Generic;
 
 internal static class KeyValuePairPolyfillExtensions

--- a/addin/lambda-boss/ExcelNameValidator.cs
+++ b/addin/lambda-boss/ExcelNameValidator.cs
@@ -27,22 +27,28 @@ public static class ExcelNameValidator
         if (string.IsNullOrWhiteSpace(name))
             return ValidationResult.Invalid("Name is required.");
 
-        if (name.Length > 255)
+        // name is non-null after the IsNullOrWhiteSpace guard; net48's
+        // BCL doesn't annotate IsNullOrWhiteSpace with [NotNullWhen(false)],
+        // so the analyzer can't narrow on its own. Re-bind to a non-null
+        // local so the rest of the method reads cleanly.
+        var n = name!;
+
+        if (n.Length > 255)
             return ValidationResult.Invalid("Name is too long (max 255 characters).");
 
-        var first = name[0];
+        var first = n[0];
         if (!char.IsLetter(first) && first != '_' && first != '\\')
             return ValidationResult.Invalid("Name must start with a letter, underscore, or backslash.");
 
-        foreach (var c in name)
+        foreach (var c in n)
             if (!char.IsLetterOrDigit(c) && c != '_' && c != '.' && c != '\\' && c != '?')
                 return ValidationResult.Invalid($"Invalid character '{c}' in name.");
 
-        if (Reserved.Contains(name))
-            return ValidationResult.Invalid($"'{name}' is reserved by Excel.");
+        if (Reserved.Contains(n))
+            return ValidationResult.Invalid($"'{n}' is reserved by Excel.");
 
-        if (CellRefPattern.IsMatch(name))
-            return ValidationResult.Invalid($"'{name}' looks like a cell reference.");
+        if (CellRefPattern.IsMatch(n))
+            return ValidationResult.Invalid($"'{n}' looks like a cell reference.");
 
         return ValidationResult.Valid();
     }

--- a/addin/lambda-boss/GatherEngine.cs
+++ b/addin/lambda-boss/GatherEngine.cs
@@ -98,10 +98,10 @@ public static class GatherEngine
                 roleOverrides ??= new Dictionary<FormulaRef, BindingRole>();
                 roleOverrides[r.Source] = r.RoleOverride.Value;
             }
-            if (!string.IsNullOrEmpty(r.NameOverride))
+            if (r.NameOverride is { Length: > 0 } nameOverride)
             {
                 nameOverrides ??= new Dictionary<FormulaRef, string>();
-                nameOverrides[r.Source] = r.NameOverride;
+                nameOverrides[r.Source] = nameOverride;
             }
         }
         return GatherInternal(sink, selection, source, excluded, roleOverrides, nameOverrides);

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -59,11 +59,13 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
 
     public override int GetHashCode()
     {
-        // Microsoft.Bcl.HashCode on net48 calls StringComparer.GetHashCode directly,
-        // which throws on null. Net6's built-in HashCode tolerates null. Coalesce
-        // to the empty string to match .NET 6 behaviour across the migration.
+        // Microsoft.Bcl.HashCode on net48 calls StringComparer.GetHashCode
+        // directly, which throws on null where .NET 6's built-in HashCode
+        // tolerates it. Sheet is annotated non-nullable so we trust the
+        // contract; ExternalWorkbook is genuinely nullable, so we coalesce
+        // to "" before hashing.
         var hash = new HashCode();
-        hash.Add(Sheet ?? "", StringComparer.OrdinalIgnoreCase);
+        hash.Add(Sheet, StringComparer.OrdinalIgnoreCase);
         hash.Add(Column);
         hash.Add(Row);
         hash.Add(ExternalWorkbook ?? "", StringComparer.OrdinalIgnoreCase);

--- a/addin/lambda-boss/GatherTypes.cs
+++ b/addin/lambda-boss/GatherTypes.cs
@@ -134,15 +134,26 @@ public sealed record CellRef(string Sheet, int Column, int Row, string? External
 ///     range refs without recursing into their constituent cells; the engine
 ///     promotes each unique range to a single leaf input and drops walked
 ///     cells covered by any promoted range. Equality follows
-///     <see cref="CellRef" />'s case-insensitive sheet rule.
+///     <see cref="CellRef" />'s case-insensitive sheet rule, plus the
+///     <see cref="IsSpilled" /> flag so <c>A1</c> and <c>A1#</c> dedupe
+///     as distinct refs — what spec 0008 (<c>/Refactor</c>) needs. Range
+///     refs always have <see cref="IsSpilled" /> = false (Excel has no
+///     <c>A1:B5#</c> syntax). <see cref="CellRefExtractor.Rewrite" />
+///     transparently falls back from a spilled key to its non-spilled
+///     equivalent when the spilled key isn't in the lookup, so
+///     <c>/Gather</c> — which only ever registers non-spilled keys —
+///     keeps its PR 5 behaviour of collapsing <c>A1#</c> tokens to the
+///     anchor cell's binding name.
 /// </summary>
-public sealed record FormulaRef(CellRef Start, CellRef? End = null)
+public sealed record FormulaRef(CellRef Start, CellRef? End = null, bool IsSpilled = false)
 {
     public bool IsRange => End is not null;
 
     /// <summary>
     ///     The convenience accessor most callers want; for ranges it returns
     ///     <c>Start:End</c> so the value still uniquely identifies the ref.
+    ///     Does NOT include the spill <c>#</c> suffix — call
+    ///     <see cref="DisplayAddress" /> for the LET-binding render form.
     /// </summary>
     public string A1Address => IsRange ? $"{Start.A1Address}:{End!.A1Address}" : Start.A1Address;
 
@@ -174,12 +185,33 @@ public sealed record FormulaRef(CellRef Start, CellRef? End = null)
     ///     The form to emit as a LET binding RHS when the LET lives on
     ///     <paramref name="hostSheet" />. For ranges, the sheet qualifier is
     ///     emitted once on Start; the End cell's address is rendered bare.
+    ///     Single-cell refs flagged as <see cref="IsSpilled" /> append a
+    ///     trailing <c>#</c> so the binding represents the whole spilled
+    ///     array rather than just the anchor's value.
     /// </summary>
     public string DisplayAddress(string hostSheet)
     {
-        if (!IsRange)
-            return Start.DisplayAddress(hostSheet);
-        return $"{Start.DisplayAddress(hostSheet)}:{End!.A1Address}";
+        if (IsRange)
+            return $"{Start.DisplayAddress(hostSheet)}:{End!.A1Address}";
+        var addr = Start.DisplayAddress(hostSheet);
+        return IsSpilled ? addr + "#" : addr;
+    }
+
+    public bool Equals(FormulaRef? other)
+    {
+        return other is not null
+               && Start.Equals(other.Start)
+               && Equals(End, other.End)
+               && IsSpilled == other.IsSpilled;
+    }
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Start);
+        hash.Add(End);
+        hash.Add(IsSpilled);
+        return hash.ToHashCode();
     }
 }
 

--- a/addin/lambda-boss/LetNameSanitizer.cs
+++ b/addin/lambda-boss/LetNameSanitizer.cs
@@ -31,7 +31,10 @@ public static class LetNameSanitizer
         if (string.IsNullOrEmpty(text))
             return null;
 
-        var trimmed = text.Trim();
+        // text is non-null after the IsNullOrEmpty guard; net48's BCL
+        // doesn't annotate IsNullOrEmpty with [NotNullWhen(false)], so
+        // the analyzer can't narrow on its own.
+        var trimmed = text!.Trim();
         if (trimmed.Length == 0)
             return null;
 

--- a/addin/lambda-boss/RefactorEngine.cs
+++ b/addin/lambda-boss/RefactorEngine.cs
@@ -1,0 +1,132 @@
+using System.Text;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     Spec 0008 / PR 1 — the <c>/Refactor</c> entry point. Takes a
+///     formula and the active cell's sheet, hoists every cell ref and
+///     range into its own LET binding, and emits a tidy
+///     <c>=LET(...)</c>. Existing LETs are refused in PR 1 with an
+///     <see cref="RefactorDiagnosticKind.ExistingLet" /> diagnostic; PR 2
+///     removes that refusal.
+///
+///     The tracer is intentionally minimal: <see cref="Refactor" />
+///     produces an initial pass with auto-named bindings;
+///     <see cref="Recompute" /> re-runs with the dialog's per-row state
+///     so the user can rename, drop, and reorder.
+/// </summary>
+public static class RefactorEngine
+{
+    /// <summary>
+    ///     Runs the initial refactor over <paramref name="formula" />,
+    ///     assigning each extracted ref an auto-name in first-seen
+    ///     order (<c>input1</c>, <c>input2</c>, …). <paramref name="activeSheet" />
+    ///     is the sheet the formula lives on; unqualified refs resolve
+    ///     against it and in-sheet refs render bare in binding RHSes.
+    /// </summary>
+    public static RefactorResult Refactor(string formula, string activeSheet)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+        if (activeSheet is null) throw new ArgumentNullException(nameof(activeSheet));
+
+        if (LetParser.IsLetFormula(formula))
+        {
+            return new RefactorResult(
+                formula,
+                Array.Empty<RefactorInputRow>(),
+                formula,
+                new RefactorDiagnostic(
+                    RefactorDiagnosticKind.ExistingLet,
+                    "Refactor on existing LET formulas is coming in PR 2 (spec 0008)."));
+        }
+
+        var extracted = CellRefExtractor.Extract(formula, activeSheet);
+        var rows = new List<RefactorInputRow>(extracted.Count);
+        var nameIndex = 1;
+        foreach (var r in extracted)
+        {
+            var rhs = r.DisplayAddress(activeSheet);
+            rows.Add(new RefactorInputRow(r, $"input{nameIndex}", rhs));
+            nameIndex++;
+        }
+        var let = Synthesise(formula, activeSheet, rows);
+        return new RefactorResult(formula, rows, let);
+    }
+
+    /// <summary>
+    ///     Re-runs the refactor with the dialog's per-row state.
+    ///     <paramref name="rowStates" /> is the full set of rows in
+    ///     user-chosen order; rows with <see cref="RefactorRowState.Include" />
+    ///     = false are dropped from the LET (their tokens stay in the
+    ///     rewritten body as-is). The engine trusts the dialog's name
+    ///     validation: collisions and invalid names get passed through
+    ///     verbatim so the user's typed text round-trips.
+    /// </summary>
+    public static RefactorResult Recompute(
+        string formula,
+        string activeSheet,
+        IReadOnlyList<RefactorRowState> rowStates)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+        if (activeSheet is null) throw new ArgumentNullException(nameof(activeSheet));
+        if (rowStates is null) throw new ArgumentNullException(nameof(rowStates));
+
+        if (LetParser.IsLetFormula(formula))
+        {
+            return new RefactorResult(
+                formula,
+                Array.Empty<RefactorInputRow>(),
+                formula,
+                new RefactorDiagnostic(
+                    RefactorDiagnosticKind.ExistingLet,
+                    "Refactor on existing LET formulas is coming in PR 2 (spec 0008)."));
+        }
+
+        var rows = new List<RefactorInputRow>(rowStates.Count);
+        foreach (var rs in rowStates)
+        {
+            if (!rs.Include) continue;
+            var rhs = rs.Source.DisplayAddress(activeSheet);
+            rows.Add(new RefactorInputRow(rs.Source, rs.Name, rhs));
+        }
+
+        var let = Synthesise(formula, activeSheet, rows);
+        return new RefactorResult(formula, rows, let);
+    }
+
+    private static string Synthesise(
+        string formula,
+        string activeSheet,
+        IReadOnlyList<RefactorInputRow> rows)
+    {
+        if (rows.Count == 0)
+        {
+            // No refs at all (or all dropped) — return the formula
+            // verbatim. The dialog can still open on an empty input set
+            // so the user sees that there's nothing to extract.
+            return formula;
+        }
+
+        var lookup = new Dictionary<FormulaRef, string>(rows.Count);
+        foreach (var row in rows)
+            lookup[row.Source] = row.Name;
+
+        var body = CellRefExtractor.Rewrite(
+            StripLeadingEquals(formula), activeSheet, lookup);
+
+        var bindings = rows
+            .Select(r => (r.Name, Value: r.Source.DisplayAddress(activeSheet)))
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.Append('=');
+        FormulaFormatter.AppendLet(sb, indent: 0, bindings, body);
+        return sb.ToString();
+    }
+
+    private static string StripLeadingEquals(string formula)
+    {
+        var trimmed = formula.TrimStart();
+        return trimmed.StartsWith("=", StringComparison.Ordinal) ? trimmed[1..] : trimmed;
+    }
+}

--- a/addin/lambda-boss/RefactorTypes.cs
+++ b/addin/lambda-boss/RefactorTypes.cs
@@ -1,0 +1,63 @@
+namespace LambdaBoss;
+
+/// <summary>
+///     Spec 0008 / PR 1 — types shared between <see cref="RefactorEngine" />
+///     and the <c>/Refactor</c> slash command. The tracer slice only needs
+///     the input-row and result records; promotable-row and calc-binding
+///     records arrive in PR 2/3.
+/// </summary>
+public sealed record RefactorInputRow(
+    FormulaRef Source,
+    string Name,
+    string Rhs);
+
+/// <summary>
+///     User's per-row state passed back into
+///     <see cref="RefactorEngine.Recompute" />. PR 1 carries just the
+///     binding name and Include flag — reorder happens dialog-side by
+///     resequencing the list before the call. <see cref="Source" />
+///     identifies the row so the engine can map it back onto the
+///     extracted refs (which the engine re-derives from the formula on
+///     every recompute).
+/// </summary>
+public sealed record RefactorRowState(
+    FormulaRef Source,
+    string Name,
+    bool Include = true);
+
+/// <summary>
+///     The engine's output. <see cref="OriginalFormula" /> is the formula
+///     text passed in (handy for the dialog header). <see cref="Inputs" />
+///     is the in-dialog-order list of input rows; PR 1 always emits them
+///     in first-seen ref order on the initial call.
+///     <see cref="SynthesisedLet" /> is the formatted <c>=LET(...)</c>
+///     text ready to write back to the active cell on Save (or the
+///     unchanged formula when every row was dropped).
+///     <see cref="Diagnostic" /> is non-null when the engine refused
+///     (PR 1: <c>ExistingLet</c>); in that case <see cref="Inputs" /> is
+///     empty and <see cref="SynthesisedLet" /> is the original formula
+///     unchanged.
+/// </summary>
+public sealed record RefactorResult(
+    string OriginalFormula,
+    IReadOnlyList<RefactorInputRow> Inputs,
+    string SynthesisedLet,
+    RefactorDiagnostic? Diagnostic = null);
+
+/// <summary>
+///     A refusal reason. PR 1 only emits <see cref="RefactorDiagnosticKind.ExistingLet" />.
+///     PR 2 removes that case; further PRs add new kinds as needed
+///     (e.g. malformed formula).
+/// </summary>
+public sealed record RefactorDiagnostic(
+    RefactorDiagnosticKind Kind,
+    string Message);
+
+public enum RefactorDiagnosticKind
+{
+    /// <summary>
+    ///     The active cell already holds a <c>=LET(...)</c>. PR 1 refuses
+    ///     and instructs the user to wait for PR 2.
+    /// </summary>
+    ExistingLet
+}

--- a/addin/lambda-boss/UI/LambdaPopup.xaml.cs
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml.cs
@@ -435,6 +435,14 @@ public partial class LambdaPopup
                 ExcelAsyncUtil.QueueAsMacro(() => GatherCommand.Run());
             }),
         new SlashCommand(
+            "Refactor",
+            "Rewrite the active cell's formula as a tidy =LET(...) with one binding per ref",
+            () =>
+            {
+                Hide();
+                ExcelAsyncUtil.QueueAsMacro(() => RefactorCommand.Run());
+            }),
+        new SlashCommand(
             "Load Library",
             "Switch to Library mode to pick a library",
             () =>

--- a/addin/lambda-boss/UI/RefactorToLetWindow.xaml
+++ b/addin/lambda-boss/UI/RefactorToLetWindow.xaml
@@ -1,0 +1,175 @@
+<Window x:Class="LambdaBoss.UI.RefactorToLetWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dd="urn:gong-wpf-dragdrop"
+        Title="Lambda Boss — Refactor to LET"
+        Width="640" Height="560"
+        WindowStyle="ToolWindow"
+        ShowInTaskbar="True"
+        Topmost="True"
+        ResizeMode="CanResizeWithGrip"
+        Background="#1e1e1e"
+        PreviewKeyDown="Window_PreviewKeyDown">
+
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="Original formula"
+                   FontSize="13"
+                   FontWeight="Bold"
+                   Foreground="#dcdcaa"
+                   Margin="0,0,0,4" />
+
+        <TextBox x:Name="OriginalFormulaText"
+                 Grid.Row="1"
+                 IsReadOnly="True"
+                 IsReadOnlyCaretVisible="False"
+                 Padding="6,4"
+                 FontSize="12"
+                 FontFamily="Consolas"
+                 Background="#2d2d2d"
+                 Foreground="#cccccc"
+                 BorderBrush="#3e3e3e"
+                 BorderThickness="1"
+                 TextWrapping="Wrap"
+                 AcceptsReturn="True"
+                 VerticalScrollBarVisibility="Auto"
+                 MaxHeight="80" />
+
+        <TextBlock Grid.Row="2"
+                   Text="Inputs"
+                   FontSize="13"
+                   FontWeight="Bold"
+                   Foreground="#dcdcaa"
+                   Margin="0,12,0,4" />
+
+        <Border Grid.Row="3"
+                Background="#252526"
+                BorderBrush="#3e3e3e"
+                BorderThickness="1"
+                MaxHeight="220">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="InputsList"
+                              dd:DragDrop.IsDragSource="True"
+                              dd:DragDrop.IsDropTarget="True"
+                              dd:DragDrop.UseDefaultDragAdorner="True"
+                              dd:DragDrop.UseDefaultEffectDataTemplate="True">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <DockPanel Margin="4,3"
+                                       PreviewKeyDown="InputRow_PreviewKeyDown">
+                                <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                                <Border DockPanel.Dock="Left"
+                                        Width="16"
+                                        Margin="0,0,4,0"
+                                        Background="Transparent"
+                                        Cursor="SizeAll"
+                                        ToolTip="Drag to reorder (or Alt+Up / Alt+Down)">
+                                    <TextBlock Text="&#x22EE;&#x22EE;"
+                                               Foreground="#808080"
+                                               FontSize="14"
+                                               HorizontalAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               IsHitTestVisible="False" />
+                                </Border>
+                                <CheckBox DockPanel.Dock="Left"
+                                          dd:DragDrop.DragSourceIgnore="True"
+                                          IsChecked="{Binding Include, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                          VerticalAlignment="Center"
+                                          Margin="0,0,8,0"
+                                          Cursor="Hand"
+                                          ToolTip="Uncheck to leave this ref inline in the LET body" />
+                                <TextBlock DockPanel.Dock="Right"
+                                           Text="{Binding Rhs}"
+                                           Foreground="{Binding RhsBrush}"
+                                           FontFamily="Consolas"
+                                           FontSize="12"
+                                           VerticalAlignment="Center"
+                                           Margin="8,0,0,0"
+                                           TextTrimming="CharacterEllipsis"
+                                           ToolTip="{Binding Rhs}" />
+                                <TextBox dd:DragDrop.DragSourceIgnore="True"
+                                         Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         IsEnabled="{Binding Include}"
+                                         Padding="4,2"
+                                         FontFamily="Consolas"
+                                         FontSize="13"
+                                         Background="#1e1e1e"
+                                         Foreground="{Binding NameBrush}"
+                                         CaretBrush="#cccccc"
+                                         BorderBrush="{Binding NameBorderBrush}"
+                                         BorderThickness="1"
+                                         GotFocus="NameTextBox_GotFocus"
+                                         PreviewMouseLeftButtonDown="NameTextBox_PreviewMouseLeftButtonDown" />
+                                <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
+                            </DockPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
+        <Grid Grid.Row="4" Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0"
+                       Text="Preview"
+                       FontSize="13"
+                       FontWeight="Bold"
+                       Foreground="#dcdcaa"
+                       Margin="0,0,0,4" />
+            <TextBox x:Name="PreviewText"
+                     Grid.Row="1"
+                     IsReadOnly="True"
+                     IsReadOnlyCaretVisible="False"
+                     Padding="6,4"
+                     FontSize="12"
+                     FontFamily="Consolas"
+                     Background="#252526"
+                     Foreground="#cccccc"
+                     BorderBrush="#3e3e3e"
+                     BorderThickness="1"
+                     TextWrapping="NoWrap"
+                     AcceptsReturn="True"
+                     VerticalScrollBarVisibility="Auto"
+                     HorizontalScrollBarVisibility="Auto" />
+        </Grid>
+
+        <DockPanel Grid.Row="5" Margin="0,12,0,0">
+            <Button x:Name="CancelButton"
+                    DockPanel.Dock="Right"
+                    Content="Cancel"
+                    Padding="16,4"
+                    Margin="6,0,0,0"
+                    Background="Transparent"
+                    Foreground="#cccccc"
+                    BorderBrush="#3e3e3e"
+                    BorderThickness="1"
+                    Cursor="Hand"
+                    Click="CancelButton_Click" />
+            <Button x:Name="SaveButton"
+                    DockPanel.Dock="Right"
+                    Content="Save"
+                    Padding="16,4"
+                    Cursor="Hand"
+                    Background="#0e639c"
+                    Foreground="#ffffff"
+                    BorderThickness="0"
+                    Click="SaveButton_Click" />
+            <TextBlock x:Name="StatusText"
+                       Foreground="#808080"
+                       FontSize="11"
+                       VerticalAlignment="Center" />
+        </DockPanel>
+    </Grid>
+</Window>

--- a/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
+++ b/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
@@ -34,8 +34,6 @@ public partial class RefactorToLetWindow
     private const string InvalidNameStatusText =
         "Fix invalid names before saving";
 
-    private readonly string _activeSheet;
-    private readonly string _originalFormula;
     private readonly Func<IReadOnlyList<RefactorRowState>, RefactorResult> _recompute;
     private readonly ObservableCollection<RefactorInputRowVm> _rows = [];
 
@@ -48,13 +46,10 @@ public partial class RefactorToLetWindow
 
     public RefactorToLetWindow(
         RefactorResult initial,
-        string activeSheet,
         Func<IReadOnlyList<RefactorRowState>, RefactorResult> recompute)
     {
         InitializeComponent();
         _result = initial;
-        _activeSheet = activeSheet;
-        _originalFormula = initial.OriginalFormula;
         _recompute = recompute;
 
         OriginalFormulaText.Text = initial.OriginalFormula;

--- a/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
+++ b/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
@@ -1,0 +1,331 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace LambdaBoss.UI;
+
+/// <summary>
+///     Spec 0008 / PR 1 — the <c>/Refactor</c> dialog. Shows the active
+///     cell's original formula, the engine-extracted input bindings (with
+///     editable names, Include checkbox, and drag/Alt+Up-Down reorder),
+///     and a live preview of the synthesised LET. Save returns the
+///     preview text via <see cref="SavedFormula" />; Cancel discards.
+///
+///     The code-behind is intentionally thin: every row-state change
+///     (rename, Include toggle, reorder) calls back into the supplied
+///     <c>recompute</c> delegate (which wraps
+///     <see cref="RefactorEngine.Recompute" />), and the result replaces
+///     the preview + the row collection in place. Live name validation
+///     gates the Save button via per-row canonicality (mirrors
+///     <see cref="GatherWindow" />'s pattern but without the engine-side
+///     collision-suffix dance — /Refactor is a one-shot pass, so the
+///     dialog enforces both shape and cross-row uniqueness up front).
+/// </summary>
+public partial class RefactorToLetWindow
+{
+    private const string DefaultStatusText =
+        "Save writes the LET into the active cell · Esc to cancel";
+
+    private const string InvalidNameStatusText =
+        "Fix invalid names before saving";
+
+    private readonly string _activeSheet;
+    private readonly string _originalFormula;
+    private readonly Func<IReadOnlyList<RefactorRowState>, RefactorResult> _recompute;
+    private readonly ObservableCollection<RefactorInputRowVm> _rows = [];
+
+    private RefactorResult _result;
+    // Reentrancy guard: rebuilding the row list during a Recompute fires
+    // INotifyPropertyChanged on each VM, which would re-enter the change
+    // handler. The guard short-circuits the nested calls so a single
+    // user action yields exactly one engine call.
+    private bool _suppressRecompute;
+
+    public RefactorToLetWindow(
+        RefactorResult initial,
+        string activeSheet,
+        Func<IReadOnlyList<RefactorRowState>, RefactorResult> recompute)
+    {
+        InitializeComponent();
+        _result = initial;
+        _activeSheet = activeSheet;
+        _originalFormula = initial.OriginalFormula;
+        _recompute = recompute;
+
+        OriginalFormulaText.Text = initial.OriginalFormula;
+        PreviewText.Text = initial.SynthesisedLet;
+
+        BuildRowsFromInputs(initial.Inputs);
+        _rows.CollectionChanged += Rows_CollectionChanged;
+        InputsList.ItemsSource = _rows;
+
+        UpdateSaveButtonEnabled(RevalidateNames());
+    }
+
+    /// <summary>Populated on Save; null when cancelled.</summary>
+    public string? SavedFormula { get; private set; }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        SavedFormula = _result.SynthesisedLet;
+        DialogResult = true;
+        Close();
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        SavedFormula = null;
+        DialogResult = false;
+        Close();
+    }
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            CancelButton_Click(this, new RoutedEventArgs());
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Enter
+            && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control
+            && SaveButton.IsEnabled)
+        {
+            SaveButton_Click(this, new RoutedEventArgs());
+            e.Handled = true;
+        }
+    }
+
+    private void InputRow_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        var alt = (Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt;
+        if (!alt) return;
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        if (key != Key.Up && key != Key.Down) return;
+        if (sender is not FrameworkElement { DataContext: RefactorInputRowVm row }) return;
+
+        var index = _rows.IndexOf(row);
+        if (index < 0) return;
+
+        if (key == Key.Up && index > 0)
+            _rows.Move(index, index - 1);
+        else if (key == Key.Down && index < _rows.Count - 1)
+            _rows.Move(index, index + 1);
+
+        e.Handled = true;
+    }
+
+    private void NameTextBox_GotFocus(object sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox tb)
+            tb.SelectAll();
+    }
+
+    private void NameTextBox_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not TextBox tb) return;
+        if (tb.IsKeyboardFocusWithin) return;
+        tb.Focus();
+        e.Handled = true;
+    }
+
+    private void BuildRowsFromInputs(IReadOnlyList<RefactorInputRow> inputs)
+    {
+        _suppressRecompute = true;
+        try
+        {
+            foreach (var v in _rows)
+                v.PropertyChanged -= Row_PropertyChanged;
+            _rows.Clear();
+
+            foreach (var input in inputs)
+            {
+                var vm = new RefactorInputRowVm(input);
+                vm.PropertyChanged += Row_PropertyChanged;
+                _rows.Add(vm);
+            }
+        }
+        finally
+        {
+            _suppressRecompute = false;
+        }
+    }
+
+    private void Rows_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        // Reorder via drag/drop or Alt+Up/Down fires Move; rerun the
+        // engine so the preview reflects the new binding order.
+        if (e.Action == NotifyCollectionChangedAction.Move && !_suppressRecompute)
+            RecomputeAndRefresh();
+    }
+
+    private void Row_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_suppressRecompute) return;
+        if (e.PropertyName is not (nameof(RefactorInputRowVm.Name)
+            or nameof(RefactorInputRowVm.Include)))
+            return;
+
+        UpdateSaveButtonEnabled(RevalidateNames());
+        RecomputeAndRefresh();
+    }
+
+    private void RecomputeAndRefresh()
+    {
+        var rowStates = _rows
+            .Select(r => new RefactorRowState(r.Source, r.Name, r.Include))
+            .ToList();
+
+        var newResult = _recompute(rowStates);
+        if (newResult.Diagnostic != null)
+            return;
+
+        _suppressRecompute = true;
+        try
+        {
+            _result = newResult;
+            PreviewText.Text = newResult.SynthesisedLet;
+        }
+        finally
+        {
+            _suppressRecompute = false;
+        }
+    }
+
+    /// <summary>
+    ///     Stamps each row's <see cref="RefactorInputRowVm.IsNameValid" />
+    ///     based on per-row canonicality (shape + non-reserved) AND
+    ///     cross-row uniqueness among included rows. Returns true when
+    ///     every included row is valid AND no duplicates exist.
+    /// </summary>
+    private bool RevalidateNames()
+    {
+        var included = _rows.Where(r => r.Include).ToList();
+        var dupes = included
+            .GroupBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .SelectMany(g => g)
+            .ToHashSet();
+
+        var allValid = true;
+        foreach (var vm in _rows)
+        {
+            bool valid;
+            if (!vm.Include)
+            {
+                valid = true;
+            }
+            else
+            {
+                var shapeOk = ExcelNameValidator.Validate(vm.Name).IsValid;
+                valid = shapeOk && !dupes.Contains(vm);
+                if (!valid) allValid = false;
+            }
+            vm.IsNameValid = valid;
+        }
+        return allValid;
+    }
+
+    private void UpdateSaveButtonEnabled(bool allValid)
+    {
+        SaveButton.IsEnabled = allValid && _rows.Any(r => r.Include);
+        if (!allValid)
+            StatusText.Text = InvalidNameStatusText;
+        else if (!_rows.Any(r => r.Include))
+            StatusText.Text = "No bindings selected — nothing to refactor";
+        else
+            StatusText.Text = DefaultStatusText;
+    }
+}
+
+/// <summary>
+///     Row view-model bound to <see cref="RefactorToLetWindow" />'s
+///     inputs list. Carries the row's <see cref="Source" /> identity and
+///     the user-editable <see cref="Name" /> + <see cref="Include" />.
+///     <see cref="IsNameValid" /> is set by the dialog on every
+///     validation pass and drives the red-border on the Name TextBox.
+/// </summary>
+public class RefactorInputRowVm : INotifyPropertyChanged
+{
+    private static readonly Brush ActiveNameBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#dcdcaa"));
+
+    private static readonly Brush ActiveRhsBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#cccccc"));
+
+    private static readonly Brush MutedBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#6a6a6a"));
+
+    private static readonly Brush InvalidNameBorderBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#f48771"));
+
+    private static readonly Brush DefaultNameBorderBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#3e3e3e"));
+
+    private bool _include = true;
+    private bool _isNameValid = true;
+    private string _name;
+
+    public RefactorInputRowVm(RefactorInputRow input)
+    {
+        Source = input.Source;
+        _name = input.Name;
+        Rhs = input.Rhs;
+    }
+
+    public FormulaRef Source { get; }
+    public string Rhs { get; }
+
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            if (_name == value) return;
+            _name = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool Include
+    {
+        get => _include;
+        set
+        {
+            if (_include == value) return;
+            _include = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(NameBrush));
+            OnPropertyChanged(nameof(RhsBrush));
+        }
+    }
+
+    public bool IsNameValid
+    {
+        get => _isNameValid;
+        set
+        {
+            if (_isNameValid == value) return;
+            _isNameValid = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(NameBorderBrush));
+        }
+    }
+
+    public Brush NameBrush => Include ? ActiveNameBrush : MutedBrush;
+    public Brush RhsBrush => Include ? ActiveRhsBrush : MutedBrush;
+    public Brush NameBorderBrush => IsNameValid ? DefaultNameBorderBrush : InvalidNameBorderBrush;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? prop = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+    }
+}

--- a/plans/0008-refactor-to-let.md
+++ b/plans/0008-refactor-to-let.md
@@ -1,0 +1,123 @@
+# 0008 — Refactor to LET — Implementation Plan
+
+## Overview
+
+Build the `/Refactor` slash command in 4 sequenced PR-sized slices. **PR 1 is a tracer bullet** that closes the loop end-to-end on the simplest case — a non-LET formula with cell refs and ranges — so Tim can drop into Excel and exercise the feature from day one. Subsequent slices each add one capability: existing-LET handling, then the promotable section in two halves.
+
+**Engine vs UI split.** Domain logic lives in pure C# classes under `addin/lambda-boss/`, mirroring `LetParser` / `LetToLambdaBuilder` / `GatherEngine`. `RefactorToLetWindow` and its row view-models stay in `addin/lambda-boss/UI/`. Code-behind is kept thin: it wires controls and forwards user input to the engine, which returns the synthesised LET text and the binding-list view-model. Workbook reads (for the defined-name lookup, only) are abstracted behind an `IWorkbookContext` interface so the engine is unit-testable without Excel.
+
+**Reuse from spec 0005 (`/Gather`).** `/Gather` shipped a lot of infrastructure that maps directly:
+
+| Component | What `/Refactor` reuses |
+|---|---|
+| `CellRefExtractor.Extract` | Walks formula text, returns unique `FormulaRef`s in first-seen order. Used as-is. |
+| `CellRefExtractor.Rewrite` | Rewrites refs to binding names via a `FormulaRef → name` lookup. Used as-is. |
+| `CellRef` / `FormulaRef` | Already case-insensitive on sheet equality. `DisplayAddress(hostSheet)` already renders bare for in-sheet refs and qualified otherwise — exactly the spec's sheet-qualifier dedupe behaviour. |
+| `LetNameSanitizer` | Used directly for any user-entered renames; auto-names just emit `inputN` so no sanitisation needed there. |
+| `LetParser` | Used to detect and parse existing LETs in PR 2. `IsLetFormula` / `Parse` / `SplitTopLevelCommas` / `FindMatchingClose` / `SkipString` semantics all apply. |
+| `LambdaSignatureParser.IsLambdaFormula` | Used in PR 3 to exclude LAMBDA-bound workbook names from the promotable list. |
+| `FormulaFormatter.AppendLet` | Used to render the synthesised LET. |
+| `ExcelNameValidator` | Used for live validation of user-entered binding names in the dialog. |
+
+**Shared-infra change in PR 1: spill flag on `FormulaRef`.** Today `CellRefExtractor`'s regex matches the trailing `#` on `A1#` (via the `(?<spill>\#)` group) but `BuildFormulaRef` discards it — both `A1` and `A1#` produce identical `FormulaRef`s. `/Refactor` needs them to dedupe as distinct bindings (per spec). The cleanest fix is to add a `bool IsSpilled` field to `FormulaRef`, include it in equality + hash, and populate it from the regex group. `/Gather` is not expected to break: its precedent walk uses `WalkedCell.Ref` (a `CellRef`, no spill flag) for graph identity, and the binding-RHS spill marker comes from `ICellSource.HasSpill`, not from `FormulaRef`. The new flag is purely informational for `/Gather`. Risk + mitigation called out in PR 1 below.
+
+**Branching.** Implementation branches from `main`. Each slice is its own PR, merged into `main` in sequence — `/Gather` used a long-lived spec branch because there were 12 slices; with 4 here, merging straight to `main` is simpler and keeps history flatter. PR N branches from `main` after PR N-1 has merged.
+
+## Files to Touch
+
+### New (engine)
+
+- `addin/lambda-boss/RefactorEngine.cs` — top-level entry. Takes formula text + active sheet + (PR 3+) workbook-name lookup, returns a `RefactorResult` (binding rows + promotable rows + synthesised LET + diagnostics).
+- `addin/lambda-boss/RefactorTypes.cs` — shared records: `RefactorInputRow`, `RefactorPromotableRow`, `RefactorCalcBindingRow`, `RefactorRowState`, `RefactorResult`, `RefactorDiagnostic`, `IWorkbookContext`.
+
+### New (UI)
+
+- `addin/lambda-boss/UI/RefactorToLetWindow.xaml` — dialog: original formula header, inputs section, promotable section (PR 3+), read-only calc-binding section (PR 2+), preview pane, Save/Cancel.
+- `addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs` — wiring + row view-models with `INotifyPropertyChanged`. Mirrors `LetToLambdaWindow` / `GatherWindow`.
+
+### New (command)
+
+- `addin/lambda-boss/Commands/RefactorCommand.cs` — slash-command handler. Reads active cell, builds an `IWorkbookContext` adapter over the live workbook (PR 3+), runs the engine, opens `RefactorToLetWindow`, writes the LET back to the active cell on Save. Pattern mirrors `GatherCommand`.
+
+### New (tests)
+
+- `addin/lambda-boss.Tests/RefactorEngineTests.cs` — covers the public engine surface with an in-memory `IWorkbookContext` stub. Round-trip safety: every synthesised LET is asserted to parse cleanly via `LetParser.Parse` and feed cleanly into `LetToLambdaBuilder.Build`.
+- `addin/lambda-boss.Tests/CellRefExtractorSpillTests.cs` (PR 1) — focused tests for the new `IsSpilled` propagation; complements existing `CellRefExtractorTests`.
+
+### Modified
+
+- `addin/lambda-boss/GatherTypes.cs` — add `bool IsSpilled` to `FormulaRef` (with equality + hash). PR 1.
+- `addin/lambda-boss/CellRefExtractor.cs` — `BuildFormulaRef` reads the existing `(?<spill>\#)` group and sets `IsSpilled` accordingly. Range matches (where `col2` is set) always have `IsSpilled = false` (Excel has no `A1:B5#` syntax). PR 1.
+- `addin/lambda-boss/UI/LambdaPopup.xaml.cs` — register the `/Refactor` command in `BuildCommandRegistry()`. PR 1.
+
+## Order of Operations
+
+Each step is one PR-sized issue. Each branches from `main` after the previous PR has merged.
+
+1. **Tracer bullet — non-LET formula, refs + ranges + spill, end-to-end.**
+   - Add `IsSpilled` to `FormulaRef` (equality + hash + `DisplayAddress` rendering); `CellRefExtractor.BuildFormulaRef` populates it. Verify existing `CellRefExtractorTests` and `GatherEngineTests` still pass — if any `/Gather` test fails because of double-counting `A1` vs `A1#`, fall back to keeping `FormulaRef` unchanged and tracking spill in a `RefactorEngine`-local key wrapper instead.
+   - Register `/Refactor` slash command in `LambdaPopup.xaml.cs`. On an empty / literal active cell, popup closes silently (matches `/Gather`'s pattern). On a formula cell, the command runs.
+   - `RefactorEngine.Refactor(string formula, string activeSheet)` walks the formula via `CellRefExtractor.Extract`, dedupes by `FormulaRef` (which now distinguishes spill from non-spill), assigns `inputN` auto-names, rewrites refs to binding names via `CellRefExtractor.Rewrite`, and emits the synthesised LET via `FormulaFormatter.AppendLet`.
+   - **Existing LET refused** in this PR — `RefactorEngine` checks `LetParser.IsLetFormula` and returns a `RefactorDiagnostic` of kind `ExistingLet` with message *"Refactor on existing LET formulas is coming in PR 2 (spec 0008)."* The slash command shows the diagnostic via `MessageBox`. This refusal is removed in PR 2.
+   - **External refs handled in-line for tracer**: in PR 1, external refs (`FormulaRef.IsExternal == true`) are extracted as inputs alongside same-workbook refs — same behaviour as today's `/Gather`. PR 3 moves them into the promotable section (default off).
+   - `RefactorToLetWindow`: original-formula header (read-only), inputs section with rename + Include checkbox + reorder (Alt+Up/Down + drag, reusing `KeptRowReorderHandler` from `LetToLambdaWindow`), preview pane via `FormulaFormatter`, Save/Cancel. No promotable section, no calc-binding section.
+   - Live name validation: `ExcelNameValidator` for shape, collision check across rows. Save disabled when invalid.
+   - Tests (`RefactorEngineTests`): single cell ref, multiple refs deduped, range, spill-distinct (`A1` and `A1#` produce two bindings), sheet-qualified ref dedupe (`A1` and `Sheet1!A1` collapse when active sheet is `Sheet1`), cross-sheet ref stays distinct, rename through body, round-trip via `LetParser.Parse` + `LetToLambdaBuilder.Build`.
+   - Manual Excel test: type `=IF(A1<10, IF(A1>2, SUM(B1:B5), 0), SUM(B2:B6))` into a cell, run `/Refactor`, save, confirm the resulting LET evaluates identically.
+
+2. **Existing-LET handling — full refactor.**
+   - Remove the PR 1 refusal. When `LetParser.IsLetFormula(formula)` is true, parse via `LetParser.Parse`.
+   - **Treat existing value bindings as input rows.** Pre-populate the dialog with one input row per existing value binding (name, RHS, source = "existing LET binding"). Calculation bindings populate a separate read-only section.
+   - **Walk for new refs**: run `CellRefExtractor.Extract` over each calculation binding's RHS and the body. Any ref not already represented by an existing value binding (matched by canonical `FormulaRef`) becomes a new input row with an auto-name. Auto-name allocator skips numbers already in use as existing binding names.
+   - **Merge duplicate value bindings**: for each pair of value bindings with equivalent canonical RHS (compare via `FormulaRef` parsed from the RHS; falls back to literal string compare if the RHS isn't a single ref), keep the first binding's name, drop the others, rewrite references to the dropped name in calc bindings + body + later value bindings. The surviving row displays a `merged ← {oldName}` note.
+   - **Rewrite all references**: after merge + extraction, run `CellRefExtractor.Rewrite` over each calc binding RHS and the body using the full `FormulaRef → bindingName` lookup.
+   - **Reorder**: synthesised LET emits all value bindings first (in dialog order), then calc bindings (in original source order).
+   - **ISOMITTED interaction (spec note)**: no special-case code; existing-LET rules above cover it naturally. Test case: feed in a LET that came from round-tripping an optional-param LAMBDA, verify the `IF(ISOMITTED(...))` wrappers survive and any cell refs inside the default expression get extracted.
+   - Dialog gains a read-only "Calculation bindings" section under the inputs, showing each calc binding's name + rewritten RHS. Not reorderable, not droppable. Visually distinguish via a section header.
+   - Tests: messy LET with duplicate value bindings (merge), refs inside calc bindings (extract), refs inside body (extract), ISOMITTED wrapper survives, already-tidy LET produces a no-op rewrite (preview matches original modulo whitespace), reorder of existing bindings via UI.
+   - Manual Excel test: paste a messy LET (e.g. `=LET(a, A1, b, A1, getMax, MAX(B1:B5), IF(a<10, getMax, b))`), run `/Refactor`, save, confirm the resulting LET evaluates identically and has the expected shape.
+
+3. **Promotable section: named ranges + external refs.**
+   - New `IWorkbookContext` interface: `IReadOnlyDictionary<string, string> WorkbookNames { get; }` mapping name → `RefersTo`. Lookup is `OrdinalIgnoreCase`. The live adapter (`RefactorCommand`) populates this from `workbook.Names` and the active sheet's `worksheet.Names` (unioned) once when the dialog opens.
+   - LAMBDA-name detection: a name with `RefersTo` starting with `=LAMBDA(` (via `LambdaSignatureParser.IsLambdaFormula`) is excluded from the promotable list. The engine treats those identifiers as function calls and leaves them inline.
+   - Identifier tokenizer: a small new helper that walks formula text (skipping strings, mirroring `CellRefExtractor`'s `SkipString` rule) and yields `(identifier, position)` for each bare identifier that isn't a function call (i.e. not immediately followed by `(`). Used to find candidate defined-name references. Lookbehind / trailing guards match `CellRefExtractor`'s identifier-boundary rules to avoid splitting `Help?Foo` style names.
+   - For each unique candidate identifier present in `WorkbookNames` and not a LAMBDA, emit a `RefactorPromotableRow(kind: NamedRange, token: identifier, occurrences: N, promote: false)`.
+   - External refs: in PR 1 they extract as inputs by default. In this PR, change the engine so refs where `FormulaRef.IsExternal == true` emit as `RefactorPromotableRow(kind: ExternalRef, token: original-text, occurrences: N, promote: false)` instead — same default-off behaviour. Authors can still promote them.
+   - Dialog gains a "Promote to input" section below the inputs (and above the calc-binding section). Each promotable row shows token text, occurrences count, and a Promote checkbox. Promoting moves the row up into the inputs section with an auto-name and editable name field; un-promoting moves it back.
+   - Rewrite step: when a named range is promoted, the rewrite pass adds the identifier (with its positions) to a separate rewrite map that swaps the bare name for the binding name. Falls back to a second-pass identifier rewriter rather than extending `CellRefExtractor.Rewrite` (which is tightly coupled to A1-shaped patterns).
+   - Tests: workbook-scoped named range promoted (rewrites everywhere; binding RHS is the original identifier text), worksheet-scoped named range promoted, LAMBDA name excluded from promotables, named range left un-promoted (stays inline, no binding), external ref defaults to promotable + promotable when toggled on, identifier-boundary correctness (`Help?Foo` not split).
+   - Manual Excel test: define a workbook name `Tax_Rate = 0.2`, type `=A1 * Tax_Rate + Tax_Rate`, run `/Refactor`, verify `Tax_Rate` appears in the promotable section with occurrences=2; promote it, save, confirm the LET evaluates.
+
+4. **Promotable section: literals + drop-input UX polish.**
+   - Literal tokenizer: walks formula text (skipping strings and cell-ref tokens recognized by `CellRefExtractor`'s pattern; we can pre-mask those ranges before walking) and yields:
+     - **Numeric literals**: optional sign + digits + optional decimal + optional scientific exponent. Dedupe by parsed numeric value.
+     - **String literals**: the content between matched `"`s with embedded `""` un-escaped. Dedupe by string value.
+     - **Boolean literals**: `TRUE` / `FALSE` (case-insensitive) when not followed by `(` (so we don't catch user-defined functions named `TRUE` — unlikely but defensive). Dedupe by boolean value.
+   - For each unique literal value, emit a `RefactorPromotableRow(kind: Literal, token: original-text-of-first-occurrence, occurrences: N, promote: false)`. Promoting replaces every occurrence with the binding name; binding RHS is the original token text (preserves formatting like `0.20` vs `0.2`).
+   - Drop-input UX (called out in spec): unticking Include on an extracted input row restores the original token everywhere it occurred. No warning shown even if that re-introduces duplication. Implementation: the engine's rewrite pass simply omits the dropped row from the rewrite map, and `CellRefExtractor.Rewrite` / the identifier rewriter / the literal rewriter leave unmapped tokens as-is.
+   - Status text refinements: status bar at the bottom of the dialog shows merge notes, validation errors, and a summary count ("3 inputs, 2 promotable, 1 calculation binding").
+   - Tests: numeric literal promoted (one `10` replaced everywhere), string literal promoted (with embedded `""`), boolean literal promoted, two distinct numerics stay distinct, drop-input restores literal token, drop-input restores named-range identifier, status text rendering.
+   - Manual Excel test: type `=IF(A1 > 100, "high", IF(A1 > 50, "medium", "low")) + IF(B1 > 100, 1, 0)`, run `/Refactor`, verify the promotable section shows `100`, `"high"`, `"medium"`, `"low"`, `50`, `1`, `0`; promote `100` only, save, confirm both occurrences of `100` were replaced.
+
+## Testing Approach
+
+**Unit tests (xUnit, runs without Excel).** `RefactorEngine` is tested via an in-memory `IWorkbookContext` stub returning a fixed names → `RefersTo` map. No active-cell state is needed — the engine takes formula text + active sheet name as plain strings.
+
+**Round-trip safety.** `RefactorEngineTests` asserts that every synthesised LET parses cleanly via `LetParser.Parse(...)` *and* feeds cleanly through `LetToLambdaBuilder.Build(...)` (with a default `LambdaGenerationRequest` keeping all inputs) for every fixture. This catches both LET-malformed output and LET-that-LetToLambdaBuilder-can't-stomach output early.
+
+**View-model tests.** Row view-models (`RefactorInputRow`, `RefactorPromotableRow`) tested for `INotifyPropertyChanged` semantics and live validation. Pattern mirrors `LetToLambdaWindow`'s existing row tests.
+
+**Manual Excel tests.** Each PR's issue body lists a 2-3 step Excel scenario Tim can run after a build to verify the slice (scenarios listed under each PR above).
+
+The existing `addin/lambda-boss.AddinTests/` project covers ribbon-level Excel automation; no new add-in tests required for this feature unless the manual smoke checks find a gap the unit tests miss.
+
+## Open Questions
+
+All resolved at spec time. Two carried into this plan, both with clear tentative answers:
+
+- **Worksheet-scoped names**: PR 3 unions `workbook.Names` and the active sheet's `worksheet.Names` into one lookup, so worksheet-scoped names behave the same as workbook-scoped ones. Confirmed during plan — the tentative answer in the spec is correct.
+- **LAMBDA identifier without a trailing `(`**: PR 3 treats any identifier matching a workbook name whose `RefersTo` starts with `=LAMBDA(` as a LAMBDA name and excludes it from promotables, regardless of whether the formula text has a trailing `(`. Malformed in-progress formulas are rare and the safer behaviour is to never promote a LAMBDA name. Confirmed during plan — the tentative answer in the spec is correct.
+
+One plan-only open question:
+
+- **Spill flag on `FormulaRef` vs. local key in `RefactorEngine`.** PR 1's first step is to add `IsSpilled` to `FormulaRef`. If existing `CellRefExtractorTests` or `GatherEngineTests` fail because of double-counted `A1` vs `A1#` entries (i.e. `/Gather`'s working sets dedupe FormulaRefs in a way that now sees two distinct entries where it used to see one), we fall back to keeping `FormulaRef` unchanged and tracking spill in a `(FormulaRef, bool)` key wrapper inside `RefactorEngine`. The fallback is contained — no shared-infra change, slightly more local code in the engine. The risk is real but small: skimming `GatherEngine.cs` suggests its working sets are keyed on `CellRef` for graph identity and `FormulaRef` only for range/exclusion bookkeeping, neither of which should be affected by the new flag. Confirm by running the full test suite as the first step of PR 1.

--- a/specs/0008-refactor-to-let.md
+++ b/specs/0008-refactor-to-let.md
@@ -1,0 +1,184 @@
+# 0008 — Refactor to LET
+
+## Problem
+
+Today, the path to a registered LAMBDA requires the author to hand-write a `=LET(...)` first, with every input they want exposed as a LAMBDA parameter already pulled into its own value binding. `LET to LAMBDA` (spec 0001/0002) then only treats those value bindings as candidate parameters. This is friction in two distinct situations:
+
+1. **No LET at all.** The author has a working but messy expression like `=IF(A1<10, IF(A1>2, SUM(B1:B5), 0), SUM(B2:B6))` and wants a LAMBDA. They must mechanically rewrite the formula as a LET, identifying the cell refs/ranges by eye, picking names, and rewriting every occurrence.
+2. **Messy LET.** The author has a LET, but the inputs they care about aren't standalone value bindings — they're embedded inside calculation bindings or the body. Or the LET has two value bindings with the same RHS (e.g. `LET(a, A1, b, A1, ...)`), which today produces two LAMBDA parameters where the author wanted one.
+
+Both situations have the same underlying need: hoist every reference to an in-cell input — cell refs, ranges, optionally named ranges/literals — into its own value binding, dedupe by canonical address, and rewrite the rest of the formula to use the new names. `/Gather` (spec 0005) already does a related thing across cells; this spec is its within-cell counterpart.
+
+## Proposed Solution
+
+A new slash command, `/Refactor` (full name **Refactor to LET**), that takes the active cell's formula — LET or not — and rewrites it as a tidy LET where every cell ref and range appears as a single value binding. The author then runs `LET to LAMBDA` as the next step. The two commands stay separate; chaining is a deliberate user action, mirroring the `/Gather → /LET to LAMBDA` pattern.
+
+### Worked example — non-LET formula
+
+Active cell:
+
+```excel
+=IF(A1<10, IF(A1>2, SUM(B1:B5), 0), SUM(B2:B6))
+```
+
+After `/Refactor` (with default auto-names, all promotable rows left un-promoted):
+
+```excel
+=LET(
+    input1, A1,
+    input2, B1:B5,
+    input3, B2:B6,
+    IF(input1<10, IF(input1>2, SUM(input2), 0), SUM(input3)))
+```
+
+The author renames in the dialog before Save (or after, by hand). Then `/LET to LAMBDA` does its existing work.
+
+### Worked example — messy LET (full refactor)
+
+Active cell:
+
+```excel
+=LET(
+    a, A1,
+    b, A1,
+    getMax, MAX(B1:B5),
+    IF(a<10, getMax, b))
+```
+
+After `/Refactor`:
+
+- `b`'s RHS matches `a`'s RHS (`A1`) — merged into `a` (rule: keep the first binding's name; rewrite later refs to use it).
+- `MAX(B1:B5)` contains `B1:B5`, which gets hoisted as a new input binding `input1`.
+- `getMax` stays as a calculation binding but its RHS is rewritten to use `input1`.
+- The body's reference to `b` becomes `a`.
+
+Result:
+
+```excel
+=LET(
+    a, A1,
+    input1, B1:B5,
+    getMax, MAX(input1),
+    IF(a<10, getMax, a))
+```
+
+The dialog shows a `merged b ← a` note so the author knows what happened.
+
+### Activation
+
+- Open the main popup, type `/Refactor`, press Enter.
+- The popup closes and a new `RefactorToLetWindow` opens, with the active cell's formula as the input.
+- If the active cell is empty or holds a literal value (no `=`-prefixed formula), the command does nothing — no dialog, no error message. Same pattern as `/Gather`.
+
+### Token extraction
+
+The refactor walks the formula's token stream, skipping over string literals (using the same `SkipString` semantics as `LetParser`), and classifies each token:
+
+| Token shape | Default action | Notes |
+|---|---|---|
+| A1-style cell ref: `A1`, `$A$1`, `Sheet1!A1` | Extract as input | Canonical form for dedupe: row/column letters uppercased, `$` dropped, sheet qualifier normalised (see below). `A1` and `$A$1` and `$A1` collapse to the same binding (first occurrence wins for RHS text). |
+| Range ref: `A1:B5`, `B:B`, `Sheet1!A1:B5`, `$A:$A` | Extract as input | Same canonicalisation rules; range bounds are normalised so `A1:B5` and `B5:A1` collapse. |
+| Spilled ref: `A1#` | Extract as input | Binding RHS keeps the `#`. Dedupe key is distinct from `A1` — the `#` matters for dynamic-array semantics. Mirrors `/Gather`'s rule. |
+| External workbook ref: `[Other.xlsx]Sheet1!A1` | Show in dialog as promotable, default off | When left un-promoted, the ref is inlined in the body; the author opts in if they want it as a LAMBDA input. |
+| Named range / defined name (workbook or sheet scope) | Show in dialog as promotable, default off | Detection: any identifier in the formula that resolves to a workbook `Name` whose `RefersTo` does **not** start with `=LAMBDA(`. LAMBDA names are function calls, not inputs, and are excluded from promotion. The dialog reads `workbook.Names` **once** on open and builds an `OrdinalIgnoreCase` lookup; identifier tokens are checked against this lookup as we walk. |
+| Numeric literal, string literal, boolean literal | Show in dialog as promotable, default off | Literals stay inline by default. Dedupe by value equality (numeric / string / boolean equality), so two occurrences of `10` collapse to one promotable row and a single Promote toggle replaces every occurrence with the binding name. |
+| Function calls, operators, parentheses, commas | Left as-is | The refactor never extracts sub-expressions. |
+| LET binding names from an existing LET | Reused, not re-extracted | When the input is already a LET, existing bindings appear as rows in the dialog and can be renamed / dropped / reordered like any other row. |
+
+**Sheet-qualifier normalisation.** An unqualified ref (`A1`) is treated as referring to the active cell's sheet, so `A1` and `Sheet1!A1` collapse to the same binding when the active cell is on `Sheet1`. Refs to other sheets keep their qualifier and stay distinct. The canonical dedupe key uses the fully sheet-qualified form (with the active cell's sheet name filled in for unqualified refs). The binding's RHS text preserves whichever form appeared **first** in the original formula, so the LET reads naturally relative to its source.
+
+For each extracted token, the **dedupe key** is the canonical form. The first occurrence's text becomes the binding RHS; all later occurrences are rewritten to the binding name.
+
+### Existing-LET handling
+
+When the active cell's formula starts with `=LET(...)`, `/Refactor` performs a **full refactor**:
+
+1. Parse the LET via the existing `LetParser`.
+2. Treat each existing **value binding** as a row in the dialog. Pre-populate name and RHS.
+3. Walk each existing **calculation binding**'s RHS and the **body** for extractable tokens, hoisting per the rules above.
+4. **Merge value bindings with equivalent RHS.** Two value bindings whose RHS canonicalises to the same key are merged: the first binding's name wins; later bindings are removed from the row list and their references in calculation bindings / body / other value bindings are rewritten to the surviving name. The dialog shows a `merged <old> ← <kept>` note next to the surviving row.
+5. **Calculation bindings stay calculation bindings** — they keep their original name and order, but their RHS is rewritten to use input bindings. The refactor does not convert calculations into inputs.
+6. **Ordering**: the synthesised LET puts all value bindings first (in the order the dialog shows), then calculation bindings (in their original source order). This matches the canonical shape that `LET to LAMBDA` expects.
+
+**Round-tripped LAMBDAs (spec 0002 optional params).** When the input LET came from `/EditLambda` on a LAMBDA that was originally created with optional parameters, its body contains `IF(ISOMITTED(paramName), default, paramName)` wrappers. These wrappers are walked like any other expression: `paramName` is already a value binding (so it's reused), and the `default` sub-expression is walked for extractable refs in the normal way. No special-case logic is needed — the existing-LET rules above cover it naturally. A test case will confirm.
+
+If the existing LET parses cleanly via `LetParser` but contains no extractable tokens after merge (already perfectly tidy), the dialog still opens, shows the existing bindings, and lets the author rename or reorder. Save is a no-op rewrite if nothing changed.
+
+If parsing fails (`FormatException` from `LetParser`), refuse with the same error wording `ConvertLetToLambdaCommand` uses.
+
+### Naming
+
+- **Auto-name format**: `input1`, `input2`, ... assigned in the order tokens are first encountered in the formula.
+- **Collision avoidance**: if the active cell's formula or workbook context already binds `input1` (existing LET binding name, or a defined name on the workbook), the auto-namer skips that number and tries the next.
+- **Rename**: every row in the dialog has a name editor with live validation (same `ExcelNameValidator` and collision rules as `LetToLambdaWindow`).
+- **No label-from-cell heuristic**: `/Gather` reads neighbouring cells to seed names; `/Refactor` does not, because it operates on a single cell. Authors who want meaningful names rename in the dialog.
+
+### Dialog (`RefactorToLetWindow`)
+
+A new WPF window modelled on `LetToLambdaWindow`. Layout:
+
+- **Active cell address and original formula** (read-only header).
+- **Inputs section** — a reorderable list of rows. Each row shows:
+  - **Binding name** (editable, live-validated).
+  - **RHS** (read-only).
+  - **Source** badge — "extracted", "existing LET binding", or "merged ← otherName" for merge survivors.
+  - **Include** checkbox — when off, the binding is dropped and its inline occurrences are restored to the original text everywhere they occurred, with no warning even if that re-introduces duplication. The preview pane is the source of truth for what will be written. For value bindings only; calculation bindings (in the existing-LET case) cannot be dropped here (use a separate flow if you want to inline a calculation step).
+  - **Drag handle** for reorder (kept rows only, matching `LetToLambdaWindow`).
+- **Promote-to-input section** — a separate list of *candidate* rows for named ranges, external refs, and literals found in the formula. Each row has:
+  - **Token text** (read-only).
+  - **Occurrences count** — helpful for deciding whether promoting saves work.
+  - **Promote** checkbox (default off). When on, the row moves into the Inputs section with an auto-name and an editable name field, just like an extracted ref.
+- **Calculation bindings** (existing-LET case only) — shown read-only with their (rewritten) RHS, so the author can verify the rewrites look correct. Not reorderable, not droppable.
+- **Preview pane** — read-only, shows the synthesised LET via the existing `FormulaFormatter`. Updates live as the author edits rows.
+- **Save** — writes the synthesised LET to the active cell. **Cancel** — closes with no change.
+
+Keyboard semantics match other Lambda Boss dialogs: Escape cancels, Ctrl+Enter saves, Alt+Up / Alt+Down reorder a focused input row.
+
+### Output
+
+On Save, the active cell's formula is overwritten with the synthesised `=LET(...)`. Same single-Excel-operation pattern as `/Gather` — no separate snapshot; relies on Excel's native undo stack.
+
+After Save, the author typically opens the popup and runs `/LET to LAMBDA` as the second step. The two commands chain naturally but are not automatically linked.
+
+## User Stories
+
+- As a model author, I want to refactor a messy single-cell formula into a tidy LET, so that I can run LET to LAMBDA without writing the LET by hand.
+- As a model author with an existing LET whose inputs aren't standalone value bindings, I want a one-shot tidy that hoists cell refs out of calculation bindings and merges duplicate value bindings, so that LET to LAMBDA exposes the right parameters.
+- As an author refactoring a formula, I want to see all named ranges and literals the formula touches, and choose which ones to promote to LAMBDA inputs, so that I can expose the constants I want to parameterise without having every magic number become a binding by default.
+
+## Acceptance Criteria
+
+- [ ] A new slash command `/Refactor` registered in the main popup.
+- [ ] When invoked with the active cell holding a formula (LET or not), opens `RefactorToLetWindow` with the cell's formula as input.
+- [ ] When invoked with the active cell empty or a literal value, the popup closes silently (no dialog, no error).
+- [ ] Token extraction handles A1-style cell refs and ranges (with sheet qualifier, `$`-prefixed, and spilled `A1#` forms), and dedupes by canonical form (`A1` and `$A$1` merge into one binding; `A1` and `A1#` stay separate).
+- [ ] Range bounds normalise so `A1:B5` and `B5:A1` collapse to the same binding.
+- [ ] String literals are skipped during token extraction (no extraction inside `"..."`).
+- [ ] Existing LET formulas are parsed via `LetParser`; on `FormatException`, refuse with a clear error and no dialog.
+- [ ] Existing value bindings with equivalent canonical RHS are merged, with the first binding's name kept and later refs rewritten. The dialog surfaces each merge with a visible note.
+- [ ] Existing calculation bindings are preserved (name + order); their RHS is rewritten to use input bindings, but they themselves are not extracted or dropped.
+- [ ] Named ranges, external workbook refs, and literals appear in a separate "Promote to input" section with default-off toggles. When promoted, they become input bindings with auto-names.
+- [ ] LAMBDA names (workbook names whose `RefersTo` starts with `=LAMBDA(`) are **not** offered as promotable.
+- [ ] Auto-names follow `inputN` sequential format, skipping any number already in use as a binding name in the formula or as a workbook name.
+- [ ] Each input row exposes a live-validated name editor, an Include checkbox, and reorder controls (Alt+Up/Alt+Down + drag handle). Validation reuses `ExcelNameValidator` and the same collision rules as `LetToLambdaWindow`.
+- [ ] The Preview pane shows the synthesised LET formatted via `FormulaFormatter`, updating as the author edits the dialog.
+- [ ] Save writes the synthesised LET into the active cell. Cancel closes the dialog with no change.
+- [ ] The synthesised LET parses cleanly via `LetParser` (round-trip safety) and, when fed straight into `LetToLambdaBuilder`, produces a working LAMBDA.
+- [ ] Unit tests cover: non-LET formula, existing-tidy LET (no-op rewrite), existing-messy LET (merge + hoist), spill refs preserved, sheet-qualified refs, range normalisation, named-range promotion, literal promotion, external-ref promotion, auto-name collision avoidance, and full round-trip through `LetToLambdaBuilder`.
+
+## Out of Scope
+
+- Producing a LAMBDA. The author runs `/LET to LAMBDA` after Save. The dialog has no "Save and convert" shortcut button.
+- Sub-expression extraction. If `SUM(B1:B5)` appears twice, only `B1:B5` is shared as a binding; the `SUM(...)` call remains inline in both places. Common-subexpression elimination is a separate, harder problem.
+- Walking precedent cells. That's `/Gather`'s job; `/Refactor` operates on a single cell's formula text.
+- Auto-promoting named ranges or literals based on heuristics. They appear in the dialog and stay un-promoted unless the author opts in.
+- **Demoting calculation bindings to inputs** (or vice versa) in the existing-LET case. Example: `=LET(getMax, MAX(A1:A10), getMax + 5)` — today `A1:A10` becomes the input and `getMax` stays as a calculation binding rewritten to `MAX(input1)`. Demoting `getMax` to an input would *discard* the `MAX(A1:A10)` calculation and turn `getMax` into a direct LAMBDA parameter the caller supplies pre-computed. That changes semantics and is a different feature; out of scope here.
+- Persistence of dialog state across opens; each `/Refactor` invocation starts fresh.
+- Detecting and inlining a single LAMBDA call in the active cell. Use `/EditLambda` (spec 0003) first, then `/Refactor`.
+- Reverse direction (LET back into a non-LET expression with everything inlined).
+- Warning on volatile functions, errors in cell values, or external-workbook reachability — same as `/Gather`, those pass through silently.
+
+## Open Questions
+
+- **Worksheet-scoped names.** Excel lets a `Name` be scoped to a worksheet rather than the workbook. The defined-name lookup built from `workbook.Names` includes workbook-scoped names; worksheet-scoped names live on `worksheet.Names`. Should `/Refactor` also read the active sheet's `Names` collection and treat those as promotable? Tentative: yes, union the active sheet's names into the lookup so worksheet-scoped names behave the same as workbook-scoped ones. Confirm during plan.
+- **LAMBDA identifier without a trailing `(`.** A defined name whose `RefersTo` starts with `=LAMBDA(` is excluded from promotion. But a malformed/in-progress formula could reference such a name without a `(` after it (e.g. an incomplete edit). Tentative: still treat it as a LAMBDA-name reference and skip promotion — there's no scenario where the author wants to promote a LAMBDA name into a binding. Confirm during plan.


### PR DESCRIPTION
Closes #202

Tracer-bullet slice of spec 0008 — `/Refactor`. End-to-end loop on the simplest case: a non-LET formula with cell refs and ranges (including spill refs), the dialog with rename / Include / reorder, and write-back via `Formula2`. Existing LETs are refused with a "coming in PR 2" message.

## Summary

- **Shared infra**: `FormulaRef` gains `IsSpilled` (equality + hash + `DisplayAddress`) so `A1` and `A1#` dedupe as distinct refs. `CellRefExtractor.BuildFormulaRef` populates it; `CellRefExtractor.Rewrite` falls back from spilled → non-spilled when the spilled key isn't in the lookup, preserving `/Gather`'s PR 5 token-collapse behaviour. `CellGraphWalker` normalises the spill flag out of cell-level precedents (graph identity already lives on `CellRef`; spill-ness on `WalkedCell.HasSpill`).
- **Engine**: `RefactorEngine.Refactor(formula, activeSheet)` returns auto-named bindings + the synthesised LET. `Recompute(...)` re-runs with per-row state (rename / Include drop / reorder).
- **UI**: `RefactorToLetWindow` — read-only formula header, inputs list with Include checkbox + rename + drag/Alt-Up-Down reorder, live preview, Save/Cancel. Per-row + cross-row name validation gates the Save button.
- **Slash command**: `/Refactor` registered in `LambdaPopup`; `RefactorCommand` mirrors `GatherCommand`'s threading + diagnostic pattern, writes back via `Formula2`.

## Test plan

- [x] `dotnet build addin/lambda-boss.slnx` — clean
- [x] `dotnet test addin/lambda-boss.Tests` — 921 passing (up from 900: 13 new `RefactorEngineTests` + 8 new `CellRefExtractorSpillTests`)
- [x] Manual Excel smoke: `=IF(A1<10, IF(A1>2, SUM(B1:B5), 0), SUM(B2:B6))` → `/Refactor` → Save — confirmed by Tim that the resulting LET evaluates identically
- [x] Reviewer: run a /Gather over a chain containing a spilling anchor to confirm the walker normalisation didn't regress anything subtle

## Reference

- Spec: [`specs/0008-refactor-to-let.md`](specs/0008-refactor-to-let.md)
- Plan: [`plans/0008-refactor-to-let.md`](plans/0008-refactor-to-let.md) § PR 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)