### PR TITLE
Refactor to LET — PR 2: existing-LET handling (spec 0008)

### DIFF
--- a/addin/lambda-boss.Tests/RefactorEngineTests.cs
+++ b/addin/lambda-boss.Tests/RefactorEngineTests.cs
@@ -3,14 +3,18 @@ using Xunit;
 namespace LambdaBoss.Tests;
 
 /// <summary>
-///     Spec 0008 / PR 1 — the tracer slice's engine tests. Covers the
-///     happy path (refs, ranges, spill-distinct, sheet-qualifier
-///     dedupe), the rename path, the Include-drop path, and round-trip
-///     safety via <see cref="LetParser" /> + <see cref="LetToLambdaBuilder" />.
+///     Spec 0008 — <see cref="RefactorEngine" /> tests. Covers the non-LET
+///     happy path (refs, ranges, spill-distinct, sheet-qualifier dedupe),
+///     the rename / drop / reorder paths, the existing-LET path (merge,
+///     extract from calc bindings and body, ISOMITTED survival, drop
+///     inlines RHS, auto-name collision), and round-trip safety via
+///     <see cref="LetParser" /> + <see cref="LetToLambdaBuilder" />.
 /// </summary>
 public class RefactorEngineTests
 {
     private const string Sheet = "Sheet1";
+
+    // ---------- non-LET path ----------
 
     [Fact]
     public void Refactor_SingleCellRef_BindsToInput1()
@@ -21,13 +25,13 @@ public class RefactorEngineTests
         var row = Assert.Single(result.Inputs);
         Assert.Equal("input1", row.Name);
         Assert.Equal("A1", row.Rhs);
+        Assert.Equal(RefactorRowOrigin.Extracted, row.Origin);
         Assert.Contains("input1*2", result.SynthesisedLet);
     }
 
     [Fact]
     public void Refactor_MultipleRefsDeduped_OneBindingPerUniqueRef()
     {
-        // A1 appears twice, B2 once → two bindings, two rewrites of A1.
         var result = RefactorEngine.Refactor("=A1+B2+A1", Sheet);
 
         Assert.Equal(2, result.Inputs.Count);
@@ -52,7 +56,6 @@ public class RefactorEngineTests
     [Fact]
     public void Refactor_SpillRefAndAnchor_BindAsTwoDistinctInputs()
     {
-        // Spec 0008 dedupe rule: A1 and A1# get distinct bindings.
         var result = RefactorEngine.Refactor("=A1+SUM(A1#)", Sheet);
 
         Assert.Equal(2, result.Inputs.Count);
@@ -64,7 +67,6 @@ public class RefactorEngineTests
     [Fact]
     public void Refactor_SheetQualifiedRefMatchingActiveSheet_CollapsesToBareForm()
     {
-        // Sheet1!A1 with active sheet Sheet1 should dedupe with A1.
         var result = RefactorEngine.Refactor("=A1+Sheet1!A1", Sheet);
 
         var row = Assert.Single(result.Inputs);
@@ -75,25 +77,11 @@ public class RefactorEngineTests
     [Fact]
     public void Refactor_CrossSheetRef_StaysDistinct()
     {
-        // Sheet2!A1 from Sheet1 stays cross-sheet; the binding RHS is
-        // sheet-qualified so the LET resolves correctly when the cell
-        // lives on Sheet1.
         var result = RefactorEngine.Refactor("=A1+Sheet2!A1", Sheet);
 
         Assert.Equal(2, result.Inputs.Count);
         Assert.Equal("A1", result.Inputs[0].Rhs);
         Assert.Equal("Sheet2!A1", result.Inputs[1].Rhs);
-    }
-
-    [Fact]
-    public void Refactor_ExistingLet_Refused()
-    {
-        var result = RefactorEngine.Refactor("=LET(x, A1, x + 1)", Sheet);
-
-        Assert.NotNull(result.Diagnostic);
-        Assert.Equal(RefactorDiagnosticKind.ExistingLet, result.Diagnostic.Kind);
-        Assert.Empty(result.Inputs);
-        Assert.Equal("=LET(x, A1, x + 1)", result.SynthesisedLet);
     }
 
     [Fact]
@@ -111,7 +99,7 @@ public class RefactorEngineTests
         var initial = RefactorEngine.Refactor("=IF(A1<10, A1*2, 0)", Sheet);
         var row = initial.Inputs[0];
 
-        var renamed = new[] { new RefactorRowState(row.Source, "count") };
+        var renamed = new[] { new RefactorRowState(row.Key, "count") };
         var result = RefactorEngine.Recompute("=IF(A1<10, A1*2, 0)", Sheet, renamed);
 
         Assert.Single(result.Inputs);
@@ -122,11 +110,10 @@ public class RefactorEngineTests
     [Fact]
     public void Recompute_DroppedRow_LeavesTokenInBody()
     {
-        // Worked example from the spec: drop A1 → "IF(A1<10, ...)" stays.
         var initial = RefactorEngine.Refactor("=IF(A1<10, A1*2, B1)", Sheet);
         var rows = initial.Inputs
             .Select(r => new RefactorRowState(
-                r.Source,
+                r.Key,
                 r.Name,
                 Include: r.Rhs != "A1"))
             .ToArray();
@@ -136,7 +123,6 @@ public class RefactorEngineTests
 
         Assert.Single(result.Inputs);
         Assert.Equal("B1", result.Inputs[0].Rhs);
-        // A1 stays as A1 because its binding was dropped.
         Assert.Contains("IF(A1<10, A1*2, input2)", result.SynthesisedLet);
     }
 
@@ -144,18 +130,16 @@ public class RefactorEngineTests
     public void Recompute_Reordered_BindingOrderMatchesRowOrder()
     {
         var initial = RefactorEngine.Refactor("=A1+B2", Sheet);
-        // Swap order: B2 first, A1 second.
         var swapped = new[]
         {
-            new RefactorRowState(initial.Inputs[1].Source, initial.Inputs[1].Name),
-            new RefactorRowState(initial.Inputs[0].Source, initial.Inputs[0].Name),
+            new RefactorRowState(initial.Inputs[1].Key, initial.Inputs[1].Name),
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
         };
 
         var result = RefactorEngine.Recompute("=A1+B2", Sheet, swapped);
 
         Assert.Equal("B2", result.Inputs[0].Rhs);
         Assert.Equal("A1", result.Inputs[1].Rhs);
-        // Synthesised LET emits bindings in dialog order — B2 first.
         var b2Pos = result.SynthesisedLet.IndexOf("B2", StringComparison.Ordinal);
         var a1Pos = result.SynthesisedLet.IndexOf(" A1,", StringComparison.Ordinal);
         Assert.True(b2Pos < a1Pos, "B2 binding should precede A1 binding");
@@ -164,7 +148,6 @@ public class RefactorEngineTests
     [Fact]
     public void Refactor_SpecWorkedExample_ProducesRoundTrippableLet()
     {
-        // The worked example from the spec.
         var formula = "=IF(A1<10, IF(A1>2, SUM(B1:B5), 0), SUM(B2:B6))";
         var result = RefactorEngine.Refactor(formula, Sheet);
 
@@ -174,7 +157,6 @@ public class RefactorEngineTests
         Assert.Equal("B1:B5", result.Inputs[1].Rhs);
         Assert.Equal("B2:B6", result.Inputs[2].Rhs);
 
-        // Round-trip safety.
         AssertRoundTrips(result.SynthesisedLet);
     }
 
@@ -199,12 +181,259 @@ public class RefactorEngineTests
         }
     }
 
+    // ---------- existing-LET path ----------
+
+    [Fact]
+    public void Refactor_ExistingLet_TreatsValueBindingsAsInputs()
+    {
+        var result = RefactorEngine.Refactor("=LET(a, A1, b, B1, a + b)", Sheet);
+
+        Assert.Null(result.Diagnostic);
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Equal("a", result.Inputs[0].Name);
+        Assert.Equal("A1", result.Inputs[0].Rhs);
+        Assert.Equal(RefactorRowOrigin.ExistingLetValue, result.Inputs[0].Origin);
+        Assert.Equal("b", result.Inputs[1].Name);
+        Assert.Equal("B1", result.Inputs[1].Rhs);
+        Assert.Empty(result.CalcBindings);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_MergesDuplicateValueBindings_FirstWins()
+    {
+        // a, A1 + b, A1 → merge b into a; body 'a + b' rewrites to 'a + a'.
+        var result = RefactorEngine.Refactor("=LET(a, A1, b, A1, a + b)", Sheet);
+
+        Assert.Null(result.Diagnostic);
+        var row = Assert.Single(result.Inputs);
+        Assert.Equal("a", row.Name);
+        Assert.Equal("A1", row.Rhs);
+        Assert.NotNull(row.MergedFrom);
+        Assert.Equal(new[] { "b" }, row.MergedFrom);
+        Assert.Contains("a + a", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_MergesLiteralRhs()
+    {
+        // Bindings whose RHS isn't a single ref fall back to literal string
+        // compare for merge — two `"hello"` literals collapse.
+        var result = RefactorEngine.Refactor(
+            "=LET(greeting, \"hello\", salutation, \"hello\", greeting & salutation)", Sheet);
+
+        var row = Assert.Single(result.Inputs);
+        Assert.Equal("greeting", row.Name);
+        Assert.Equal("\"hello\"", row.Rhs);
+        Assert.Equal(new[] { "salutation" }, row.MergedFrom);
+        Assert.Contains("greeting & greeting", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_SpecWorkedExample()
+    {
+        // Spec's messy-LET worked example: a/b dedupe + B1:B5 hoisted from
+        // calc binding.
+        var formula = "=LET(a, A1, b, A1, getMax, MAX(B1:B5), IF(a<10, getMax, b))";
+        var result = RefactorEngine.Refactor(formula, Sheet);
+
+        Assert.Null(result.Diagnostic);
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Equal("a", result.Inputs[0].Name);
+        Assert.Equal("A1", result.Inputs[0].Rhs);
+        Assert.Equal(new[] { "b" }, result.Inputs[0].MergedFrom);
+        Assert.Equal("input1", result.Inputs[1].Name);
+        Assert.Equal("B1:B5", result.Inputs[1].Rhs);
+
+        var calc = Assert.Single(result.CalcBindings);
+        Assert.Equal("getMax", calc.Name);
+        Assert.Equal("MAX(input1)", calc.RewrittenRhs);
+
+        // Body: IF(a<10, getMax, b)  →  IF(a<10, getMax, a)
+        Assert.Contains("IF(a<10, getMax, a)", result.SynthesisedLet);
+        AssertRoundTrips(result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_ExtractsRefsFromBody()
+    {
+        var result = RefactorEngine.Refactor("=LET(a, A1, a + B1)", Sheet);
+
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Equal("a", result.Inputs[0].Name);
+        Assert.Equal("input1", result.Inputs[1].Name);
+        Assert.Equal("B1", result.Inputs[1].Rhs);
+        Assert.Contains("a + input1", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_AutoNameSkipsExistingBindingNames()
+    {
+        // Existing LET uses 'input1' as a binding name; new auto-name
+        // allocator must skip 1 and use input2 onward.
+        var result = RefactorEngine.Refactor("=LET(input1, A1, input1 + B1)", Sheet);
+
+        var newRow = result.Inputs.Single(r => r.Origin == RefactorRowOrigin.Extracted);
+        Assert.Equal("input2", newRow.Name);
+        Assert.Equal("B1", newRow.Rhs);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_IsomittedWrapper_Survives_AndRefsInDefaultExtracted()
+    {
+        // Mirrors the shape produced by /EditLambda on a LAMBDA with an
+        // optional `factor` param: `factor` becomes a calc binding whose
+        // RHS wraps the default expression in IF(ISOMITTED(factor), ...).
+        // The cell ref inside the default expression should extract; the
+        // ISOMITTED wrapper should survive verbatim.
+        var formula =
+            "=LET(x, A1, factor, IF(ISOMITTED(factor), B1*0.1, factor), x*factor)";
+        var result = RefactorEngine.Refactor(formula, Sheet);
+
+        Assert.Null(result.Diagnostic);
+        // x stays as a value binding; B1 hoists out of the calc binding.
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Equal("x", result.Inputs[0].Name);
+        Assert.Equal("A1", result.Inputs[0].Rhs);
+        Assert.Equal("input1", result.Inputs[1].Name);
+        Assert.Equal("B1", result.Inputs[1].Rhs);
+
+        var calc = Assert.Single(result.CalcBindings);
+        Assert.Equal("factor", calc.Name);
+        // ISOMITTED(factor) survives untouched; B1 inside the default
+        // becomes input1.
+        Assert.Equal("IF(ISOMITTED(factor), input1*0.1, factor)", calc.RewrittenRhs);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_AlreadyTidyLet_NoOpRewrite()
+    {
+        // Tidy LET: no merge, no extractable refs in calc/body.
+        var result = RefactorEngine.Refactor("=LET(a, A1, b, B1, a + b)", Sheet);
+
+        Assert.Null(result.Diagnostic);
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Empty(result.CalcBindings);
+        // Output should be the same LET, modulo whitespace.
+        var stripped = StripWhitespace(result.SynthesisedLet);
+        Assert.Equal("=LET(a,A1,b,B1,a+b)", stripped);
+    }
+
+    [Fact]
+    public void Refactor_MalformedLet_ReturnsDiagnostic()
+    {
+        // Missing close paren — LetParser throws FormatException; the
+        // engine wraps it in a MalformedLet diagnostic.
+        var result = RefactorEngine.Refactor("=LET(a, A1, a + 1", Sheet);
+
+        Assert.NotNull(result.Diagnostic);
+        Assert.Equal(RefactorDiagnosticKind.MalformedLet, result.Diagnostic!.Kind);
+        Assert.Empty(result.Inputs);
+        Assert.Empty(result.CalcBindings);
+        Assert.Equal("=LET(a, A1, a + 1", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_ExistingLet_DropValueBinding_InlinesOriginalRhs()
+    {
+        // Drop the value binding `a, A1`. References to `a` everywhere
+        // collapse back to `A1`.
+        var formula = "=LET(a, A1, calc, a + 5, a * calc)";
+        var initial = RefactorEngine.Refactor(formula, Sheet);
+        var rowStates = initial.Inputs
+            .Select(r => new RefactorRowState(r.Key, r.Name, Include: false))
+            .ToList();
+
+        var result = RefactorEngine.Recompute(formula, Sheet, rowStates);
+
+        Assert.Empty(result.Inputs);
+        var calc = Assert.Single(result.CalcBindings);
+        Assert.Equal("calc", calc.Name);
+        Assert.Equal("A1 + 5", calc.RewrittenRhs);
+        // Body: a * calc → A1 * calc.
+        Assert.Contains("A1 * calc", result.SynthesisedLet);
+        AssertRoundTrips(result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_PreservesCalcBindingsInSourceOrder()
+    {
+        var formula = "=LET(a, A1, step1, a + 1, step2, step1 * 2, step2 - a)";
+        var result = RefactorEngine.Refactor(formula, Sheet);
+
+        Assert.Single(result.Inputs);
+        Assert.Equal(2, result.CalcBindings.Count);
+        Assert.Equal("step1", result.CalcBindings[0].Name);
+        Assert.Equal("step2", result.CalcBindings[1].Name);
+        var firstPos = result.SynthesisedLet.IndexOf("step1,", StringComparison.Ordinal);
+        var secondPos = result.SynthesisedLet.IndexOf("step2,", StringComparison.Ordinal);
+        Assert.True(firstPos < secondPos, "step1 should precede step2 in source-order emit");
+    }
+
+    [Fact]
+    public void Recompute_ExistingLet_ReorderInputs_DialogOrderWins()
+    {
+        var formula = "=LET(a, A1, b, B1, a + b)";
+        var initial = RefactorEngine.Refactor(formula, Sheet);
+        var swapped = new[]
+        {
+            new RefactorRowState(initial.Inputs[1].Key, initial.Inputs[1].Name),
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
+        };
+
+        var result = RefactorEngine.Recompute(formula, Sheet, swapped);
+
+        Assert.Equal("b", result.Inputs[0].Name);
+        Assert.Equal("a", result.Inputs[1].Name);
+        var bPos = result.SynthesisedLet.IndexOf("b, B1", StringComparison.Ordinal);
+        var aPos = result.SynthesisedLet.IndexOf("a, A1", StringComparison.Ordinal);
+        Assert.True(bPos < aPos, "b binding should precede a binding");
+    }
+
+    [Fact]
+    public void Recompute_ExistingLet_RenameValueBinding_RewritesEverywhere()
+    {
+        var formula = "=LET(a, A1, b, A1, calc, a + b, a * calc + b)";
+        var initial = RefactorEngine.Refactor(formula, Sheet);
+
+        // a is the survivor; rename it to 'first'. b (merged-away) should
+        // also resolve to 'first' in body + calc bindings.
+        var rowStates = initial.Inputs
+            .Select(r => new RefactorRowState(r.Key, "first"))
+            .ToList();
+
+        var result = RefactorEngine.Recompute(formula, Sheet, rowStates);
+
+        Assert.Single(result.Inputs);
+        Assert.Equal("first", result.Inputs[0].Name);
+        var calc = Assert.Single(result.CalcBindings);
+        Assert.Equal("first + first", calc.RewrittenRhs);
+        Assert.Contains("first * calc + first", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_RoundTripsViaLetParserAndBuilder()
+    {
+        var formulas = new[]
+        {
+            "=LET(a, A1, a + 1)",
+            "=LET(a, A1, b, A1, a + b)",
+            "=LET(a, A1, getMax, MAX(B1:B5), IF(a<10, getMax, a))",
+            "=LET(x, A1, factor, IF(ISOMITTED(factor), B1*0.1, factor), x*factor)",
+            "=LET(a, A1, step1, a + 1, step2, step1 * 2, step2 - a)",
+        };
+
+        foreach (var formula in formulas)
+        {
+            var result = RefactorEngine.Refactor(formula, Sheet);
+            Assert.Null(result.Diagnostic);
+            AssertRoundTrips(result.SynthesisedLet);
+        }
+    }
+
     /// <summary>
     ///     Confirms the synthesised LET parses via <see cref="LetParser.Parse" />
     ///     AND feeds cleanly through <see cref="LetToLambdaBuilder.Build" />
-    ///     with a default request keeping all inputs. Catches both
-    ///     malformed-LET output and LET-that-LetToLambdaBuilder-rejects
-    ///     output early.
+    ///     with a default request keeping all inputs.
     /// </summary>
     private static void AssertRoundTrips(string synthesisedLet)
     {
@@ -216,5 +445,10 @@ public class RefactorEngineTests
         var request = new LambdaGenerationRequest("RoundTrip", parsed, inputs);
         var lambdaText = LetToLambdaBuilder.Build(request);
         Assert.StartsWith("=LAMBDA(", lambdaText);
+    }
+
+    private static string StripWhitespace(string s)
+    {
+        return new string(s.Where(c => !char.IsWhiteSpace(c)).ToArray());
     }
 }

--- a/addin/lambda-boss/RefactorEngine.cs
+++ b/addin/lambda-boss/RefactorEngine.cs
@@ -1,66 +1,51 @@
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace LambdaBoss;
 
 /// <summary>
-///     Spec 0008 / PR 1 — the <c>/Refactor</c> entry point. Takes a
-///     formula and the active cell's sheet, hoists every cell ref and
-///     range into its own LET binding, and emits a tidy
-///     <c>=LET(...)</c>. Existing LETs are refused in PR 1 with an
-///     <see cref="RefactorDiagnosticKind.ExistingLet" /> diagnostic; PR 2
-///     removes that refusal.
+///     Spec 0008 — the <c>/Refactor</c> entry point. Takes a formula and
+///     the active cell's sheet, hoists every cell ref / range into its own
+///     LET binding, and emits a tidy <c>=LET(...)</c>.
 ///
-///     The tracer is intentionally minimal: <see cref="Refactor" />
-///     produces an initial pass with auto-named bindings;
-///     <see cref="Recompute" /> re-runs with the dialog's per-row state
-///     so the user can rename, drop, and reorder.
+///     PR 2 adds existing-LET handling. When the input is already a LET,
+///     value bindings pre-populate the Inputs section; calculation bindings
+///     populate the read-only Calculation-bindings section; value bindings
+///     with equivalent canonical RHS are merged (first wins); cell refs
+///     inside calculation bindings or the body are extracted as new input
+///     rows; the synthesised LET emits all value bindings first (in dialog
+///     order) followed by all calc bindings (in source order).
+///
+///     The engine re-derives merge state on every <see cref="Recompute" />
+///     call — the dialog only carries name / Include / order for each row
+///     via <see cref="RefactorRowState" />, not the underlying merge graph,
+///     so the engine has to be re-run anchored on the source formula
+///     text.
 /// </summary>
 public static class RefactorEngine
 {
     /// <summary>
-    ///     Runs the initial refactor over <paramref name="formula" />,
-    ///     assigning each extracted ref an auto-name in first-seen
-    ///     order (<c>input1</c>, <c>input2</c>, …). <paramref name="activeSheet" />
-    ///     is the sheet the formula lives on; unqualified refs resolve
-    ///     against it and in-sheet refs render bare in binding RHSes.
+    ///     Runs the initial refactor over <paramref name="formula" />.
+    ///     Existing LETs are parsed and merged/extracted per spec 0008;
+    ///     non-LET formulas have their cell refs hoisted in first-seen
+    ///     order.
     /// </summary>
     public static RefactorResult Refactor(string formula, string activeSheet)
     {
         if (formula is null) throw new ArgumentNullException(nameof(formula));
         if (activeSheet is null) throw new ArgumentNullException(nameof(activeSheet));
 
-        if (LetParser.IsLetFormula(formula))
-        {
-            return new RefactorResult(
-                formula,
-                Array.Empty<RefactorInputRow>(),
-                formula,
-                new RefactorDiagnostic(
-                    RefactorDiagnosticKind.ExistingLet,
-                    "Refactor on existing LET formulas is coming in PR 2 (spec 0008)."));
-        }
-
-        var extracted = CellRefExtractor.Extract(formula, activeSheet);
-        var rows = new List<RefactorInputRow>(extracted.Count);
-        var nameIndex = 1;
-        foreach (var r in extracted)
-        {
-            var rhs = r.DisplayAddress(activeSheet);
-            rows.Add(new RefactorInputRow(r, $"input{nameIndex}", rhs));
-            nameIndex++;
-        }
-        var let = Synthesise(formula, activeSheet, rows);
-        return new RefactorResult(formula, rows, let);
+        return RefactorInternal(formula, activeSheet, rowStates: null);
     }
 
     /// <summary>
     ///     Re-runs the refactor with the dialog's per-row state.
     ///     <paramref name="rowStates" /> is the full set of rows in
     ///     user-chosen order; rows with <see cref="RefactorRowState.Include" />
-    ///     = false are dropped from the LET (their tokens stay in the
-    ///     rewritten body as-is). The engine trusts the dialog's name
-    ///     validation: collisions and invalid names get passed through
-    ///     verbatim so the user's typed text round-trips.
+    ///     = false are dropped. For non-LET formulas a dropped row leaves
+    ///     its source cell ref inline (matching PR 1). For existing LETs a
+    ///     dropped value binding is removed and its name is inlined back to
+    ///     the binding's original RHS text wherever it appeared.
     /// </summary>
     public static RefactorResult Recompute(
         string formula,
@@ -71,57 +56,590 @@ public static class RefactorEngine
         if (activeSheet is null) throw new ArgumentNullException(nameof(activeSheet));
         if (rowStates is null) throw new ArgumentNullException(nameof(rowStates));
 
+        return RefactorInternal(formula, activeSheet, rowStates);
+    }
+
+    private static RefactorResult RefactorInternal(
+        string formula,
+        string activeSheet,
+        IReadOnlyList<RefactorRowState>? rowStates)
+    {
         if (LetParser.IsLetFormula(formula))
+            return RefactorExistingLet(formula, activeSheet, rowStates);
+        return RefactorNonLet(formula, activeSheet, rowStates);
+    }
+
+    // ---------------- non-LET path ----------------
+
+    private static RefactorResult RefactorNonLet(
+        string formula,
+        string activeSheet,
+        IReadOnlyList<RefactorRowState>? rowStates)
+    {
+        var extracted = CellRefExtractor.Extract(formula, activeSheet);
+
+        var defaultRows = new List<RefactorInputRow>(extracted.Count);
+        var nameIndex = 1;
+        foreach (var fr in extracted)
+        {
+            defaultRows.Add(new RefactorInputRow(
+                Key: BuildExtractedKey(fr, activeSheet),
+                Source: fr,
+                Name: $"input{nameIndex}",
+                Rhs: fr.DisplayAddress(activeSheet),
+                Origin: RefactorRowOrigin.Extracted));
+            nameIndex++;
+        }
+
+        var finalRows = ApplyRowStates(defaultRows, rowStates);
+        var keptRows = finalRows.Where(r => r.IsIncluded).ToList();
+
+        var synthesisedLet = BuildSynthesisedLet(
+            formula, activeSheet, keptRows, Array.Empty<RefactorCalcBindingRow>(),
+            isExistingLet: false, body: null, identifierSubstitutions: null);
+
+        return new RefactorResult(
+            formula,
+            keptRows.Select(r => r.Row).ToList(),
+            Array.Empty<RefactorCalcBindingRow>(),
+            synthesisedLet);
+    }
+
+    // ---------------- existing-LET path ----------------
+
+    private static RefactorResult RefactorExistingLet(
+        string formula,
+        string activeSheet,
+        IReadOnlyList<RefactorRowState>? rowStates)
+    {
+        ParsedLet parsed;
+        try
+        {
+            parsed = LetParser.Parse(formula);
+        }
+        catch (FormatException ex)
         {
             return new RefactorResult(
                 formula,
                 Array.Empty<RefactorInputRow>(),
+                Array.Empty<RefactorCalcBindingRow>(),
                 formula,
                 new RefactorDiagnostic(
-                    RefactorDiagnosticKind.ExistingLet,
-                    "Refactor on existing LET formulas is coming in PR 2 (spec 0008)."));
+                    RefactorDiagnosticKind.MalformedLet,
+                    $"Refactor can't parse this LET: {ex.Message}"));
         }
 
-        var rows = new List<RefactorInputRow>(rowStates.Count);
-        foreach (var rs in rowStates)
+        var valueBindings = parsed.Bindings.Where(b => !b.IsCalculation).ToList();
+        var calcBindings = parsed.Bindings.Where(b => b.IsCalculation).ToList();
+
+        // Step 1 — merge duplicate value bindings (first occurrence wins).
+        var merge = MergeValueBindings(valueBindings, activeSheet);
+
+        // Step 2 — walk calc binding RHSes and the body for new refs.
+        //   Refs already represented by a kept value binding (matched via
+        //   canonical FormulaRef) are skipped; everything else becomes an
+        //   auto-named Extracted row.
+        var existingRefs = new HashSet<FormulaRef>();
+        foreach (var survivor in merge.Survivors)
         {
-            if (!rs.Include) continue;
-            var rhs = rs.Source.DisplayAddress(activeSheet);
-            rows.Add(new RefactorInputRow(rs.Source, rs.Name, rhs));
+            var fr = TryParseSingleRef(survivor.RhsText, activeSheet);
+            if (fr != null) existingRefs.Add(fr);
         }
 
-        var let = Synthesise(formula, activeSheet, rows);
-        return new RefactorResult(formula, rows, let);
+        var usedNames = new HashSet<string>(
+            parsed.Bindings.Select(b => b.Name), StringComparer.OrdinalIgnoreCase);
+
+        var newRows = new List<RefactorInputRow>();
+        var seenNew = new HashSet<FormulaRef>();
+        var autoNameIndex = 1;
+
+        foreach (var calc in calcBindings)
+            ExtractNewRefs(calc.RhsText, activeSheet, existingRefs, seenNew, usedNames, ref autoNameIndex, newRows);
+        ExtractNewRefs(parsed.Body, activeSheet, existingRefs, seenNew, usedNames, ref autoNameIndex, newRows);
+
+        // Step 3 — build the existing-LET-value rows (in source order).
+        var existingValueRows = new List<RefactorInputRow>(merge.Survivors.Count);
+        foreach (var s in merge.Survivors)
+        {
+            merge.MergedFromBySurvivor.TryGetValue(s.Name, out var mergedFrom);
+            existingValueRows.Add(new RefactorInputRow(
+                Key: BuildExistingLetKey(s.Name),
+                Source: TryParseSingleRef(s.RhsText, activeSheet),
+                Name: s.Name,
+                Rhs: s.RhsText,
+                Origin: RefactorRowOrigin.ExistingLetValue,
+                MergedFrom: mergedFrom));
+        }
+
+        // Step 4 — combine and apply rowStates (rename / include / order).
+        var defaultRows = existingValueRows.Concat(newRows).ToList();
+        var finalRows = ApplyRowStates(defaultRows, rowStates);
+
+        // Step 5 — assemble the rewrite maps and synthesise.
+        var keptRows = finalRows.Where(r => r.IsIncluded).ToList();
+
+        var identifierSubs = BuildIdentifierSubstitutions(
+            valueBindings, merge, finalRows);
+
+        var rewrittenCalcs = RewriteCalcBindings(
+            calcBindings, activeSheet, keptRows, identifierSubs);
+
+        var synthesisedLet = BuildSynthesisedLet(
+            formula, activeSheet, keptRows, rewrittenCalcs,
+            isExistingLet: true, body: parsed.Body, identifierSubstitutions: identifierSubs);
+
+        return new RefactorResult(
+            formula,
+            keptRows.Select(r => r.Row).ToList(),
+            rewrittenCalcs,
+            synthesisedLet);
     }
 
-    private static string Synthesise(
-        string formula,
-        string activeSheet,
-        IReadOnlyList<RefactorInputRow> rows)
+    // ---------------- merge ----------------
+
+    private record MergeResult(
+        IReadOnlyList<LetBinding> Survivors,
+        IReadOnlyDictionary<string, string> SurvivorByOriginalName,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> MergedFromBySurvivor);
+
+    private static MergeResult MergeValueBindings(
+        IReadOnlyList<LetBinding> valueBindings,
+        string activeSheet)
     {
-        if (rows.Count == 0)
+        var survivors = new List<LetBinding>();
+        var survivorByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var survivorByKey = new Dictionary<string, LetBinding>(StringComparer.Ordinal);
+        var mergedFrom = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var vb in valueBindings)
         {
-            // No refs at all (or all dropped) — return the formula
-            // verbatim. The dialog can still open on an empty input set
-            // so the user sees that there's nothing to extract.
-            return formula;
+            var canon = CanonicalRhsKey(vb.RhsText, activeSheet);
+            if (survivorByKey.TryGetValue(canon, out var existing))
+            {
+                survivorByName[vb.Name] = existing.Name;
+                if (!mergedFrom.TryGetValue(existing.Name, out var list))
+                {
+                    list = new List<string>();
+                    mergedFrom[existing.Name] = list;
+                }
+                list.Add(vb.Name);
+            }
+            else
+            {
+                survivors.Add(vb);
+                survivorByName[vb.Name] = vb.Name;
+                survivorByKey[canon] = vb;
+            }
         }
 
-        var lookup = new Dictionary<FormulaRef, string>(rows.Count);
-        foreach (var row in rows)
-            lookup[row.Source] = row.Name;
+        return new MergeResult(
+            survivors,
+            survivorByName,
+            mergedFrom.ToDictionary(
+                kv => kv.Key,
+                kv => (IReadOnlyList<string>)kv.Value,
+                StringComparer.OrdinalIgnoreCase));
+    }
 
-        var body = CellRefExtractor.Rewrite(
-            StripLeadingEquals(formula), activeSheet, lookup);
+    /// <summary>
+    ///     Canonical key for value-binding merge. A single-ref RHS canonicalises
+    ///     to its <see cref="FormulaRef" />'s sheet-qualified display form
+    ///     (so <c>A1</c> and <c>$A$1</c> and <c>Sheet1!A1</c> on Sheet1 all
+    ///     collapse); anything else falls back to the trimmed literal text
+    ///     (numeric / string / boolean / bare identifier RHSes compare by
+    ///     value via string equality after trim).
+    /// </summary>
+    private static string CanonicalRhsKey(string rhsText, string activeSheet)
+    {
+        var fr = TryParseSingleRef(rhsText, activeSheet);
+        if (fr != null)
+            return "ref:" + BuildExtractedKey(fr, activeSheet);
+        return "lit:" + rhsText.Trim();
+    }
 
-        var bindings = rows
-            .Select(r => (r.Name, Value: r.Source.DisplayAddress(activeSheet)))
+    // ---------------- identifier substitutions ----------------
+
+    /// <summary>
+    ///     Builds the <c>originalName → replacement</c> map applied to calc
+    ///     bindings and the body. Three sources feed it:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             Merge survivors that were dropped by the user: the
+    ///             original RHS text replaces every reference to the
+    ///             survivor's original name (and to each merged-away
+    ///             name).
+    ///         </item>
+    ///         <item>
+    ///             Merge survivors that were kept but renamed: the new name
+    ///             replaces every reference to the original name and to
+    ///             each merged-away name.
+    ///         </item>
+    ///         <item>
+    ///             Merge survivors that were kept with their original name:
+    ///             references to merged-away names alone need rewriting to
+    ///             the survivor's name; references to the survivor stay
+    ///             as-is.
+    ///         </item>
+    ///     </list>
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> BuildIdentifierSubstitutions(
+        IReadOnlyList<LetBinding> originalValueBindings,
+        MergeResult merge,
+        IReadOnlyList<MaterialisedRow> finalRows)
+    {
+        var rowByKey = finalRows.ToDictionary(r => r.Row.Key, StringComparer.Ordinal);
+        var subs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var ovb in originalValueBindings)
+        {
+            var survivorName = merge.SurvivorByOriginalName[ovb.Name];
+            var survivorRow = rowByKey[BuildExistingLetKey(survivorName)];
+
+            string replacement;
+            if (!survivorRow.IsIncluded)
+            {
+                // Dropped — inline the survivor's original RHS text.
+                replacement = survivorRow.Row.Rhs;
+            }
+            else
+            {
+                replacement = survivorRow.Row.Name;
+                // No-op when the survivor's name didn't change AND this row
+                // is itself the survivor — body/calcs already reference it
+                // by that name.
+                if (string.Equals(replacement, ovb.Name, StringComparison.OrdinalIgnoreCase))
+                    continue;
+            }
+
+            subs[ovb.Name] = replacement;
+        }
+
+        return subs;
+    }
+
+    // ---------------- ref extraction (calc bindings + body) ----------------
+
+    private static void ExtractNewRefs(
+        string text,
+        string activeSheet,
+        HashSet<FormulaRef> existingRefs,
+        HashSet<FormulaRef> seenNew,
+        HashSet<string> usedNames,
+        ref int autoNameIndex,
+        List<RefactorInputRow> sink)
+    {
+        foreach (var fr in CellRefExtractor.Extract(text, activeSheet))
+        {
+            if (existingRefs.Contains(fr)) continue;
+            if (!seenNew.Add(fr)) continue;
+
+            string name;
+            while (true)
+            {
+                name = "input" + autoNameIndex;
+                autoNameIndex++;
+                if (!usedNames.Contains(name))
+                    break;
+            }
+            usedNames.Add(name);
+
+            sink.Add(new RefactorInputRow(
+                Key: BuildExtractedKey(fr, activeSheet),
+                Source: fr,
+                Name: name,
+                Rhs: fr.DisplayAddress(activeSheet),
+                Origin: RefactorRowOrigin.Extracted));
+        }
+    }
+
+    // ---------------- rowState materialisation ----------------
+
+    /// <summary>
+    ///     Pairs each engine-derived <see cref="RefactorInputRow" /> with
+    ///     the dialog's user-edited state. Captures the row's "current"
+    ///     <see cref="Name" /> and <see cref="IsIncluded" /> flag so the
+    ///     rewrite + synthesis passes can read them without re-keying
+    ///     against the input rowStates dictionary.
+    /// </summary>
+    private sealed record MaterialisedRow(RefactorInputRow Row, bool IsIncluded);
+
+    private static List<MaterialisedRow> ApplyRowStates(
+        IReadOnlyList<RefactorInputRow> defaultRows,
+        IReadOnlyList<RefactorRowState>? rowStates)
+    {
+        if (rowStates is null)
+            return defaultRows.Select(r => new MaterialisedRow(r, IsIncluded: true)).ToList();
+
+        var byKey = defaultRows.ToDictionary(r => r.Key, StringComparer.Ordinal);
+        var ordered = new List<MaterialisedRow>(rowStates.Count);
+        var consumed = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var rs in rowStates)
+        {
+            if (!byKey.TryGetValue(rs.Key, out var row)) continue;
+            consumed.Add(rs.Key);
+            // The dialog owns the binding name; the engine just forwards it
+            // (validation is enforced dialog-side).
+            ordered.Add(new MaterialisedRow(
+                row with { Name = rs.Name },
+                IsIncluded: rs.Include));
+        }
+
+        // Any rows the rowStates didn't mention (shouldn't happen in
+        // practice — the dialog tracks every row) are appended at the end
+        // in their default order, kept included so they aren't silently
+        // lost.
+        foreach (var row in defaultRows)
+            if (!consumed.Contains(row.Key))
+                ordered.Add(new MaterialisedRow(row, IsIncluded: true));
+
+        return ordered;
+    }
+
+    // ---------------- rewrite & synthesis ----------------
+
+    private static IReadOnlyList<RefactorCalcBindingRow> RewriteCalcBindings(
+        IReadOnlyList<LetBinding> calcBindings,
+        string activeSheet,
+        IReadOnlyList<MaterialisedRow> keptRows,
+        IReadOnlyDictionary<string, string> identifierSubs)
+    {
+        if (calcBindings.Count == 0)
+            return Array.Empty<RefactorCalcBindingRow>();
+
+        var refLookup = BuildFormulaRefLookup(keptRows);
+        var result = new List<RefactorCalcBindingRow>(calcBindings.Count);
+        foreach (var c in calcBindings)
+        {
+            var rewritten = RewriteText(c.RhsText, activeSheet, refLookup, identifierSubs);
+            result.Add(new RefactorCalcBindingRow(c.Name, rewritten));
+        }
+        return result;
+    }
+
+    private static IReadOnlyDictionary<FormulaRef, string> BuildFormulaRefLookup(
+        IReadOnlyList<MaterialisedRow> keptRows)
+    {
+        var dict = new Dictionary<FormulaRef, string>();
+        foreach (var r in keptRows)
+            if (r.Row.Source is { } src)
+                dict[src] = r.Row.Name;
+        return dict;
+    }
+
+    /// <summary>
+    ///     Runs the cell-ref rewrite (replacing in-scope <see cref="FormulaRef" />s
+    ///     with their kept binding names) followed by the identifier
+    ///     rewrite (renaming merged-away binding names or inlining the RHS
+    ///     of dropped existing-LET value bindings).
+    /// </summary>
+    private static string RewriteText(
+        string text,
+        string activeSheet,
+        IReadOnlyDictionary<FormulaRef, string> refLookup,
+        IReadOnlyDictionary<string, string> identifierSubs)
+    {
+        var afterRefs = refLookup.Count > 0
+            ? CellRefExtractor.Rewrite(text, activeSheet, refLookup)
+            : text;
+        if (identifierSubs.Count == 0)
+            return afterRefs;
+        return RewriteIdentifiers(afterRefs, identifierSubs);
+    }
+
+    // Identifier rewriter: substitutes whole-token identifiers from
+    // <paramref name="subs" /> while leaving strings, sheet/workbook
+    // qualifiers, and cell-shaped tokens alone. Cell refs in qualified
+    // form (e.g. <c>Sheet1!A1</c>) keep their pieces — the lookbehind
+    // class guards against renaming the <c>A1</c> tail of a sheet
+    // qualifier.
+    private static readonly Regex IdentifierTokenPattern = new(
+        // Lookbehind matches the same identifier-boundary characters
+        // CellRefExtractor uses, so we don't accidentally substitute the
+        // tail of a sheet-qualified ref (`Sheet1!A1` keeps its `A1`) or
+        // the row digits inside a numeric (`123` isn't an identifier
+        // anyway, but the negative lookbehind on '.' also prevents
+        // matching across decimal points).
+        @"(?<![A-Za-z0-9_.!:'\]#?])[A-Za-z_][A-Za-z0-9_.?]*",
+        RegexOptions.CultureInvariant);
+
+    private static string RewriteIdentifiers(
+        string text,
+        IReadOnlyDictionary<string, string> subs)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+
+        var sb = new StringBuilder(text.Length);
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (text[i] == '"')
+            {
+                var end = SkipString(text, i);
+                sb.Append(text, i, end - i);
+                i = end;
+                continue;
+            }
+
+            // Single-quoted sheet name / external workbook qualifier:
+            // copy through verbatim so identifiers inside the quotes
+            // aren't substituted.
+            if (text[i] == '\'')
+            {
+                var end = SkipSingleQuoted(text, i);
+                sb.Append(text, i, end - i);
+                i = end;
+                continue;
+            }
+
+            var nextQuote = IndexOfAny(text, i, '"', '\'');
+            var segEnd = nextQuote < 0 ? text.Length : nextQuote;
+            var segment = text.Substring(i, segEnd - i);
+            var rewritten = IdentifierTokenPattern.Replace(segment, m =>
+                subs.TryGetValue(m.Value, out var replacement) ? replacement : m.Value);
+            sb.Append(rewritten);
+            i = segEnd;
+        }
+        return sb.ToString();
+    }
+
+    private static int IndexOfAny(string text, int start, char a, char b)
+    {
+        for (var i = start; i < text.Length; i++)
+            if (text[i] == a || text[i] == b)
+                return i;
+        return -1;
+    }
+
+    private static int SkipString(string text, int openQuoteIndex)
+    {
+        var i = openQuoteIndex + 1;
+        while (i < text.Length)
+        {
+            if (text[i] == '"')
+            {
+                if (i + 1 < text.Length && text[i + 1] == '"')
+                {
+                    i += 2;
+                    continue;
+                }
+                return i + 1;
+            }
+            i++;
+        }
+        return text.Length;
+    }
+
+    private static int SkipSingleQuoted(string text, int openQuoteIndex)
+    {
+        var i = openQuoteIndex + 1;
+        while (i < text.Length)
+        {
+            if (text[i] == '\'')
+            {
+                if (i + 1 < text.Length && text[i + 1] == '\'')
+                {
+                    i += 2;
+                    continue;
+                }
+                return i + 1;
+            }
+            i++;
+        }
+        return text.Length;
+    }
+
+    // ---------------- LET synthesis ----------------
+
+    private static string BuildSynthesisedLet(
+        string originalFormula,
+        string activeSheet,
+        IReadOnlyList<MaterialisedRow> keptInputs,
+        IReadOnlyList<RefactorCalcBindingRow> rewrittenCalcs,
+        bool isExistingLet,
+        string? body,
+        IReadOnlyDictionary<string, string>? identifierSubstitutions)
+    {
+        // No work to do — nothing extracted and nothing merged.
+        if (!isExistingLet && keptInputs.Count == 0)
+            return originalFormula;
+
+        // An existing LET with zero kept inputs AND zero calc bindings
+        // collapses to its body — the dialog still synthesises a valid
+        // formula so the user can save (matches PR 1's "all dropped"
+        // behaviour).
+        if (isExistingLet && keptInputs.Count == 0 && rewrittenCalcs.Count == 0)
+        {
+            var rewrittenBody = RewriteText(
+                body!, activeSheet,
+                BuildFormulaRefLookup(keptInputs),
+                identifierSubstitutions ?? new Dictionary<string, string>());
+            return "=" + rewrittenBody;
+        }
+
+        var bindings = keptInputs
+            .Select(r => (r.Row.Name, Value: r.Row.Rhs))
+            .Concat(rewrittenCalcs.Select(c => (c.Name, c.RewrittenRhs)))
             .ToList();
+
+        string bodyText;
+        if (isExistingLet)
+        {
+            bodyText = RewriteText(
+                body!, activeSheet,
+                BuildFormulaRefLookup(keptInputs),
+                identifierSubstitutions ?? new Dictionary<string, string>());
+        }
+        else
+        {
+            // Non-LET: the original formula's content (sans leading '=') is
+            // the LET body, with cell refs rewritten to kept binding names.
+            bodyText = CellRefExtractor.Rewrite(
+                StripLeadingEquals(originalFormula),
+                activeSheet,
+                BuildFormulaRefLookup(keptInputs));
+        }
 
         var sb = new StringBuilder();
         sb.Append('=');
-        FormulaFormatter.AppendLet(sb, indent: 0, bindings, body);
+        FormulaFormatter.AppendLet(sb, indent: 0, bindings, bodyText);
         return sb.ToString();
+    }
+
+    // ---------------- keys & helpers ----------------
+
+    private static string BuildExtractedKey(FormulaRef fr, string activeSheet)
+    {
+        // DisplayAddress with the active sheet as host is unique per
+        // FormulaRef (spill suffix and range tail included), so it doubles
+        // as a stable string key the dialog can echo back via RefactorRowState.
+        return "ref:" + fr.DisplayAddress(activeSheet);
+    }
+
+    private static string BuildExistingLetKey(string bindingName)
+    {
+        return "name:" + bindingName;
+    }
+
+    /// <summary>
+    ///     If <paramref name="rhsText" /> consists of exactly one cell-shaped
+    ///     ref (single cell, range, or spill — optionally sheet- or
+    ///     workbook-qualified) and nothing else, returns that ref;
+    ///     otherwise null. Used to decide whether a value binding's RHS
+    ///     can be merged by canonical FormulaRef (vs literal-string fallback)
+    ///     and to populate <see cref="RefactorInputRow.Source" />.
+    /// </summary>
+    private static FormulaRef? TryParseSingleRef(string rhsText, string activeSheet)
+    {
+        if (string.IsNullOrWhiteSpace(rhsText)) return null;
+        var refs = CellRefExtractor.Extract(rhsText, activeSheet);
+        if (refs.Count != 1) return null;
+        // Verify the RHS is JUST that ref (no surrounding tokens or
+        // operators) by rewriting it to a sentinel and checking the
+        // remainder is whitespace.
+        var sentinel = "";
+        var probe = CellRefExtractor.Rewrite(
+            rhsText, activeSheet, new Dictionary<FormulaRef, string> { [refs[0]] = sentinel });
+        return probe.Trim() == sentinel ? refs[0] : null;
     }
 
     private static string StripLeadingEquals(string formula)

--- a/addin/lambda-boss/RefactorEngine.cs
+++ b/addin/lambda-boss/RefactorEngine.cs
@@ -7,7 +7,6 @@ namespace LambdaBoss;
 ///     Spec 0008 — the <c>/Refactor</c> entry point. Takes a formula and
 ///     the active cell's sheet, hoists every cell ref / range into its own
 ///     LET binding, and emits a tidy <c>=LET(...)</c>.
-///
 ///     PR 2 adds existing-LET handling. When the input is already a LET,
 ///     value bindings pre-populate the Inputs section; calculation bindings
 ///     populate the read-only Calculation-bindings section; value bindings
@@ -15,7 +14,6 @@ namespace LambdaBoss;
 ///     inside calculation bindings or the body are extracted as new input
 ///     rows; the synthesised LET emits all value bindings first (in dialog
 ///     order) followed by all calc bindings (in source order).
-///
 ///     The engine re-derives merge state on every <see cref="Recompute" />
 ///     call — the dialog only carries name / Include / order for each row
 ///     via <see cref="RefactorRowState" />, not the underlying merge graph,
@@ -24,6 +22,22 @@ namespace LambdaBoss;
 /// </summary>
 public static class RefactorEngine
 {
+    // Identifier rewriter: substitutes whole-token identifiers from
+    // <paramref name="subs" /> while leaving strings, sheet/workbook
+    // qualifiers, and cell-shaped tokens alone. Cell refs in qualified
+    // form (e.g. <c>Sheet1!A1</c>) keep their pieces — the lookbehind
+    // class guards against renaming the <c>A1</c> tail of a sheet
+    // qualifier.
+    private static readonly Regex IdentifierTokenPattern = new(
+        // Lookbehind matches the same identifier-boundary characters
+        // CellRefExtractor uses, so we don't accidentally substitute the
+        // tail of a sheet-qualified ref (`Sheet1!A1` keeps its `A1`) or
+        // the row digits inside a numeric (`123` isn't an identifier
+        // anyway, but the negative lookbehind on '.' also prevents
+        // matching across decimal points).
+        @"(?<![A-Za-z0-9_.!:'\]#?])[A-Za-z_][A-Za-z0-9_.?]*",
+        RegexOptions.CultureInvariant);
+
     /// <summary>
     ///     Runs the initial refactor over <paramref name="formula" />.
     ///     Existing LETs are parsed and merged/extracted per spec 0008;
@@ -35,7 +49,7 @@ public static class RefactorEngine
         if (formula is null) throw new ArgumentNullException(nameof(formula));
         if (activeSheet is null) throw new ArgumentNullException(nameof(activeSheet));
 
-        return RefactorInternal(formula, activeSheet, rowStates: null);
+        return RefactorInternal(formula, activeSheet, null);
     }
 
     /// <summary>
@@ -83,11 +97,11 @@ public static class RefactorEngine
         foreach (var fr in extracted)
         {
             defaultRows.Add(new RefactorInputRow(
-                Key: BuildExtractedKey(fr, activeSheet),
-                Source: fr,
-                Name: $"input{nameIndex}",
-                Rhs: fr.DisplayAddress(activeSheet),
-                Origin: RefactorRowOrigin.Extracted));
+                BuildExtractedKey(fr, activeSheet),
+                fr,
+                $"input{nameIndex}",
+                fr.DisplayAddress(activeSheet),
+                RefactorRowOrigin.Extracted));
             nameIndex++;
         }
 
@@ -96,7 +110,7 @@ public static class RefactorEngine
 
         var synthesisedLet = BuildSynthesisedLet(
             formula, activeSheet, keptRows, Array.Empty<RefactorCalcBindingRow>(),
-            isExistingLet: false, body: null, identifierSubstitutions: null);
+            false, null, null);
 
         return new RefactorResult(
             formula,
@@ -163,12 +177,12 @@ public static class RefactorEngine
         {
             merge.MergedFromBySurvivor.TryGetValue(s.Name, out var mergedFrom);
             existingValueRows.Add(new RefactorInputRow(
-                Key: BuildExistingLetKey(s.Name),
-                Source: TryParseSingleRef(s.RhsText, activeSheet),
-                Name: s.Name,
-                Rhs: s.RhsText,
-                Origin: RefactorRowOrigin.ExistingLetValue,
-                MergedFrom: mergedFrom));
+                BuildExistingLetKey(s.Name),
+                TryParseSingleRef(s.RhsText, activeSheet),
+                s.Name,
+                s.RhsText,
+                RefactorRowOrigin.ExistingLetValue,
+                mergedFrom));
         }
 
         // Step 4 — combine and apply rowStates (rename / include / order).
@@ -186,7 +200,7 @@ public static class RefactorEngine
 
         var synthesisedLet = BuildSynthesisedLet(
             formula, activeSheet, keptRows, rewrittenCalcs,
-            isExistingLet: true, body: parsed.Body, identifierSubstitutions: identifierSubs);
+            true, parsed.Body, identifierSubs);
 
         return new RefactorResult(
             formula,
@@ -194,13 +208,6 @@ public static class RefactorEngine
             rewrittenCalcs,
             synthesisedLet);
     }
-
-    // ---------------- merge ----------------
-
-    private record MergeResult(
-        IReadOnlyList<LetBinding> Survivors,
-        IReadOnlyDictionary<string, string> SurvivorByOriginalName,
-        IReadOnlyDictionary<string, IReadOnlyList<string>> MergedFromBySurvivor);
 
     private static MergeResult MergeValueBindings(
         IReadOnlyList<LetBinding> valueBindings,
@@ -219,9 +226,10 @@ public static class RefactorEngine
                 survivorByName[vb.Name] = existing.Name;
                 if (!mergedFrom.TryGetValue(existing.Name, out var list))
                 {
-                    list = new List<string>();
+                    list = [];
                     mergedFrom[existing.Name] = list;
                 }
+
                 list.Add(vb.Name);
             }
             else
@@ -341,34 +349,24 @@ public static class RefactorEngine
                 if (!usedNames.Contains(name))
                     break;
             }
+
             usedNames.Add(name);
 
             sink.Add(new RefactorInputRow(
-                Key: BuildExtractedKey(fr, activeSheet),
-                Source: fr,
-                Name: name,
-                Rhs: fr.DisplayAddress(activeSheet),
-                Origin: RefactorRowOrigin.Extracted));
+                BuildExtractedKey(fr, activeSheet),
+                fr,
+                name,
+                fr.DisplayAddress(activeSheet),
+                RefactorRowOrigin.Extracted));
         }
     }
-
-    // ---------------- rowState materialisation ----------------
-
-    /// <summary>
-    ///     Pairs each engine-derived <see cref="RefactorInputRow" /> with
-    ///     the dialog's user-edited state. Captures the row's "current"
-    ///     <see cref="Name" /> and <see cref="IsIncluded" /> flag so the
-    ///     rewrite + synthesis passes can read them without re-keying
-    ///     against the input rowStates dictionary.
-    /// </summary>
-    private sealed record MaterialisedRow(RefactorInputRow Row, bool IsIncluded);
 
     private static List<MaterialisedRow> ApplyRowStates(
         IReadOnlyList<RefactorInputRow> defaultRows,
         IReadOnlyList<RefactorRowState>? rowStates)
     {
         if (rowStates is null)
-            return defaultRows.Select(r => new MaterialisedRow(r, IsIncluded: true)).ToList();
+            return defaultRows.Select(r => new MaterialisedRow(r, true)).ToList();
 
         var byKey = defaultRows.ToDictionary(r => r.Key, StringComparer.Ordinal);
         var ordered = new List<MaterialisedRow>(rowStates.Count);
@@ -381,7 +379,7 @@ public static class RefactorEngine
             // (validation is enforced dialog-side).
             ordered.Add(new MaterialisedRow(
                 row with { Name = rs.Name },
-                IsIncluded: rs.Include));
+                rs.Include));
         }
 
         // Any rows the rowStates didn't mention (shouldn't happen in
