### PR TITLE
Add ALL / ANY / COUNTOF array reducers

### DIFF
--- a/lambdas/array/ALL.lambda
+++ b/lambdas/array/ALL.lambda
@@ -1,0 +1,31 @@
+/*  FUNCTION NAME:      ALL
+    DESCRIPTION:*//**Returns TRUE if every item satisfies the predicate, else FALSE.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-05-28  Claude      Initial version
+*/
+ALL = LAMBDA(
+//  Parameter Declarations
+    [items],
+    [predicate],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →ALL(items, [predicate])¶" &
+                "DESCRIPTION:   →Returns TRUE if every item satisfies the predicate, else FALSE.¶" &
+                "VERSION:       →May 28 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   items          →(Required) Array or range of values to test.¶" &
+                "   predicate      →(Optional) LAMBDA(v) returning TRUE/FALSE or 0/1. If omitted, items are assumed to already be boolean or 0/1 values.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=ALL({""A"",""B"",""C""}, LAMBDA(c, CODE(c)>=65))¶" &
+                "Result         →TRUE",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(items),
+    //  Procedure
+        pred, IF(ISOMITTED(predicate), LAMBDA(val, val), predicate),
+        mapped, MAP(items, pred),
+        result, SUM(--NOT(mapped))=0,
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/ALL.tests.yaml
+++ b/lambdas/array/ALL.tests.yaml
@@ -1,0 +1,36 @@
+tests:
+  - name: predicate true for every item
+    args: ['={"A","B","C"}', '=LAMBDA(c, CODE(c)>=65)']
+    expected: True
+
+  - name: predicate false for one item
+    args: ['={"A","B","Z"}', '=LAMBDA(c, c<"Z")']
+    expected: False
+
+  - name: predicate true for none
+    args: ['={1,2,3}', '=LAMBDA(n, n>10)']
+    expected: False
+
+  - name: no predicate - all booleans true
+    args: ['={TRUE,TRUE,TRUE}']
+    expected: True
+
+  - name: no predicate - one boolean false
+    args: ['={TRUE,TRUE,FALSE}']
+    expected: False
+
+  - name: no predicate - all 0/1 truthy
+    args: ['={1,1,1}']
+    expected: True
+
+  - name: no predicate - contains zero
+    args: ['={1,1,0,1}']
+    expected: False
+
+  - name: vertical array with predicate
+    args: ['={2;4;6;8}', '=LAMBDA(n, MOD(n,2)=0)']
+    expected: True
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/array/ANY.lambda
+++ b/lambdas/array/ANY.lambda
@@ -1,0 +1,31 @@
+/*  FUNCTION NAME:      ANY
+    DESCRIPTION:*//**Returns TRUE if at least one item satisfies the predicate, else FALSE.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-05-28  Claude      Initial version
+*/
+ANY = LAMBDA(
+//  Parameter Declarations
+    [items],
+    [predicate],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →ANY(items, [predicate])¶" &
+                "DESCRIPTION:   →Returns TRUE if at least one item satisfies the predicate, else FALSE.¶" &
+                "VERSION:       →May 28 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   items          →(Required) Array or range of values to test.¶" &
+                "   predicate      →(Optional) LAMBDA(v) returning TRUE/FALSE or 0/1. If omitted, items are assumed to already be boolean or 0/1 values.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=ANY({""A"",""B"",""C""}, LAMBDA(c, c=""B""))¶" &
+                "Result         →TRUE",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(items),
+    //  Procedure
+        pred, IF(ISOMITTED(predicate), LAMBDA(val, val), predicate),
+        mapped, MAP(items, pred),
+        result, SUM(--mapped)>0,
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/ANY.tests.yaml
+++ b/lambdas/array/ANY.tests.yaml
@@ -1,0 +1,36 @@
+tests:
+  - name: predicate matches one item
+    args: ['={"A","B","C"}', '=LAMBDA(c, c="B")']
+    expected: True
+
+  - name: predicate matches no items
+    args: ['={"A","B","C"}', '=LAMBDA(c, c="Z")']
+    expected: False
+
+  - name: predicate matches every item
+    args: ['={1,2,3}', '=LAMBDA(n, n>0)']
+    expected: True
+
+  - name: no predicate - one boolean true
+    args: ['={FALSE,FALSE,TRUE}']
+    expected: True
+
+  - name: no predicate - all booleans false
+    args: ['={FALSE,FALSE,FALSE}']
+    expected: False
+
+  - name: no predicate - one 1 among zeros
+    args: ['={0,0,1,0}']
+    expected: True
+
+  - name: no predicate - all zeros
+    args: ['={0,0,0}']
+    expected: False
+
+  - name: vertical array with predicate
+    args: ['={1;3;5;7}', '=LAMBDA(n, MOD(n,2)=0)']
+    expected: False
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/array/COUNTOF.lambda
+++ b/lambdas/array/COUNTOF.lambda
@@ -1,0 +1,31 @@
+/*  FUNCTION NAME:      COUNTOF
+    DESCRIPTION:*//**Counts items for which the predicate is TRUE (or truthy items when predicate is omitted).*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-05-28  Claude      Initial version
+*/
+COUNTOF = LAMBDA(
+//  Parameter Declarations
+    [items],
+    [predicate],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →COUNTOF(items, [predicate])¶" &
+                "DESCRIPTION:   →Counts items for which the predicate is TRUE (or truthy items when predicate is omitted).¶" &
+                "VERSION:       →May 28 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   items          →(Required) Array or range of values to test.¶" &
+                "   predicate      →(Optional) LAMBDA(v) returning TRUE/FALSE or 0/1. If omitted, items are assumed to already be boolean or 0/1 values.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=COUNTOF({1,2,3,4,5}, LAMBDA(n, n>=3))¶" &
+                "Result         →3",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(items),
+    //  Procedure
+        pred, IF(ISOMITTED(predicate), LAMBDA(val, val), predicate),
+        mapped, MAP(items, pred),
+        result, SUM(--mapped),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/COUNTOF.tests.yaml
+++ b/lambdas/array/COUNTOF.tests.yaml
@@ -1,0 +1,36 @@
+tests:
+  - name: predicate matches some items
+    args: ['={1,2,3,4,5}', '=LAMBDA(n, n>=3)']
+    expected: 3
+
+  - name: predicate matches no items
+    args: ['={1,2,3}', '=LAMBDA(n, n>10)']
+    expected: 0
+
+  - name: predicate matches every item
+    args: ['={1,2,3}', '=LAMBDA(n, n>0)']
+    expected: 3
+
+  - name: no predicate - count 0/1 array
+    args: ['={1,0,1,1,0}']
+    expected: 3
+
+  - name: no predicate - boolean array
+    args: ['={TRUE,FALSE,TRUE}']
+    expected: 2
+
+  - name: no predicate - all zeros
+    args: ['={0,0,0}']
+    expected: 0
+
+  - name: string predicate over letters
+    args: ['={"A","B","C","D"}', '=LAMBDA(c, c<"C")']
+    expected: 2
+
+  - name: vertical array with predicate
+    args: ['={2;4;6;7;8}', '=LAMBDA(n, MOD(n,2)=0)']
+    expected: 4
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Three new array-reducer LAMBDAs in `lambdas/array/`:

- `ALL(items, [predicate])` — TRUE if every item satisfies the predicate (or all items are truthy when predicate omitted).
- `ANY(items, [predicate])` — TRUE if at least one item satisfies the predicate.
- `COUNTOF(items, [predicate])` — count of items where the predicate is TRUE.

Predicate is an optional `LAMBDA(v)`. When omitted, items are treated as already boolean (or 0/1). Internally each builds a `pred` LAMBDA via `IF(ISOMITTED(predicate), LAMBDA(val, val), predicate)`, then reduces `MAP(items, pred)` with `SUM` / `SUM(--NOT(...))`.

These round out the same family as `CONTAINS` and the `FINDFIRST` / `FINDALL` loop helpers.

Closes #208

## Test plan

- [x] `LambdaFormatTests` passes (472/472)
- [x] Full `LambdaHarnessTests` passes (500/500 — 27 new cases, was 473)
- [x] Spot-check in Excel: `=ALL({"A","B","C"}, LAMBDA(c, CODE(c)>=65))` → TRUE, `=ANY({1,2,3}, LAMBDA(n, n=2))` → TRUE, `=COUNTOF({1,2,3,4,5}, LAMBDA(n, n>=3))` → 3
- [x] `=ALL()`, `=ANY()`, `=COUNTOF()` (no args) each return the help table

🤖 Generated with [Claude Code](https://claude.com/claude-code)