### PR TITLE
Speed up addin tests ~14x and add LAMBDA_FILTER env var

### DIFF
--- a/.claude/skills/create-lambda/SKILL.md
+++ b/.claude/skills/create-lambda/SKILL.md
@@ -306,13 +306,21 @@ Then re-run the test. If validation fails, read the error output, fix the `.lamb
 
 ### Step 7 — Run Functional Tests
 
-Excel is available in this environment. Run the test harness to verify the LAMBDA works end-to-end:
+Excel is available in this environment. Run the test harness scoped to this LAMBDA only — the full suite is ~470 cases and takes much longer than necessary while iterating. Use `LAMBDA_FILTER` (case-insensitive substring match against the lambda file path) to narrow the run:
 
-```bash
-dotnet test addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj --filter "LambdaHarnessTests"
+```powershell
+$env:LAMBDA_FILTER = "<Name>"
+dotnet test addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj --filter "FullyQualifiedName~LambdaHarnessTests"
+Remove-Item Env:LAMBDA_FILTER
 ```
 
 If tests fail, read the output, fix the `.lambda` file or `.tests.yaml`, and re-run until all tests pass.
+
+Before raising the PR (Step 8), run the full suite once **without** `LAMBDA_FILTER` to confirm the new LAMBDA hasn't broken anything else (e.g. a shared helper, a name collision, or a dependency-injection ordering issue):
+
+```bash
+dotnet test addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj --filter "FullyQualifiedName~LambdaHarnessTests"
+```
 
 ### Step 8 — Commit, Push, and Create PR
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,19 @@ dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj
 dotnet test addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj
 ```
 
+### Targeting a single LAMBDA
+
+The harness has ~470+ theory cases across all `*.tests.yaml` files. xUnit's `--filter` can't narrow to a single LAMBDA (all theory cases collapse under one `LambdaTest` method), so use the `LAMBDA_FILTER` env var instead — it's a case-insensitive substring match against the lambda file path:
+
+```powershell
+# Run only CELLDIST tests (~2 s vs ~20 s for the full suite)
+$env:LAMBDA_FILTER = "CELLDIST"
+dotnet test addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj --filter "FullyQualifiedName~LambdaHarnessTests"
+Remove-Item Env:LAMBDA_FILTER
+```
+
+When iterating on a single LAMBDA, always use `LAMBDA_FILTER`. Run the full suite (no filter) before raising the PR.
+
 The packed XLL lands at `addin/lambda-boss/bin/Release/net48/publish/lambda-boss64-packed.xll`. All managed dependencies (`lambda-boss.dll`, `YamlDotNet.dll`, `GongSolutions.WPF.DragDrop.dll`, `Ookii.Dialogs.Wpf.dll`, `System.Text.Json.dll`, and transitive packages) are embedded in the XLL as Win32 resources — there are no loose side-car DLLs to ship.
 
 ## Conventions

--- a/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
+++ b/addin/lambda-boss.AddinTests/LambdaHarnessTests.cs
@@ -27,6 +27,11 @@ public class LambdaHarnessTests
         var lambdasDir = FindLambdasDirectory();
         var yamlFiles = Directory.GetFiles(lambdasDir, "*.tests.yaml", SearchOption.AllDirectories);
 
+        // Optional env-var filter: substring match against the lambda file path.
+        // Agents iterating on a single lambda can set LAMBDA_FILTER=CELLDIST to skip
+        // the other ~450 cases. Empty/unset = run everything.
+        var filter = Environment.GetEnvironmentVariable("LAMBDA_FILTER");
+
         var deserializer = new DeserializerBuilder()
             .WithNamingConvention(UnderscoredNamingConvention.Instance)
             .Build();
@@ -37,6 +42,10 @@ public class LambdaHarnessTests
             var lambdaPath = Path.Combine(Path.GetDirectoryName(yamlPath)!, lambdaFileName);
 
             if (!File.Exists(lambdaPath))
+                continue;
+
+            if (!string.IsNullOrEmpty(filter)
+                && lambdaPath.IndexOf(filter, StringComparison.OrdinalIgnoreCase) < 0)
                 continue;
 
             var yamlContent = File.ReadAllText(yamlPath);
@@ -75,7 +84,10 @@ public class LambdaHarnessTests
             try
             {
                 cell.Formula2 = cellFormula;
-                Thread.Sleep(500);
+                // Force a synchronous recalc rather than sleeping. Application.Calculate()
+                // blocks until the workbook is fully recalculated, which is both faster
+                // and more correct than Thread.Sleep(500). See issue investigation 2026-05-28.
+                _excel.Application.Calculate();
 
                 if (!string.IsNullOrEmpty(expectedType))
                     AssertType(cell, expectedType, testName);

--- a/addin/lambda-boss.AddinTests/SmokeTests.cs
+++ b/addin/lambda-boss.AddinTests/SmokeTests.cs
@@ -45,8 +45,7 @@ public class SmokeTests
             try
             {
                 cell.Formula2 = "=TEST_DOUBLE(5)";
-                // Allow calc
-                Thread.Sleep(500);
+                _excel.Application.Calculate();
                 object? value = cell.Value;
                 _output.WriteLine($"=TEST_DOUBLE(5) result: {value}");
                 Assert.Equal(10.0, Convert.ToDouble(value));
@@ -114,7 +113,7 @@ public class SmokeTests
             try
             {
                 cell.Formula2 = "=tst.Double(5)";
-                Thread.Sleep(500);
+                _excel.Application.Calculate();
                 Assert.Equal(10.0, Convert.ToDouble(cell.Value));
             }
             finally
@@ -135,7 +134,7 @@ public class SmokeTests
             try
             {
                 cell2.Formula2 = "=tst.Double(5)";
-                Thread.Sleep(500);
+                _excel.Application.Calculate();
                 object? value = cell2.Value;
                 _output.WriteLine($"After update: =tst.Double(5) = {value}");
                 Assert.Equal(15.0, Convert.ToDouble(value));
@@ -149,7 +148,7 @@ public class SmokeTests
             var cell1Again = ws.Range["A1"];
             try
             {
-                Thread.Sleep(500);
+                _excel.Application.Calculate();
                 object? updatedValue = cell1Again.Value;
                 _output.WriteLine($"Cell A1 after update: {updatedValue}");
                 Assert.Equal(15.0, Convert.ToDouble(updatedValue));


### PR DESCRIPTION
## Summary

- Replace per-test `Thread.Sleep(500)` with `Application.Calculate()` in `LambdaHarnessTests` and `SmokeTests`. Full `LambdaHarnessTests` run drops from **4m 22s → 19s** (473/473 still pass).
- Add `LAMBDA_FILTER` env var to `LambdaHarnessTests.TestCases()` for targeted single-LAMBDA runs (~2 s for one library vs 4+ min before). Needed because xUnit's `--filter` can't narrow theory cases — they all collapse under one `LambdaTest` method in vstest discovery.
- Document the env var in `CLAUDE.md` and update the `create-lambda` skill to use it while iterating, with a full-suite run before raising the PR to catch cross-lambda regressions.

## Why

The harness was spending ~90% of its time inside defensive `Thread.Sleep(500)` calls (473 × 500 ms = ~4 min of pure sleep). Excel's `Range.Value` getter on an automatic-calc workbook is already synchronous; `Application.Calculate()` makes that explicit and removes the wait. With the speedup and the filter, agents working on a single LAMBDA get ~2 s feedback instead of 4+ min.

## Test plan

- [x] Full `LambdaHarnessTests` suite: 473/473 pass in 19 s (was 4m 22s)
- [x] `LAMBDA_FILTER=CELLDIST` narrows to 21 cases, runs in 2 s
- [x] `SmokeTests` (3 still use `Application.Calculate()` patterns) pass
- [x] Tim spot-checks a `create-lambda` iteration uses `LAMBDA_FILTER` and falls back to full suite before PR