@@ -390,7 +388,7 @@ public static class RefactorEngine
         // lost.
         foreach (var row in defaultRows)
             if (!consumed.Contains(row.Key))
-                ordered.Add(new MaterialisedRow(row, IsIncluded: true));
+                ordered.Add(new MaterialisedRow(row, true));
 
         return ordered;
     }
@@ -413,6 +411,7 @@ public static class RefactorEngine
             var rewritten = RewriteText(c.RhsText, activeSheet, refLookup, identifierSubs);
             result.Add(new RefactorCalcBindingRow(c.Name, rewritten));
         }
+
         return result;
     }
 
@@ -445,22 +444,6 @@ public static class RefactorEngine
             return afterRefs;
         return RewriteIdentifiers(afterRefs, identifierSubs);
     }
-
-    // Identifier rewriter: substitutes whole-token identifiers from
-    // <paramref name="subs" /> while leaving strings, sheet/workbook
-    // qualifiers, and cell-shaped tokens alone. Cell refs in qualified
-    // form (e.g. <c>Sheet1!A1</c>) keep their pieces — the lookbehind
-    // class guards against renaming the <c>A1</c> tail of a sheet
-    // qualifier.
-    private static readonly Regex IdentifierTokenPattern = new(
-        // Lookbehind matches the same identifier-boundary characters
-        // CellRefExtractor uses, so we don't accidentally substitute the
-        // tail of a sheet-qualified ref (`Sheet1!A1` keeps its `A1`) or
-        // the row digits inside a numeric (`123` isn't an identifier
-        // anyway, but the negative lookbehind on '.' also prevents
-        // matching across decimal points).
-        @"(?<![A-Za-z0-9_.!:'\]#?])[A-Za-z_][A-Za-z0-9_.?]*",
-        RegexOptions.CultureInvariant);
 
     private static string RewriteIdentifiers(
         string text,
@@ -499,6 +482,7 @@ public static class RefactorEngine
             sb.Append(rewritten);
             i = segEnd;
         }
+
         return sb.ToString();
     }
 
@@ -522,10 +506,13 @@ public static class RefactorEngine
                     i += 2;
                     continue;
                 }
+
                 return i + 1;
             }
+
             i++;
         }
+
         return text.Length;
     }
 
@@ -541,10 +528,13 @@ public static class RefactorEngine
                     i += 2;
                     continue;
                 }
+
                 return i + 1;
             }
+
             i++;
         }
+
         return text.Length;
     }
 
@@ -601,7 +591,7 @@ public static class RefactorEngine
 
         var sb = new StringBuilder();
         sb.Append('=');
-        FormulaFormatter.AppendLet(sb, indent: 0, bindings, bodyText);
+        FormulaFormatter.AppendLet(sb, 0, bindings, bodyText);
         return sb.ToString();
     }
 
@@ -647,4 +637,22 @@ public static class RefactorEngine
         var trimmed = formula.TrimStart();
         return trimmed.StartsWith("=", StringComparison.Ordinal) ? trimmed[1..] : trimmed;
     }
+
+    // ---------------- merge ----------------
+
+    private record MergeResult(
+        IReadOnlyList<LetBinding> Survivors,
+        IReadOnlyDictionary<string, string> SurvivorByOriginalName,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> MergedFromBySurvivor);
+
+    // ---------------- rowState materialisation ----------------
+
+    /// <summary>
+    ///     Pairs each engine-derived <see cref="RefactorInputRow" /> with
+    ///     the dialog's user-edited state. Captures the row's "current"
+    ///     Name and <see cref="IsIncluded" /> flag so the
+    ///     rewrite + synthesis passes can read them without re-keying
+    ///     against the input rowStates dictionary.
+    /// </summary>
+    private sealed record MaterialisedRow(RefactorInputRow Row, bool IsIncluded);
 }

--- a/addin/lambda-boss/RefactorTypes.cs
+++ b/addin/lambda-boss/RefactorTypes.cs
@@ -1,53 +1,87 @@
 namespace LambdaBoss;
 
 /// <summary>
-///     Spec 0008 / PR 1 — types shared between <see cref="RefactorEngine" />
-///     and the <c>/Refactor</c> slash command. The tracer slice only needs
-///     the input-row and result records; promotable-row and calc-binding
-///     records arrive in PR 2/3.
+///     Where an input row came from. <see cref="Extracted" /> is a cell ref
+///     the walker pulled out of the source formula's body or a calculation
+///     binding's RHS. <see cref="ExistingLetValue" /> is a value binding
+///     already present in an existing LET — the binding's name and RHS are
+///     pre-populated and the row can still be renamed, reordered, dropped,
+///     or marked as the survivor of a merge.
+/// </summary>
+public enum RefactorRowOrigin
+{
+    Extracted,
+    ExistingLetValue
+}
+
+/// <summary>
+///     Spec 0008 — one row in the dialog's Inputs section. PR 2 widens the
+///     PR 1 record: <see cref="Source" /> is now nullable (existing LET
+///     value bindings whose RHS isn't a single ref carry only a binding
+///     name, not a <see cref="FormulaRef" />); <see cref="Key" /> is the
+///     stable identity the dialog uses to pass state back via
+///     <see cref="RefactorRowState" />; <see cref="Origin" /> tells the
+///     dialog whether to badge the row; <see cref="MergedFrom" /> lists
+///     the original binding names that were merged into this row (so the
+///     dialog can show a "merged ← b" note next to the survivor).
 /// </summary>
 public sealed record RefactorInputRow(
-    FormulaRef Source,
+    string Key,
+    FormulaRef? Source,
     string Name,
-    string Rhs);
+    string Rhs,
+    RefactorRowOrigin Origin,
+    IReadOnlyList<string>? MergedFrom = null);
+
+/// <summary>
+///     Spec 0008 / PR 2 — a calculation binding from an existing LET, after
+///     the engine has rewritten its RHS to use the final input-binding
+///     names. Read-only in the dialog (name + RHS); kept in original
+///     source order in the synthesised LET (emitted after all value
+///     bindings).
+/// </summary>
+public sealed record RefactorCalcBindingRow(
+    string Name,
+    string RewrittenRhs);
 
 /// <summary>
 ///     User's per-row state passed back into
-///     <see cref="RefactorEngine.Recompute" />. PR 1 carries just the
-///     binding name and Include flag — reorder happens dialog-side by
-///     resequencing the list before the call. <see cref="Source" />
-///     identifies the row so the engine can map it back onto the
-///     extracted refs (which the engine re-derives from the formula on
-///     every recompute).
+///     <see cref="RefactorEngine.Recompute" />. PR 2 keys rows by
+///     <see cref="Key" /> (the matching <see cref="RefactorInputRow.Key" />)
+///     instead of <see cref="FormulaRef" /> so rows without a single-ref
+///     source (existing-LET value bindings whose RHS is a literal or named
+///     range) can be tracked too. The dialog produces the row order by
+///     resequencing this list before the call.
 /// </summary>
 public sealed record RefactorRowState(
-    FormulaRef Source,
+    string Key,
     string Name,
     bool Include = true);
 
 /// <summary>
 ///     The engine's output. <see cref="OriginalFormula" /> is the formula
 ///     text passed in (handy for the dialog header). <see cref="Inputs" />
-///     is the in-dialog-order list of input rows; PR 1 always emits them
-///     in first-seen ref order on the initial call.
-///     <see cref="SynthesisedLet" /> is the formatted <c>=LET(...)</c>
-///     text ready to write back to the active cell on Save (or the
-///     unchanged formula when every row was dropped).
-///     <see cref="Diagnostic" /> is non-null when the engine refused
-///     (PR 1: <c>ExistingLet</c>); in that case <see cref="Inputs" /> is
-///     empty and <see cref="SynthesisedLet" /> is the original formula
-///     unchanged.
+///     is the in-dialog-order list of input rows. <see cref="CalcBindings" />
+///     carries the rewritten calculation bindings from an existing LET
+///     (empty for non-LET formulas). <see cref="SynthesisedLet" /> is the
+///     formatted <c>=LET(...)</c> text ready to write back to the active
+///     cell on Save (or the unchanged formula when there's nothing to
+///     refactor). <see cref="Diagnostic" /> is non-null when the engine
+///     refused (PR 2: <c>MalformedLet</c>); in that case
+///     <see cref="Inputs" /> and <see cref="CalcBindings" /> are empty and
+///     <see cref="SynthesisedLet" /> is the original formula unchanged.
 /// </summary>
 public sealed record RefactorResult(
     string OriginalFormula,
     IReadOnlyList<RefactorInputRow> Inputs,
+    IReadOnlyList<RefactorCalcBindingRow> CalcBindings,
     string SynthesisedLet,
     RefactorDiagnostic? Diagnostic = null);
 
 /// <summary>
-///     A refusal reason. PR 1 only emits <see cref="RefactorDiagnosticKind.ExistingLet" />.
-///     PR 2 removes that case; further PRs add new kinds as needed
-///     (e.g. malformed formula).
+///     A refusal reason. PR 2 emits only <see cref="RefactorDiagnosticKind.MalformedLet" />
+///     (PR 1's <c>ExistingLet</c> refusal is gone — the engine now handles
+///     existing LETs). Further PRs add new kinds as needed.
 /// </summary>
 public sealed record RefactorDiagnostic(
     RefactorDiagnosticKind Kind,
@@ -56,8 +90,10 @@ public sealed record RefactorDiagnostic(
 public enum RefactorDiagnosticKind
 {
     /// <summary>
-    ///     The active cell already holds a <c>=LET(...)</c>. PR 1 refuses
-    ///     and instructs the user to wait for PR 2.
+    ///     The active cell starts with <c>=LET(</c> but <see cref="LetParser.Parse" />
+    ///     couldn't tokenise it (unbalanced parens, odd-arg count, invalid
+    ///     binding name). The slash command surfaces the message instead of
+    ///     opening the dialog.
     /// </summary>
-    ExistingLet
+    MalformedLet
 }

--- a/addin/lambda-boss/UI/RefactorToLetWindow.xaml
+++ b/addin/lambda-boss/UI/RefactorToLetWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:dd="urn:gong-wpf-dragdrop"
         Title="Lambda Boss — Refactor to LET"
-        Width="640" Height="560"
+        Width="640" Height="640"
         WindowStyle="ToolWindow"
         ShowInTaskbar="True"
         Topmost="True"
@@ -13,6 +13,8 @@
 
     <Grid Margin="12">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -88,6 +90,16 @@
                                           Cursor="Hand"
                                           ToolTip="Uncheck to leave this ref inline in the LET body" />
                                 <TextBlock DockPanel.Dock="Right"
+                                           Text="{Binding BadgeText}"
+                                           Visibility="{Binding BadgeVisibility}"
+                                           Foreground="#9cdcfe"
+                                           FontFamily="Consolas"
+                                           FontSize="11"
+                                           FontStyle="Italic"
+                                           VerticalAlignment="Center"
+                                           Margin="8,0,0,0"
+                                           ToolTip="{Binding BadgeTooltip}" />
+                                <TextBlock DockPanel.Dock="Right"
                                            Text="{Binding Rhs}"
                                            Foreground="{Binding RhsBrush}"
                                            FontFamily="Consolas"
@@ -117,7 +129,52 @@
             </ScrollViewer>
         </Border>
 
-        <Grid Grid.Row="4" Margin="0,12,0,0">
+        <TextBlock x:Name="CalcBindingsHeader"
+                   Grid.Row="4"
+                   Text="Calculation bindings"
+                   FontSize="13"
+                   FontWeight="Bold"
+                   Foreground="#dcdcaa"
+                   Margin="0,12,0,4"
+                   Visibility="Collapsed" />
+
+        <Border x:Name="CalcBindingsBorder"
+                Grid.Row="5"
+                Background="#252526"
+                BorderBrush="#3e3e3e"
+                BorderThickness="1"
+                MaxHeight="120"
+                Visibility="Collapsed">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="CalcBindingsList">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <DockPanel Margin="4,3">
+                                <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                                <TextBlock DockPanel.Dock="Left"
+                                           Text="{Binding Name}"
+                                           Foreground="#9cdcfe"
+                                           FontFamily="Consolas"
+                                           FontSize="13"
+                                           VerticalAlignment="Center"
+                                           MinWidth="120"
+                                           Margin="0,0,8,0" />
+                                <TextBlock Text="{Binding RewrittenRhs}"
+                                           Foreground="#cccccc"
+                                           FontFamily="Consolas"
+                                           FontSize="12"
+                                           VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis"
+                                           ToolTip="{Binding RewrittenRhs}" />
+                                <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
+                            </DockPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
+        <Grid Grid.Row="6" Margin="0,12,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -145,7 +202,7 @@
                      HorizontalScrollBarVisibility="Auto" />
         </Grid>
 
-        <DockPanel Grid.Row="5" Margin="0,12,0,0">
+        <DockPanel Grid.Row="7" Margin="0,12,0,0">
             <Button x:Name="CancelButton"
                     DockPanel.Dock="Right"
                     Content="Cancel"

--- a/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
+++ b/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
@@ -10,21 +10,22 @@ using System.Windows.Media;
 namespace LambdaBoss.UI;
 
 /// <summary>
-///     Spec 0008 / PR 1 — the <c>/Refactor</c> dialog. Shows the active
-///     cell's original formula, the engine-extracted input bindings (with
-///     editable names, Include checkbox, and drag/Alt+Up-Down reorder),
-///     and a live preview of the synthesised LET. Save returns the
-///     preview text via <see cref="SavedFormula" />; Cancel discards.
+///     Spec 0008 — the <c>/Refactor</c> dialog. Shows the active cell's
+///     original formula, the engine-extracted / existing-LET input rows
+///     (with editable names, Include checkbox, drag + Alt+Up/Down reorder),
+///     a read-only Calculation-bindings section (PR 2+), and a live
+///     preview of the synthesised LET. Save returns the preview text via
+///     <see cref="SavedFormula" />; Cancel discards.
 ///
 ///     The code-behind is intentionally thin: every row-state change
 ///     (rename, Include toggle, reorder) calls back into the supplied
 ///     <c>recompute</c> delegate (which wraps
 ///     <see cref="RefactorEngine.Recompute" />), and the result replaces
-///     the preview + the row collection in place. Live name validation
-///     gates the Save button via per-row canonicality (mirrors
-///     <see cref="GatherWindow" />'s pattern but without the engine-side
-///     collision-suffix dance — /Refactor is a one-shot pass, so the
-///     dialog enforces both shape and cross-row uniqueness up front).
+///     the preview + the calc-binding list in place. Row Keys (not
+///     <c>FormulaRef</c>s) drive the identity round-trip with the engine
+///     so existing-LET value bindings whose RHS isn't a single cell ref
+///     (e.g. a literal or a named range) can be tracked alongside
+///     extracted refs.
 /// </summary>
 public partial class RefactorToLetWindow
 {
@@ -36,6 +37,11 @@ public partial class RefactorToLetWindow
 
     private readonly Func<IReadOnlyList<RefactorRowState>, RefactorResult> _recompute;
     private readonly ObservableCollection<RefactorInputRowVm> _rows = [];
+    private readonly ObservableCollection<RefactorCalcBindingVm> _calcRows = [];
+    // Calc binding names are read-only in the dialog but they still occupy
+    // the LET's name namespace — Inputs are flagged invalid when they
+    // collide with one.
+    private IReadOnlyList<string> _calcBindingNames = Array.Empty<string>();
 
     private RefactorResult _result;
     // Reentrancy guard: rebuilding the row list during a Recompute fires
@@ -55,9 +61,12 @@ public partial class RefactorToLetWindow
         OriginalFormulaText.Text = initial.OriginalFormula;
         PreviewText.Text = initial.SynthesisedLet;
 
+        _calcBindingNames = initial.CalcBindings.Select(c => c.Name).ToList();
         BuildRowsFromInputs(initial.Inputs);
+        UpdateCalcBindings(initial.CalcBindings);
         _rows.CollectionChanged += Rows_CollectionChanged;
         InputsList.ItemsSource = _rows;
+        CalcBindingsList.ItemsSource = _calcRows;
 
         UpdateSaveButtonEnabled(RevalidateNames());
     }
@@ -152,6 +161,17 @@ public partial class RefactorToLetWindow
         }
     }
 
+    private void UpdateCalcBindings(IReadOnlyList<RefactorCalcBindingRow> calcBindings)
+    {
+        _calcRows.Clear();
+        foreach (var c in calcBindings)
+            _calcRows.Add(new RefactorCalcBindingVm(c.Name, c.RewrittenRhs));
+
+        var show = calcBindings.Count > 0;
+        CalcBindingsHeader.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+        CalcBindingsBorder.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+    }
+
     private void Rows_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         // Reorder via drag/drop or Alt+Up/Down fires Move; rerun the
@@ -174,7 +194,7 @@ public partial class RefactorToLetWindow
     private void RecomputeAndRefresh()
     {
         var rowStates = _rows
-            .Select(r => new RefactorRowState(r.Source, r.Name, r.Include))
+            .Select(r => new RefactorRowState(r.Key, r.Name, r.Include))
             .ToList();
 
         var newResult = _recompute(rowStates);
@@ -186,6 +206,7 @@ public partial class RefactorToLetWindow
         {
             _result = newResult;
             PreviewText.Text = newResult.SynthesisedLet;
+            UpdateCalcBindings(newResult.CalcBindings);
         }
         finally
         {
@@ -195,9 +216,10 @@ public partial class RefactorToLetWindow
 
     /// <summary>
     ///     Stamps each row's <see cref="RefactorInputRowVm.IsNameValid" />
-    ///     based on per-row canonicality (shape + non-reserved) AND
-    ///     cross-row uniqueness among included rows. Returns true when
-    ///     every included row is valid AND no duplicates exist.
+    ///     based on per-row canonicality (shape + non-reserved), cross-row
+    ///     uniqueness among included rows, AND collision with calc binding
+    ///     names. Returns true when every included row is valid AND no
+    ///     duplicates exist.
     /// </summary>
     private bool RevalidateNames()
     {
@@ -207,6 +229,8 @@ public partial class RefactorToLetWindow
             .Where(g => g.Count() > 1)
             .SelectMany(g => g)
             .ToHashSet();
+
+        var calcNameSet = new HashSet<string>(_calcBindingNames, StringComparer.OrdinalIgnoreCase);
 
         var allValid = true;
         foreach (var vm in _rows)
@@ -219,7 +243,8 @@ public partial class RefactorToLetWindow
             else
             {
                 var shapeOk = ExcelNameValidator.Validate(vm.Name).IsValid;
-                valid = shapeOk && !dupes.Contains(vm);
+                var collidesWithCalc = calcNameSet.Contains(vm.Name);
+                valid = shapeOk && !dupes.Contains(vm) && !collidesWithCalc;
                 if (!valid) allValid = false;
             }
             vm.IsNameValid = valid;
@@ -229,10 +254,15 @@ public partial class RefactorToLetWindow
 
     private void UpdateSaveButtonEnabled(bool allValid)
     {
-        SaveButton.IsEnabled = allValid && _rows.Any(r => r.Include);
+        // An existing LET with every input dropped still produces a valid
+        // formula (the bare body), so Save stays enabled when calc
+        // bindings exist OR at least one row is kept.
+        var hasKeptRows = _rows.Any(r => r.Include);
+        var hasCalcBindings = _calcBindingNames.Count > 0;
+        SaveButton.IsEnabled = allValid && (hasKeptRows || hasCalcBindings);
         if (!allValid)
             StatusText.Text = InvalidNameStatusText;
-        else if (!_rows.Any(r => r.Include))
+        else if (!hasKeptRows && !hasCalcBindings)
             StatusText.Text = "No bindings selected — nothing to refactor";
         else
             StatusText.Text = DefaultStatusText;
@@ -240,11 +270,13 @@ public partial class RefactorToLetWindow
 }
 
 /// <summary>
-///     Row view-model bound to <see cref="RefactorToLetWindow" />'s
-///     inputs list. Carries the row's <see cref="Source" /> identity and
-///     the user-editable <see cref="Name" /> + <see cref="Include" />.
-///     <see cref="IsNameValid" /> is set by the dialog on every
-///     validation pass and drives the red-border on the Name TextBox.
+///     Row view-model bound to <see cref="RefactorToLetWindow" />'s inputs
+///     list. Carries the row's <see cref="Key" /> identity (used to round-
+///     trip user state back to the engine via <see cref="RefactorRowState" />),
+///     the user-editable <see cref="Name" /> + <see cref="Include" />, and
+///     the merge-survivor <see cref="BadgeText" /> when applicable.
+///     <see cref="IsNameValid" /> is set by the dialog on every validation
+///     pass and drives the red-border on the Name TextBox.
 /// </summary>
 public class RefactorInputRowVm : INotifyPropertyChanged
 {
@@ -269,13 +301,31 @@ public class RefactorInputRowVm : INotifyPropertyChanged
 
     public RefactorInputRowVm(RefactorInputRow input)
     {
-        Source = input.Source;
+        Key = input.Key;
         _name = input.Name;
         Rhs = input.Rhs;
+        if (input.MergedFrom is { Count: > 0 })
+        {
+            BadgeText = "merged ← " + string.Join(", ", input.MergedFrom);
+            BadgeTooltip =
+                "This binding's RHS matched " +
+                string.Join(", ", input.MergedFrom) +
+                "; refs to those names were rewritten to use this one.";
+            BadgeVisibility = Visibility.Visible;
+        }
+        else
+        {
+            BadgeText = string.Empty;
+            BadgeTooltip = string.Empty;
+            BadgeVisibility = Visibility.Collapsed;
+        }
     }
 
-    public FormulaRef Source { get; }
+    public string Key { get; }
     public string Rhs { get; }
+    public string BadgeText { get; }
+    public string BadgeTooltip { get; }
+    public Visibility BadgeVisibility { get; }
 
     public string Name
     {
@@ -324,3 +374,9 @@ public class RefactorInputRowVm : INotifyPropertyChanged
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
     }
 }
+
+/// <summary>
+///     Read-only view-model for a calc binding in the dialog's
+///     Calculation-bindings section.
+/// </summary>
+public sealed record RefactorCalcBindingVm(string Name, string RewrittenRhs);

--- a/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
+++ b/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
@@ -16,7 +16,6 @@ namespace LambdaBoss.UI;
 ///     a read-only Calculation-bindings section (PR 2+), and a live
 ///     preview of the synthesised LET. Save returns the preview text via
 ///     <see cref="SavedFormula" />; Cancel discards.
-///
 ///     The code-behind is intentionally thin: every row-state change
 ///     (rename, Include toggle, reorder) calls back into the supplied
 ///     <c>recompute</c> delegate (which wraps
@@ -35,15 +34,17 @@ public partial class RefactorToLetWindow
     private const string InvalidNameStatusText =
         "Fix invalid names before saving";
 
-    private readonly Func<IReadOnlyList<RefactorRowState>, RefactorResult> _recompute;
-    private readonly ObservableCollection<RefactorInputRowVm> _rows = [];
-    private readonly ObservableCollection<RefactorCalcBindingVm> _calcRows = [];
     // Calc binding names are read-only in the dialog but they still occupy
     // the LET's name namespace — Inputs are flagged invalid when they
     // collide with one.
-    private IReadOnlyList<string> _calcBindingNames = Array.Empty<string>();
+    private readonly IReadOnlyList<string> _calcBindingNames;
+    private readonly ObservableCollection<RefactorCalcBindingVm> _calcRows = [];
+
+    private readonly Func<IReadOnlyList<RefactorRowState>, RefactorResult> _recompute;
+    private readonly ObservableCollection<RefactorInputRowVm> _rows = [];
 
     private RefactorResult _result;
+
     // Reentrancy guard: rebuilding the row list during a Recompute fires
     // INotifyPropertyChanged on each VM, which would re-enter the change
     // handler. The guard short-circuits the nested calls so a single
@@ -237,9 +238,7 @@ public partial class RefactorToLetWindow
         {
             bool valid;
             if (!vm.Include)
-            {
                 valid = true;
-            }
             else
             {
                 var shapeOk = ExcelNameValidator.Validate(vm.Name).IsValid;
@@ -247,8 +246,10 @@ public partial class RefactorToLetWindow
                 valid = shapeOk && !dupes.Contains(vm) && !collidesWithCalc;
                 if (!valid) allValid = false;
             }
+
             vm.IsNameValid = valid;
         }
+
         return allValid;
     }
 


### PR DESCRIPTION
## Summary

- Removes the PR 1 existing-LET refusal. `/Refactor` now parses an existing `=LET(...)` via `LetParser`, treats each value binding as an Inputs-section row, extracts new refs from calculation bindings and the body, merges duplicate value bindings (first name wins, references rewritten), and emits the synthesised LET with all value bindings first (dialog order) followed by all calc bindings (original source order).
- Dialog gains a read-only **Calculation bindings** section under the inputs, plus a `merged ← b` badge on merge survivors. Row identity moves from `FormulaRef` to a stable string `Key` so existing-LET value bindings whose RHS isn't a single ref (literals, named ranges) are trackable alongside extracted refs.
- ISOMITTED wrappers survive verbatim; cell refs inside `IF(ISOMITTED(...))` default expressions are extracted via the normal walk — no special-case code. `Refactor_ExistingLet_IsomittedWrapper_Survives_AndRefsInDefaultExtracted` covers this.
- PR 1's `ExistingLet` diagnostic is replaced by `MalformedLet`, surfaced when `LetParser.Parse` throws on a syntactically broken LET (unbalanced parens, etc.).

## Test plan

- [x] `dotnet test addin/lambda-boss.Tests/lambda-boss.Tests.csproj` — 958 / 958 passing (26 RefactorEngineTests, including 13 new for the existing-LET path)
- [x] `dotnet test addin/lambda-boss.AddinTests/lambda-boss.AddinTests.csproj` — 504 / 504 passing
- [x] Manual Excel smoke (from issue body): paste `=LET(a, A1, b, A1, getMax, MAX(B1:B5), IF(a<10, getMax, b))`, run `/Refactor`, save, confirm the resulting LET evaluates identically and has the expected shape (single `a` binding with `merged ← b` badge, `B1:B5` hoisted as `input1`, `getMax` rewritten to `MAX(input1)`)
- [x] Manual Excel smoke: paste `=LET(input1, A1, input1 + B1)`, run `/Refactor`, confirm the new B1 ref is auto-named `input2` (allocator skips numbers already in use)

## Reference

- Plan: [plans/0008-refactor-to-let.md § PR 2](../blob/main/plans/0008-refactor-to-let.md)
- Tracking: #201

Closes #203