### PR TITLE
Refactor to LET — PR 3: promotable named ranges + external refs (spec 0008)

### DIFF
--- a/addin/lambda-boss.Tests/RefactorEngineTests.cs
+++ b/addin/lambda-boss.Tests/RefactorEngineTests.cs
@@ -451,4 +451,201 @@ public class RefactorEngineTests
     {
         return new string(s.Where(c => !char.IsWhiteSpace(c)).ToArray());
     }
+
+    // ---------- PR 3 — promotables: named ranges + external refs ----------
+
+    /// <summary>In-memory <see cref="IWorkbookContext" /> stub for tests.</summary>
+    private sealed class StubContext : IWorkbookContext
+    {
+        public StubContext(params (string Name, string RefersTo)[] entries)
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (n, r) in entries) dict[n] = r;
+            WorkbookNames = dict;
+        }
+
+        public IReadOnlyDictionary<string, string> WorkbookNames { get; }
+    }
+
+    [Fact]
+    public void Refactor_NamedRange_AppearsAsPromotable_WithOccurrenceCount()
+    {
+        var ctx = new StubContext(("Tax_Rate", "=0.2"));
+        var result = RefactorEngine.Refactor("=A1 * Tax_Rate + Tax_Rate", Sheet, ctx);
+
+        Assert.Null(result.Diagnostic);
+        var promotable = Assert.Single(result.Promotables);
+        Assert.Equal(RefactorPromotableKind.NamedRange, promotable.Kind);
+        Assert.Equal("Tax_Rate", promotable.Token);
+        Assert.Equal(2, promotable.Occurrences);
+
+        // Un-promoted: stays inline; only A1 becomes a binding.
+        var input = Assert.Single(result.Inputs);
+        Assert.Equal("A1", input.Rhs);
+        Assert.Contains("input1 * Tax_Rate + Tax_Rate", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_NamedRange_LambdaName_IsExcludedFromPromotables()
+    {
+        // Defined name 'MyLambda' resolves to =LAMBDA(...) — should be
+        // skipped, regardless of whether the formula has a trailing '('.
+        var ctx = new StubContext(
+            ("MyLambda", "=LAMBDA(x, x + 1)"),
+            ("Tax_Rate", "=0.2"));
+
+        var withCall = RefactorEngine.Refactor("=MyLambda(A1) + Tax_Rate", Sheet, ctx);
+        var promo = Assert.Single(withCall.Promotables);
+        Assert.Equal("Tax_Rate", promo.Token);
+
+        // Naked reference (no trailing '(' — malformed/in-progress shape)
+        // should also be excluded.
+        var withoutCall = RefactorEngine.Refactor("=A1 + MyLambda + Tax_Rate", Sheet, ctx);
+        var promo2 = Assert.Single(withoutCall.Promotables);
+        Assert.Equal("Tax_Rate", promo2.Token);
+    }
+
+    [Fact]
+    public void Refactor_NamedRange_NoContext_NoPromotableEmitted()
+    {
+        // No workbook context → identifier walker can't recognise names.
+        var result = RefactorEngine.Refactor("=A1 * Tax_Rate", Sheet, context: null);
+        Assert.Empty(result.Promotables);
+    }
+
+    [Fact]
+    public void Recompute_NamedRangePromoted_RewritesEverywhere()
+    {
+        var ctx = new StubContext(("Tax_Rate", "=0.2"));
+        var initial = RefactorEngine.Refactor("=A1 * Tax_Rate + Tax_Rate", Sheet, ctx);
+        Assert.Equal(2, initial.Promotables[0].Occurrences);
+
+        var promo = initial.Promotables[0];
+        var rowStates = new[]
+        {
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
+            new RefactorRowState(promo.Key, "rate"),
+        };
+
+        var result = RefactorEngine.Recompute(
+            "=A1 * Tax_Rate + Tax_Rate", Sheet, rowStates, ctx);
+
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Empty(result.Promotables);
+        var promoted = result.Inputs[1];
+        Assert.Equal("rate", promoted.Name);
+        Assert.Equal("Tax_Rate", promoted.Rhs);
+        Assert.Equal(RefactorRowOrigin.PromotedNamedRange, promoted.Origin);
+        Assert.Contains("rate, Tax_Rate", result.SynthesisedLet);
+        Assert.Contains("input1 * rate + rate", result.SynthesisedLet);
+        AssertRoundTrips(result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_WorksheetScopedName_BehavesAsWorkbookScoped()
+    {
+        // Worksheet-scoped names share the same lookup once the live
+        // adapter has unioned them; the engine just sees a name in the
+        // catalogue. Test by passing a worksheet-scoped style entry.
+        var ctx = new StubContext(("LocalRate", "=Sheet1!$D$10"));
+        var initial = RefactorEngine.Refactor("=LocalRate * 2", Sheet, ctx);
+
+        var promo = Assert.Single(initial.Promotables);
+        Assert.Equal("LocalRate", promo.Token);
+
+        var rowStates = new[] { new RefactorRowState(promo.Key, "rate") };
+        var result = RefactorEngine.Recompute("=LocalRate * 2", Sheet, rowStates, ctx);
+
+        Assert.Empty(result.Promotables);
+        var input = Assert.Single(result.Inputs);
+        Assert.Equal("rate", input.Name);
+        Assert.Equal("LocalRate", input.Rhs);
+        Assert.Contains("rate * 2", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_ExternalRef_AppearsAsPromotable_NotAsInputByDefault()
+    {
+        var formula = "=A1 + [Other.xlsx]Sheet1!A1";
+        var result = RefactorEngine.Refactor(formula, Sheet);
+
+        var input = Assert.Single(result.Inputs);
+        Assert.Equal("A1", input.Rhs);
+
+        var promo = Assert.Single(result.Promotables);
+        Assert.Equal(RefactorPromotableKind.ExternalRef, promo.Kind);
+        Assert.Equal("[Other.xlsx]Sheet1!A1", promo.Token);
+        Assert.Equal(1, promo.Occurrences);
+
+        // Body keeps the external ref inline.
+        Assert.Contains("input1 + [Other.xlsx]Sheet1!A1", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_ExternalRefPromoted_ProducesBinding()
+    {
+        var formula = "=A1 + [Other.xlsx]Sheet1!A1";
+        var initial = RefactorEngine.Refactor(formula, Sheet);
+        var promo = Assert.Single(initial.Promotables);
+
+        var rowStates = new[]
+        {
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
+            new RefactorRowState(promo.Key, "ext"),
+        };
+        var result = RefactorEngine.Recompute(formula, Sheet, rowStates);
+
+        Assert.Equal(2, result.Inputs.Count);
+        Assert.Empty(result.Promotables);
+        var promoted = result.Inputs[1];
+        Assert.Equal("ext", promoted.Name);
+        Assert.Equal("[Other.xlsx]Sheet1!A1", promoted.Rhs);
+        Assert.Equal(RefactorRowOrigin.PromotedExternalRef, promoted.Origin);
+        Assert.Contains("ext, [Other.xlsx]Sheet1!A1", result.SynthesisedLet);
+        Assert.Contains("input1 + ext", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_IdentifierBoundary_HelpQuestionFooNotSplit()
+    {
+        // 'Help?Foo' is a single identifier (the ? predicate convention).
+        // The candidate walker should NOT split on the '?'. If 'Help' is
+        // ALSO a workbook name, we should NOT match it inside 'Help?Foo'.
+        var ctx = new StubContext(("Help", "=42"));
+        var result = RefactorEngine.Refactor("=Help?Foo + A1", Sheet, ctx);
+
+        // 'Help?Foo' isn't in WorkbookNames → not promotable.
+        // 'Help' bare doesn't appear in the formula text either.
+        Assert.Empty(result.Promotables);
+    }
+
+    [Fact]
+    public void Refactor_NamedRange_ExistingLet_BodyReferences()
+    {
+        // Existing LET body references a named range. Should appear as
+        // promotable; existing binding names shouldn't.
+        var ctx = new StubContext(("Tax_Rate", "=0.2"));
+        var result = RefactorEngine.Refactor(
+            "=LET(a, A1, a * Tax_Rate)", Sheet, ctx);
+
+        var promo = Assert.Single(result.Promotables);
+        Assert.Equal("Tax_Rate", promo.Token);
+        Assert.Equal(RefactorPromotableKind.NamedRange, promo.Kind);
+
+        // Un-promoted: Tax_Rate stays inline.
+        Assert.Contains("a * Tax_Rate", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_NamedRange_ExistingLetBindingName_NotOfferedAsPromotable()
+    {
+        // The user has a LET binding named 'rate'. Even if 'rate' also
+        // happens to be a defined name on the workbook, treat it as the
+        // local binding within the LET scope.
+        var ctx = new StubContext(("rate", "=0.05"));
+        var result = RefactorEngine.Refactor(
+            "=LET(rate, A1, rate * 2)", Sheet, ctx);
+
+        Assert.Empty(result.Promotables);
+    }
 }

--- a/addin/lambda-boss/CellRefExtractor.cs
+++ b/addin/lambda-boss/CellRefExtractor.cs
@@ -118,6 +118,42 @@ internal static class CellRefExtractor
     }
 
     /// <summary>
+    ///     Like <see cref="Extract" /> but returns every match (not deduped),
+    ///     in source order. Spec 0008 / PR 3 uses this to count occurrences
+    ///     of external refs in the formula so the promotable section can
+    ///     surface a count alongside each token. The list is allowed to
+    ///     contain duplicates; callers group/dedupe themselves.
+    /// </summary>
+    public static IReadOnlyList<FormulaRef> ExtractAll(string formula, string defaultSheet)
+    {
+        if (string.IsNullOrEmpty(formula))
+            return Array.Empty<FormulaRef>();
+
+        var refs = new List<FormulaRef>();
+
+        var i = 0;
+        while (i < formula.Length)
+        {
+            if (formula[i] == '"')
+            {
+                i = SkipString(formula, i);
+                continue;
+            }
+
+            var nextQuote = formula.IndexOf('"', i);
+            var segEnd = nextQuote < 0 ? formula.Length : nextQuote;
+            var segment = formula[i..segEnd];
+
+            foreach (Match m in CellRefPattern.Matches(segment))
+                refs.Add(BuildFormulaRef(m, defaultSheet));
+
+            i = segEnd;
+        }
+
+        return refs;
+    }
+
+    /// <summary>
     ///     Rewrites every in-scope ref in <paramref name="formula" /> to the
     ///     binding name supplied by <paramref name="lookup" />. Refs not in
     ///     <paramref name="lookup" /> (out-of-scope cells, named ranges,

--- a/addin/lambda-boss/Commands/RefactorCommand.cs
+++ b/addin/lambda-boss/Commands/RefactorCommand.cs
@@ -45,10 +45,15 @@ internal static class RefactorCommand
             // cells, which would corrupt our refactor.
             string formula = (string)activeCell.Formula2;
 
+            // PR 3 — snapshot the workbook + active-sheet defined-name
+            // catalogue once when the dialog opens. The engine consults
+            // this on every Recompute (no further COM round-trips).
+            var context = LiveWorkbookContext.Snapshot(workbook, worksheet);
+
             RefactorResult result;
             try
             {
-                result = RefactorEngine.Refactor(formula, sheetName);
+                result = RefactorEngine.Refactor(formula, sheetName, context);
             }
             catch (Exception ex)
             {
@@ -76,7 +81,7 @@ internal static class RefactorCommand
                     {
                         try
                         {
-                            return RefactorEngine.Recompute(formula, sheetName, rows);
+                            return RefactorEngine.Recompute(formula, sheetName, rows, context);
                         }
                         catch (Exception ex)
                         {
@@ -126,6 +131,86 @@ internal static class RefactorCommand
         catch
         {
             Logger.Info($"ShowError: {message}");
+        }
+    }
+
+    /// <summary>
+    ///     Live adapter for <see cref="IWorkbookContext" />. Snapshots
+    ///     workbook-scoped names AND the active sheet's worksheet-scoped
+    ///     names once when the dialog opens (per spec 0008 / PR 3 — the
+    ///     dialog reads the catalogue once, then no more COM traffic until
+    ///     Save). Hidden names and worksheet-scoped names whose RefersTo
+    ///     can't be read (closed external sources, etc.) are skipped
+    ///     defensively rather than aborted on.
+    /// </summary>
+    private sealed class LiveWorkbookContext : IWorkbookContext
+    {
+        private LiveWorkbookContext(IReadOnlyDictionary<string, string> names)
+        {
+            WorkbookNames = names;
+        }
+
+        public IReadOnlyDictionary<string, string> WorkbookNames { get; }
+
+        public static LiveWorkbookContext Snapshot(dynamic workbook, dynamic worksheet)
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            TryHarvestNames(dict, workbook?.Names, "workbook");
+
+            try
+            {
+                TryHarvestNames(dict, worksheet?.Names, "worksheet");
+            }
+            catch (Exception ex)
+            {
+                // worksheet.Names doesn't exist in older Excel object models;
+                // workbook-scoped names alone are still useful.
+                Logger.Error("Refactor/Snapshot/Worksheet", ex);
+            }
+
+            return new LiveWorkbookContext(dict);
+        }
+
+        private static void TryHarvestNames(
+            Dictionary<string, string> sink, dynamic? names, string scope)
+        {
+            if (names is null) return;
+            try
+            {
+                int count = (int)names.Count;
+                for (var i = 1; i <= count; i++)
+                {
+                    string? key = null;
+                    try
+                    {
+                        dynamic item = names[i];
+                        key = item.Name as string;
+                        if (string.IsNullOrEmpty(key)) continue;
+                        // Strip the sheet qualifier from worksheet-scoped
+                        // names so identifier lookup matches the bare
+                        // identifier as written in the formula.
+                        var bang = key!.LastIndexOf('!');
+                        if (bang >= 0 && bang + 1 < key.Length)
+                            key = key[(bang + 1)..];
+                        var refersTo = item.RefersTo as string ?? string.Empty;
+                        // Last-write-wins when a worksheet-scoped name
+                        // shadows a workbook-scoped one of the same
+                        // identifier. Excel's own resolution prefers
+                        // worksheet scope for the active sheet, and the
+                        // worksheet pass runs second.
+                        sink[key] = refersTo;
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Refactor/Snapshot/{scope}#{i}({key ?? "?"})", ex);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Refactor/Snapshot/{scope}", ex);
+            }
         }
     }
 }

--- a/addin/lambda-boss/RefactorEngine.cs
+++ b/addin/lambda-boss/RefactorEngine.cs
@@ -7,18 +7,27 @@ namespace LambdaBoss;
 ///     Spec 0008 — the <c>/Refactor</c> entry point. Takes a formula and
 ///     the active cell's sheet, hoists every cell ref / range into its own
 ///     LET binding, and emits a tidy <c>=LET(...)</c>.
-///     PR 2 adds existing-LET handling. When the input is already a LET,
-///     value bindings pre-populate the Inputs section; calculation bindings
-///     populate the read-only Calculation-bindings section; value bindings
-///     with equivalent canonical RHS are merged (first wins); cell refs
-///     inside calculation bindings or the body are extracted as new input
-///     rows; the synthesised LET emits all value bindings first (in dialog
-///     order) followed by all calc bindings (in source order).
-///     The engine re-derives merge state on every <see cref="Recompute" />
-///     call — the dialog only carries name / Include / order for each row
-///     via <see cref="RefactorRowState" />, not the underlying merge graph,
-///     so the engine has to be re-run anchored on the source formula
-///     text.
+///     PR 2 added existing-LET handling (merge value bindings, extract
+///     refs from calc bindings and body, keep calc bindings in source
+///     order).
+///     PR 3 adds the promotable section: external refs and workbook /
+///     worksheet-scoped defined names (excluding LAMBDA names) become
+///     default-off rows in a separate section the dialog renders below
+///     the inputs. When the user toggles Promote, the dialog re-issues
+///     the row state with the promotable's Key in <see cref="RefactorRowState" />;
+///     the engine recognises the <c>extref:</c> / <c>named:</c> Key prefix
+///     and materialises the promoted row as an input binding alongside
+///     the extracted ones. The rewrite step uses a second-pass identifier
+///     rewriter (separate from <see cref="CellRefExtractor.Rewrite" />) for
+///     promoted named ranges, so the bare identifier is swapped for the
+///     binding name while leaving cell-shaped tokens, sheet qualifiers,
+///     and strings alone.
+///     The engine re-derives merge state and promotable state on every
+///     <see cref="Recompute" /> call — the dialog only carries name /
+///     Include / order / Promote-by-membership for each row via
+///     <see cref="RefactorRowState" />, not the underlying merge graph
+///     or named-range catalogue, so the engine has to be re-run anchored
+///     on the source formula text and the live workbook-name lookup.
 /// </summary>
 public static class RefactorEngine
 {
@@ -38,18 +47,35 @@ public static class RefactorEngine
         @"(?<![A-Za-z0-9_.!:'\]#?])[A-Za-z_][A-Za-z0-9_.?]*",
         RegexOptions.CultureInvariant);
 
+    // Candidate-identifier walker used to find named-range references.
+    // Same identifier shape as IdentifierTokenPattern but with a trailing
+    // negative lookahead for '(' (function calls — SUM, MAX, etc.) and
+    // '!' (sheet qualifiers — Sheet1! is the lead-in to a cell ref, not
+    // a defined-name reference). The lookbehind class mirrors
+    // CellRefExtractor's so we don't pick up the cell tail of a
+    // sheet-qualified ref.
+    private static readonly Regex CandidateIdentifierPattern = new(
+        @"(?<![A-Za-z0-9_.!:'\]#?])[A-Za-z_][A-Za-z0-9_.?]*(?![A-Za-z0-9_.?(!])",
+        RegexOptions.CultureInvariant);
+
     /// <summary>
     ///     Runs the initial refactor over <paramref name="formula" />.
     ///     Existing LETs are parsed and merged/extracted per spec 0008;
     ///     non-LET formulas have their cell refs hoisted in first-seen
-    ///     order.
+    ///     order. The optional <paramref name="context" /> supplies the
+    ///     workbook-name catalogue for PR 3's promotable section; pass
+    ///     null when only extracted-ref / existing-LET behaviour is
+    ///     needed (e.g. unit tests for PR 1/2 paths).
     /// </summary>
-    public static RefactorResult Refactor(string formula, string activeSheet)
+    public static RefactorResult Refactor(
+        string formula,
+        string activeSheet,
+        IWorkbookContext? context = null)
     {
         if (formula is null) throw new ArgumentNullException(nameof(formula));
         if (activeSheet is null) throw new ArgumentNullException(nameof(activeSheet));
 
-        return RefactorInternal(formula, activeSheet, null);
+        return RefactorInternal(formula, activeSheet, null, context);
     }
 
     /// <summary>
@@ -60,27 +86,33 @@ public static class RefactorEngine
     ///     its source cell ref inline (matching PR 1). For existing LETs a
     ///     dropped value binding is removed and its name is inlined back to
     ///     the binding's original RHS text wherever it appeared.
+    ///     PR 3: row states whose <see cref="RefactorRowState.Key" /> matches
+    ///     a default promotable (external ref or named range) are treated
+    ///     as promotions — the row materialises as an input binding instead
+    ///     of staying in the promotable section.
     /// </summary>
     public static RefactorResult Recompute(
         string formula,
         string activeSheet,
-        IReadOnlyList<RefactorRowState> rowStates)
+        IReadOnlyList<RefactorRowState> rowStates,
+        IWorkbookContext? context = null)
     {
         if (formula is null) throw new ArgumentNullException(nameof(formula));
         if (activeSheet is null) throw new ArgumentNullException(nameof(activeSheet));
         if (rowStates is null) throw new ArgumentNullException(nameof(rowStates));
 
-        return RefactorInternal(formula, activeSheet, rowStates);
+        return RefactorInternal(formula, activeSheet, rowStates, context);
     }
 
     private static RefactorResult RefactorInternal(
         string formula,
         string activeSheet,
-        IReadOnlyList<RefactorRowState>? rowStates)
+        IReadOnlyList<RefactorRowState>? rowStates,
+        IWorkbookContext? context)
     {
         if (LetParser.IsLetFormula(formula))
-            return RefactorExistingLet(formula, activeSheet, rowStates);
-        return RefactorNonLet(formula, activeSheet, rowStates);
+            return RefactorExistingLet(formula, activeSheet, rowStates, context);
+        return RefactorNonLet(formula, activeSheet, rowStates, context);
     }
 
     // ---------------- non-LET path ----------------
@@ -88,15 +120,23 @@ public static class RefactorEngine
     private static RefactorResult RefactorNonLet(
         string formula,
         string activeSheet,
-        IReadOnlyList<RefactorRowState>? rowStates)
+        IReadOnlyList<RefactorRowState>? rowStates,
+        IWorkbookContext? context)
     {
         var extracted = CellRefExtractor.Extract(formula, activeSheet);
+        var allRefs = CellRefExtractor.ExtractAll(formula, activeSheet);
 
-        var defaultRows = new List<RefactorInputRow>(extracted.Count);
-        var nameIndex = 1;
+        // Separate in-scope refs (always-input) from external refs (promotable).
+        var inScopeRefs = new List<FormulaRef>();
+        var externalRefs = new List<FormulaRef>();
         foreach (var fr in extracted)
+            (fr.IsExternal ? externalRefs : inScopeRefs).Add(fr);
+
+        var defaultInputRows = new List<RefactorInputRow>(inScopeRefs.Count);
+        var nameIndex = 1;
+        foreach (var fr in inScopeRefs)
         {
-            defaultRows.Add(new RefactorInputRow(
+            defaultInputRows.Add(new RefactorInputRow(
                 BuildExtractedKey(fr, activeSheet),
                 fr,
                 $"input{nameIndex}",
@@ -105,18 +145,40 @@ public static class RefactorEngine
             nameIndex++;
         }
 
-        var finalRows = ApplyRowStates(defaultRows, rowStates);
-        var keptRows = finalRows.Where(r => r.IsIncluded).ToList();
+        // Default promotables: external refs found anywhere in the
+        // formula + workbook-named identifiers (non-LAMBDA) found in the
+        // formula body.
+        var defaultPromotables = BuildDefaultPromotables(
+            new[] { formula },
+            allRefs,
+            activeSheet,
+            context,
+            ReadOnlyEmptySet<string>.Instance);
+
+        var promotableLookup = BuildPromotableLookup(defaultPromotables, externalRefs, activeSheet);
+
+        var (materialised, remainingPromotables) = MaterialiseRowStates(
+            defaultInputRows,
+            defaultPromotables,
+            promotableLookup,
+            rowStates,
+            nextAutoNameIndex: nameIndex,
+            existingBindingNames: ReadOnlyEmptySet<string>.Instance);
+
+        var keptRows = materialised.Where(r => r.IsIncluded).ToList();
+
+        var identifierSubs = BuildPromotedNamedRangeSubstitutions(keptRows);
 
         var synthesisedLet = BuildSynthesisedLet(
             formula, activeSheet, keptRows, Array.Empty<RefactorCalcBindingRow>(),
-            false, null, null);
+            false, null, identifierSubs);
 
         return new RefactorResult(
             formula,
             keptRows.Select(r => r.Row).ToList(),
             Array.Empty<RefactorCalcBindingRow>(),
-            synthesisedLet);
+            synthesisedLet,
+            remainingPromotables);
     }
 
     // ---------------- existing-LET path ----------------
@@ -124,7 +186,8 @@ public static class RefactorEngine
     private static RefactorResult RefactorExistingLet(
         string formula,
         string activeSheet,
-        IReadOnlyList<RefactorRowState>? rowStates)
+        IReadOnlyList<RefactorRowState>? rowStates,
+        IWorkbookContext? context)
     {
         ParsedLet parsed;
         try
@@ -138,6 +201,7 @@ public static class RefactorEngine
                 Array.Empty<RefactorInputRow>(),
                 Array.Empty<RefactorCalcBindingRow>(),
                 formula,
+                Array.Empty<RefactorPromotableRow>(),
                 new RefactorDiagnostic(
                     RefactorDiagnosticKind.MalformedLet,
                     $"Refactor can't parse this LET: {ex.Message}"));
@@ -152,7 +216,8 @@ public static class RefactorEngine
         // Step 2 — walk calc binding RHSes and the body for new refs.
         //   Refs already represented by a kept value binding (matched via
         //   canonical FormulaRef) are skipped; everything else becomes an
-        //   auto-named Extracted row.
+        //   auto-named Extracted row. External refs are routed to the
+        //   promotables list instead.
         var existingRefs = new HashSet<FormulaRef>();
         foreach (var survivor in merge.Survivors)
         {
@@ -160,16 +225,38 @@ public static class RefactorEngine
             if (fr != null) existingRefs.Add(fr);
         }
 
-        var usedNames = new HashSet<string>(
+        var existingBindingNames = new HashSet<string>(
             parsed.Bindings.Select(b => b.Name), StringComparer.OrdinalIgnoreCase);
+
+        var usedNames = new HashSet<string>(existingBindingNames, StringComparer.OrdinalIgnoreCase);
 
         var newRows = new List<RefactorInputRow>();
         var seenNew = new HashSet<FormulaRef>();
+        var externalRefsFound = new List<FormulaRef>();
         var autoNameIndex = 1;
 
         foreach (var calc in calcBindings)
-            ExtractNewRefs(calc.RhsText, activeSheet, existingRefs, seenNew, usedNames, ref autoNameIndex, newRows);
-        ExtractNewRefs(parsed.Body, activeSheet, existingRefs, seenNew, usedNames, ref autoNameIndex, newRows);
+            ExtractNewRefs(
+                calc.RhsText, activeSheet, existingRefs, seenNew, usedNames,
+                ref autoNameIndex, newRows, externalRefsFound);
+        ExtractNewRefs(
+            parsed.Body, activeSheet, existingRefs, seenNew, usedNames,
+            ref autoNameIndex, newRows, externalRefsFound);
+
+        // For promotable counting we want EVERY occurrence (including
+        // duplicates), so walk a second time without the dedupe filter.
+        var allRefsInScope = new List<FormulaRef>();
+        foreach (var calc in calcBindings)
+            allRefsInScope.AddRange(CellRefExtractor.ExtractAll(calc.RhsText, activeSheet));
+        allRefsInScope.AddRange(CellRefExtractor.ExtractAll(parsed.Body, activeSheet));
+
+        var promotableScopes = new List<string>(calcBindings.Count + 1);
+        foreach (var calc in calcBindings)
+            promotableScopes.Add(calc.RhsText);
+        promotableScopes.Add(parsed.Body);
+
+        var defaultPromotables = BuildDefaultPromotables(
+            promotableScopes, allRefsInScope, activeSheet, context, existingBindingNames);
 
         // Step 3 — build the existing-LET-value rows (in source order).
         var existingValueRows = new List<RefactorInputRow>(merge.Survivors.Count);
@@ -185,15 +272,33 @@ public static class RefactorEngine
                 mergedFrom));
         }
 
-        // Step 4 — combine and apply rowStates (rename / include / order).
+        // Step 4 — combine defaults and apply rowStates (rename / include /
+        // order / promote).
         var defaultRows = existingValueRows.Concat(newRows).ToList();
-        var finalRows = ApplyRowStates(defaultRows, rowStates);
+
+        var promotableLookup = BuildPromotableLookup(
+            defaultPromotables, externalRefsFound, activeSheet);
+
+        var (materialised, remainingPromotables) = MaterialiseRowStates(
+            defaultRows,
+            defaultPromotables,
+            promotableLookup,
+            rowStates,
+            nextAutoNameIndex: autoNameIndex,
+            existingBindingNames: existingBindingNames);
 
         // Step 5 — assemble the rewrite maps and synthesise.
-        var keptRows = finalRows.Where(r => r.IsIncluded).ToList();
+        var keptRows = materialised.Where(r => r.IsIncluded).ToList();
 
         var identifierSubs = BuildIdentifierSubstitutions(
-            valueBindings, merge, finalRows);
+            valueBindings, merge, materialised);
+
+        // Promoted named ranges add their identifier-to-binding entries
+        // on top of the existing-LET ones; the dictionaries don't overlap
+        // (promotable identifiers were excluded from defaults if they
+        // matched an existing binding name).
+        foreach (var kv in BuildPromotedNamedRangeSubstitutions(keptRows))
+            identifierSubs[kv.Key] = kv.Value;
 
         var rewrittenCalcs = RewriteCalcBindings(
             calcBindings, activeSheet, keptRows, identifierSubs);
@@ -206,7 +311,8 @@ public static class RefactorEngine
             formula,
             keptRows.Select(r => r.Row).ToList(),
             rewrittenCalcs,
-            synthesisedLet);
+            synthesisedLet,
+            remainingPromotables);
     }
 
     private static MergeResult MergeValueBindings(
@@ -290,7 +396,7 @@ public static class RefactorEngine
     ///         </item>
     ///     </list>
     /// </summary>
-    private static IReadOnlyDictionary<string, string> BuildIdentifierSubstitutions(
+    private static Dictionary<string, string> BuildIdentifierSubstitutions(
         IReadOnlyList<LetBinding> originalValueBindings,
         MergeResult merge,
         IReadOnlyList<MaterialisedRow> finalRows)
@@ -325,6 +431,26 @@ public static class RefactorEngine
         return subs;
     }
 
+    /// <summary>
+    ///     Builds the identifier → binding-name subs for promoted named
+    ///     ranges among <paramref name="keptRows" />. Promoted external
+    ///     refs aren't included here — they ride the FormulaRef rewrite
+    ///     path via <see cref="BuildFormulaRefLookup" />.
+    /// </summary>
+    private static Dictionary<string, string> BuildPromotedNamedRangeSubstitutions(
+        IReadOnlyList<MaterialisedRow> keptRows)
+    {
+        var subs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var r in keptRows)
+        {
+            if (r.Row.Origin != RefactorRowOrigin.PromotedNamedRange) continue;
+            // RHS for a promoted named range is the identifier itself.
+            subs[r.Row.Rhs] = r.Row.Name;
+        }
+
+        return subs;
+    }
+
     // ---------------- ref extraction (calc bindings + body) ----------------
 
     private static void ExtractNewRefs(
@@ -334,10 +460,17 @@ public static class RefactorEngine
         HashSet<FormulaRef> seenNew,
         HashSet<string> usedNames,
         ref int autoNameIndex,
-        List<RefactorInputRow> sink)
+        List<RefactorInputRow> sink,
+        List<FormulaRef> externalSink)
     {
         foreach (var fr in CellRefExtractor.Extract(text, activeSheet))
         {
+            if (fr.IsExternal)
+            {
+                externalSink.Add(fr);
+                continue;
+            }
+
             if (existingRefs.Contains(fr)) continue;
             if (!seenNew.Add(fr)) continue;
 
@@ -361,36 +494,268 @@ public static class RefactorEngine
         }
     }
 
-    private static List<MaterialisedRow> ApplyRowStates(
-        IReadOnlyList<RefactorInputRow> defaultRows,
-        IReadOnlyList<RefactorRowState>? rowStates)
-    {
-        if (rowStates is null)
-            return defaultRows.Select(r => new MaterialisedRow(r, true)).ToList();
+    // ---------------- promotable building & lookup ----------------
 
-        var byKey = defaultRows.ToDictionary(r => r.Key, StringComparer.Ordinal);
-        var ordered = new List<MaterialisedRow>(rowStates.Count);
-        var consumed = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var rs in rowStates)
+    /// <summary>
+    ///     Builds the default-off promotable rows: external refs (deduped,
+    ///     with occurrence counts) and workbook-name identifiers that
+    ///     aren't LAMBDA names and aren't masked by an existing LET
+    ///     binding name.
+    /// </summary>
+    private static List<RefactorPromotableRow> BuildDefaultPromotables(
+        IReadOnlyList<string> identifierScopes,
+        IReadOnlyList<FormulaRef> allRefs,
+        string activeSheet,
+        IWorkbookContext? context,
+        ISet<string> excludeBindingNames)
+    {
+        var promotables = new List<RefactorPromotableRow>();
+
+        // External refs — first-occurrence order, count all matches.
+        var externalCounts = new Dictionary<string, (FormulaRef Ref, int Count)>(StringComparer.Ordinal);
+        var externalOrder = new List<string>();
+        foreach (var fr in allRefs)
         {
-            if (!byKey.TryGetValue(rs.Key, out var row)) continue;
-            consumed.Add(rs.Key);
-            // The dialog owns the binding name; the engine just forwards it
-            // (validation is enforced dialog-side).
-            ordered.Add(new MaterialisedRow(
-                row with { Name = rs.Name },
-                rs.Include));
+            if (!fr.IsExternal) continue;
+            var key = BuildExternalRefKey(fr, activeSheet);
+            if (externalCounts.TryGetValue(key, out var existing))
+                externalCounts[key] = (existing.Ref, existing.Count + 1);
+            else
+            {
+                externalCounts[key] = (fr, 1);
+                externalOrder.Add(key);
+            }
         }
 
-        // Any rows the rowStates didn't mention (shouldn't happen in
-        // practice — the dialog tracks every row) are appended at the end
-        // in their default order, kept included so they aren't silently
-        // lost.
-        foreach (var row in defaultRows)
-            if (!consumed.Contains(row.Key))
+        foreach (var key in externalOrder)
+        {
+            var (fr, count) = externalCounts[key];
+            promotables.Add(new RefactorPromotableRow(
+                key,
+                RefactorPromotableKind.ExternalRef,
+                fr.DisplayAddress(activeSheet),
+                count));
+        }
+
+        // Named-range candidates — only when a workbook context supplies
+        // names. First-occurrence-spelling wins for display; dedupe is
+        // case-insensitive (Excel name resolution is case-insensitive).
+        if (context is { WorkbookNames.Count: > 0 })
+        {
+            var nameCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var firstSpelling = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var nameOrder = new List<string>(); // canonical (first-found) spellings
+
+            foreach (var scope in identifierScopes)
+            foreach (var identifier in WalkCandidateIdentifiers(scope))
+            {
+                if (excludeBindingNames.Contains(identifier)) continue;
+                if (!context.WorkbookNames.TryGetValue(identifier, out var refersTo)) continue;
+                if (LambdaSignatureParser.IsLambdaFormula(refersTo)) continue;
+
+                if (!nameCounts.ContainsKey(identifier))
+                {
+                    firstSpelling[identifier] = identifier;
+                    nameOrder.Add(identifier);
+                }
+
+                nameCounts[identifier] = nameCounts.TryGetValue(identifier, out var c) ? c + 1 : 1;
+            }
+
+            foreach (var spelling in nameOrder)
+            {
+                promotables.Add(new RefactorPromotableRow(
+                    BuildNamedRangeKey(spelling),
+                    RefactorPromotableKind.NamedRange,
+                    spelling,
+                    nameCounts[spelling]));
+            }
+        }
+
+        return promotables;
+    }
+
+    /// <summary>
+    ///     Walks <paramref name="text" /> for bare-identifier tokens that
+    ///     aren't immediately followed by '(' (function call) or '!'
+    ///     (sheet qualifier). String literals and single-quoted sheet/
+    ///     workbook qualifiers are skipped wholesale.
+    /// </summary>
+    private static IEnumerable<string> WalkCandidateIdentifiers(string text)
+    {
+        if (string.IsNullOrEmpty(text)) yield break;
+
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (text[i] == '"')
+            {
+                i = SkipString(text, i);
+                continue;
+            }
+
+            if (text[i] == '\'')
+            {
+                i = SkipSingleQuoted(text, i);
+                continue;
+            }
+
+            var nextQuote = IndexOfAny(text, i, '"', '\'');
+            var segEnd = nextQuote < 0 ? text.Length : nextQuote;
+            var segment = text.Substring(i, segEnd - i);
+
+            foreach (Match m in CandidateIdentifierPattern.Matches(segment))
+                yield return m.Value;
+
+            i = segEnd;
+        }
+    }
+
+    /// <summary>
+    ///     Lookup the materialiser uses to turn a promoted promotable's
+    ///     key into an input row. External refs carry their FormulaRef so
+    ///     <see cref="BuildFormulaRefLookup" /> can register them for
+    ///     cell-ref rewriting; named ranges carry only their identifier
+    ///     text (the RHS).
+    /// </summary>
+    private static Dictionary<string, PromotedInfo> BuildPromotableLookup(
+        IReadOnlyList<RefactorPromotableRow> defaultPromotables,
+        IReadOnlyList<FormulaRef> externalRefs,
+        string activeSheet)
+    {
+        var byKey = new Dictionary<string, PromotedInfo>(StringComparer.Ordinal);
+        foreach (var p in defaultPromotables)
+        {
+            switch (p.Kind)
+            {
+                case RefactorPromotableKind.NamedRange:
+                    byKey[p.Key] = new PromotedInfo(p, null);
+                    break;
+                case RefactorPromotableKind.ExternalRef:
+                    var fr = externalRefs.FirstOrDefault(
+                        r => BuildExternalRefKey(r, activeSheet) == p.Key);
+                    if (fr != null)
+                        byKey[p.Key] = new PromotedInfo(p, fr);
+                    break;
+            }
+        }
+
+        return byKey;
+    }
+
+    private sealed record PromotedInfo(RefactorPromotableRow Row, FormulaRef? ExternalSource);
+
+    // ---------------- materialisation (rowState → kept rows) ----------------
+
+    /// <summary>
+    ///     Combines the engine-derived <paramref name="defaultInputRows" />
+    ///     and <paramref name="defaultPromotables" /> with the dialog's
+    ///     per-row state. Recognises three Key shapes in
+    ///     <paramref name="rowStates" />:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             <c>ref:</c> (extracted cell ref) or <c>name:</c>
+    ///             (existing-LET value binding) — already an input row;
+    ///             update Name + Include.
+    ///         </item>
+    ///         <item>
+    ///             <c>extref:</c> (promotable external ref) or
+    ///             <c>named:</c> (promotable named range) — promotion;
+    ///             materialise as an input row and remove from the
+    ///             promotables list.
+    ///         </item>
+    ///     </list>
+    ///     Promotable rows whose Key wasn't mentioned in rowStates remain
+    ///     in the result's <see cref="RefactorResult.Promotables" />.
+    /// </summary>
+    private static (List<MaterialisedRow> Rows, List<RefactorPromotableRow> Promotables)
+        MaterialiseRowStates(
+            IReadOnlyList<RefactorInputRow> defaultInputRows,
+            IReadOnlyList<RefactorPromotableRow> defaultPromotables,
+            IReadOnlyDictionary<string, PromotedInfo> promotableLookup,
+            IReadOnlyList<RefactorRowState>? rowStates,
+            int nextAutoNameIndex,
+            ISet<string> existingBindingNames)
+    {
+        if (rowStates is null)
+            return (
+                defaultInputRows.Select(r => new MaterialisedRow(r, true)).ToList(),
+                defaultPromotables.ToList());
+
+        var byInputKey = defaultInputRows.ToDictionary(r => r.Key, StringComparer.Ordinal);
+        var ordered = new List<MaterialisedRow>(rowStates.Count);
+        var consumedInputs = new HashSet<string>(StringComparer.Ordinal);
+        var promotedKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var rs in rowStates)
+        {
+            if (byInputKey.TryGetValue(rs.Key, out var inputRow))
+            {
+                consumedInputs.Add(rs.Key);
+                ordered.Add(new MaterialisedRow(inputRow with { Name = rs.Name }, rs.Include));
+                continue;
+            }
+
+            if (promotableLookup.TryGetValue(rs.Key, out var promotable))
+            {
+                promotedKeys.Add(rs.Key);
+                var name = string.IsNullOrEmpty(rs.Name)
+                    ? AllocateAutoName(ref nextAutoNameIndex, existingBindingNames)
+                    : rs.Name;
+                ordered.Add(new MaterialisedRow(
+                    BuildPromotedInputRow(promotable, name),
+                    rs.Include));
+            }
+            // Unknown key (stale dialog state from a prior formula) — skip
+            // silently rather than throwing; the dialog round-trips fresh
+            // engine output on every change so stale keys shouldn't reach
+            // here in practice.
+        }
+
+        foreach (var row in defaultInputRows)
+            if (!consumedInputs.Contains(row.Key))
                 ordered.Add(new MaterialisedRow(row, true));
 
-        return ordered;
+        var remainingPromotables = defaultPromotables
+            .Where(p => !promotedKeys.Contains(p.Key))
+            .ToList();
+
+        return (ordered, remainingPromotables);
+    }
+
+    private static RefactorInputRow BuildPromotedInputRow(PromotedInfo info, string name)
+    {
+        switch (info.Row.Kind)
+        {
+            case RefactorPromotableKind.NamedRange:
+                return new RefactorInputRow(
+                    info.Row.Key,
+                    Source: null,
+                    name,
+                    info.Row.Token,
+                    RefactorRowOrigin.PromotedNamedRange);
+            case RefactorPromotableKind.ExternalRef:
+                return new RefactorInputRow(
+                    info.Row.Key,
+                    info.ExternalSource,
+                    name,
+                    info.Row.Token,
+                    RefactorRowOrigin.PromotedExternalRef);
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown promotable kind: {info.Row.Kind}");
+        }
+    }
+
+    private static string AllocateAutoName(ref int autoNameIndex, ISet<string> usedNames)
+    {
+        while (true)
+        {
+            var name = "input" + autoNameIndex;
+            autoNameIndex++;
+            if (!usedNames.Contains(name))
+                return name;
+        }
     }
 
     // ---------------- rewrite & synthesis ----------------
@@ -428,8 +793,9 @@ public static class RefactorEngine
     /// <summary>
     ///     Runs the cell-ref rewrite (replacing in-scope <see cref="FormulaRef" />s
     ///     with their kept binding names) followed by the identifier
-    ///     rewrite (renaming merged-away binding names or inlining the RHS
-    ///     of dropped existing-LET value bindings).
+    ///     rewrite (renaming merged-away binding names, inlining the RHS
+    ///     of dropped existing-LET value bindings, or swapping a promoted
+    ///     named range's identifier for its binding name).
     /// </summary>
     private static string RewriteText(
         string text,
@@ -551,7 +917,13 @@ public static class RefactorEngine
     {
         // No work to do — nothing extracted and nothing merged.
         if (!isExistingLet && keptInputs.Count == 0)
+        {
+            // PR 3: even without any cell-ref inputs we may need to emit a
+            // LET if the user promoted a named range. The check above
+            // already covers no-extracts AND no-promotables (the promoted
+            // rows would be in keptInputs).
             return originalFormula;
+        }
 
         // An existing LET with zero kept inputs AND zero calc bindings
         // collapses to its body — the dialog still synthesises a valid
@@ -582,11 +954,13 @@ public static class RefactorEngine
         else
         {
             // Non-LET: the original formula's content (sans leading '=') is
-            // the LET body, with cell refs rewritten to kept binding names.
-            bodyText = CellRefExtractor.Rewrite(
+            // the LET body, with cell refs and (PR 3) promoted named
+            // ranges rewritten to kept binding names.
+            bodyText = RewriteText(
                 StripLeadingEquals(originalFormula),
                 activeSheet,
-                BuildFormulaRefLookup(keptInputs));
+                BuildFormulaRefLookup(keptInputs),
+                identifierSubstitutions ?? new Dictionary<string, string>());
         }
 
         var sb = new StringBuilder();
@@ -610,6 +984,16 @@ public static class RefactorEngine
         return "name:" + bindingName;
     }
 
+    private static string BuildExternalRefKey(FormulaRef fr, string activeSheet)
+    {
+        return "extref:" + fr.DisplayAddress(activeSheet);
+    }
+
+    private static string BuildNamedRangeKey(string identifier)
+    {
+        return "named:" + identifier;
+    }
+
     /// <summary>
     ///     If <paramref name="rhsText" /> consists of exactly one cell-shaped
     ///     ref (single cell, range, or spill — optionally sheet- or
@@ -626,7 +1010,7 @@ public static class RefactorEngine
         // Verify the RHS is JUST that ref (no surrounding tokens or
         // operators) by rewriting it to a sentinel and checking the
         // remainder is whitespace.
-        var sentinel = "";
+        var sentinel = "";
         var probe = CellRefExtractor.Rewrite(
             rhsText, activeSheet, new Dictionary<FormulaRef, string> { [refs[0]] = sentinel });
         return probe.Trim() == sentinel ? refs[0] : null;
@@ -655,4 +1039,34 @@ public static class RefactorEngine
     ///     against the input rowStates dictionary.
     /// </summary>
     private sealed record MaterialisedRow(RefactorInputRow Row, bool IsIncluded);
+
+    /// <summary>
+    ///     A tiny immutable empty-set sentinel used in the non-LET path
+    ///     where there are no existing binding names to exclude. Saves an
+    ///     allocation per call without changing semantics.
+    /// </summary>
+    private sealed class ReadOnlyEmptySet<T> : ISet<T>
+    {
+        public static readonly ReadOnlyEmptySet<T> Instance = new();
+        public IEnumerator<T> GetEnumerator() { yield break; }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+        public int Count => 0;
+        public bool IsReadOnly => true;
+        public bool Contains(T item) => false;
+        public void CopyTo(T[] array, int arrayIndex) { }
+        public bool Add(T item) => throw new NotSupportedException();
+        void System.Collections.Generic.ICollection<T>.Add(T item) => throw new NotSupportedException();
+        public void Clear() => throw new NotSupportedException();
+        public bool Remove(T item) => throw new NotSupportedException();
+        public void ExceptWith(IEnumerable<T> other) => throw new NotSupportedException();
+        public void IntersectWith(IEnumerable<T> other) => throw new NotSupportedException();
+        public bool IsProperSubsetOf(IEnumerable<T> other) => other?.Any() ?? false;
+        public bool IsProperSupersetOf(IEnumerable<T> other) => false;
+        public bool IsSubsetOf(IEnumerable<T> other) => true;
+        public bool IsSupersetOf(IEnumerable<T> other) => !(other?.Any() ?? false);
+        public bool Overlaps(IEnumerable<T> other) => false;
+        public bool SetEquals(IEnumerable<T> other) => !(other?.Any() ?? false);
+        public void SymmetricExceptWith(IEnumerable<T> other) => throw new NotSupportedException();
+        public void UnionWith(IEnumerable<T> other) => throw new NotSupportedException();
+    }
 }

--- a/addin/lambda-boss/RefactorTypes.cs
+++ b/addin/lambda-boss/RefactorTypes.cs
@@ -6,12 +6,18 @@ namespace LambdaBoss;
 ///     binding's RHS. <see cref="ExistingLetValue" /> is a value binding
 ///     already present in an existing LET — the binding's name and RHS are
 ///     pre-populated and the row can still be renamed, reordered, dropped,
-///     or marked as the survivor of a merge.
+///     or marked as the survivor of a merge. PR 3 adds
+///     <see cref="PromotedNamedRange" /> and <see cref="PromotedExternalRef" />:
+///     rows that were originally promotable but the user (or the dialog's
+///     initial state) has promoted into the inputs section. The dialog
+///     uses the badge to communicate the row's provenance.
 /// </summary>
 public enum RefactorRowOrigin
 {
     Extracted,
-    ExistingLetValue
+    ExistingLetValue,
+    PromotedNamedRange,
+    PromotedExternalRef
 }
 
 /// <summary>
@@ -45,13 +51,48 @@ public sealed record RefactorCalcBindingRow(
     string RewrittenRhs);
 
 /// <summary>
+///     Spec 0008 / PR 3 — a candidate identifier or external ref that the
+///     engine found in the formula but didn't promote to an input binding
+///     by default. <see cref="Kind" /> tells the dialog whether the row
+///     represents a workbook/worksheet defined name or an external-workbook
+///     ref. <see cref="Token" /> is the user-facing label (the identifier
+///     text for named ranges, the host-relative display address for
+///     external refs). <see cref="Occurrences" /> is the number of times
+///     the token appears in the source formula — handy for the author
+///     deciding whether promoting it saves work. When the user toggles
+///     Promote on, the dialog passes the row's <see cref="Key" /> back to
+///     <see cref="RefactorEngine.Recompute" /> via
+///     <see cref="RefactorRowState" /> (the engine recognises the
+///     <c>extref:</c> / <c>named:</c> key prefix and materialises the row
+///     as an input binding with the requested name).
+/// </summary>
+public sealed record RefactorPromotableRow(
+    string Key,
+    RefactorPromotableKind Kind,
+    string Token,
+    int Occurrences);
+
+public enum RefactorPromotableKind
+{
+    /// <summary>A workbook- or worksheet-scoped defined name (not a LAMBDA).</summary>
+    NamedRange,
+
+    /// <summary>An external-workbook ref (<c>[Wb.xlsx]Sheet!A1</c>, etc.).</summary>
+    ExternalRef
+}
+
+/// <summary>
 ///     User's per-row state passed back into
 ///     <see cref="RefactorEngine.Recompute" />. PR 2 keys rows by
-///     <see cref="Key" /> (the matching <see cref="RefactorInputRow.Key" />)
-///     instead of <see cref="FormulaRef" /> so rows without a single-ref
-///     source (existing-LET value bindings whose RHS is a literal or named
-///     range) can be tracked too. The dialog produces the row order by
-///     resequencing this list before the call.
+///     <see cref="Key" /> (the matching <see cref="RefactorInputRow.Key" />
+///     or <see cref="RefactorPromotableRow.Key" />) instead of
+///     <see cref="FormulaRef" /> so rows without a single-ref source
+///     (existing-LET value bindings whose RHS is a literal or named range)
+///     can be tracked too. PR 3 reuses the same record for promoted
+///     promotables — the dialog adds the promotable's Key to this list
+///     when the user toggles Promote on, with an auto-allocated or
+///     user-edited Name. The dialog produces the row order by resequencing
+///     this list before the call.
 /// </summary>
 public sealed record RefactorRowState(
     string Key,
@@ -61,21 +102,28 @@ public sealed record RefactorRowState(
 /// <summary>
 ///     The engine's output. <see cref="OriginalFormula" /> is the formula
 ///     text passed in (handy for the dialog header). <see cref="Inputs" />
-///     is the in-dialog-order list of input rows. <see cref="CalcBindings" />
-///     carries the rewritten calculation bindings from an existing LET
-///     (empty for non-LET formulas). <see cref="SynthesisedLet" /> is the
-///     formatted <c>=LET(...)</c> text ready to write back to the active
-///     cell on Save (or the unchanged formula when there's nothing to
-///     refactor). <see cref="Diagnostic" /> is non-null when the engine
-///     refused (PR 2: <c>MalformedLet</c>); in that case
-///     <see cref="Inputs" /> and <see cref="CalcBindings" /> are empty and
-///     <see cref="SynthesisedLet" /> is the original formula unchanged.
+///     is the in-dialog-order list of input rows. <see cref="Promotables" />
+///     is the list of un-promoted candidates (named ranges, external refs)
+///     the dialog shows in its "Promote to input" section; promoted rows
+///     materialise as <see cref="RefactorInputRow" /> in
+///     <see cref="Inputs" /> and DON'T appear here.
+///     <see cref="CalcBindings" /> carries the rewritten calculation
+///     bindings from an existing LET (empty for non-LET formulas).
+///     <see cref="SynthesisedLet" /> is the formatted <c>=LET(...)</c>
+///     text ready to write back to the active cell on Save (or the
+///     unchanged formula when there's nothing to refactor).
+///     <see cref="Diagnostic" /> is non-null when the engine refused (PR 2:
+///     <c>MalformedLet</c>); in that case <see cref="Inputs" />,
+///     <see cref="Promotables" />, and <see cref="CalcBindings" /> are
+///     empty and <see cref="SynthesisedLet" /> is the original formula
+///     unchanged.
 /// </summary>
 public sealed record RefactorResult(
     string OriginalFormula,
     IReadOnlyList<RefactorInputRow> Inputs,
     IReadOnlyList<RefactorCalcBindingRow> CalcBindings,
     string SynthesisedLet,
+    IReadOnlyList<RefactorPromotableRow> Promotables,
     RefactorDiagnostic? Diagnostic = null);
 
 /// <summary>
@@ -96,4 +144,23 @@ public enum RefactorDiagnosticKind
     ///     opening the dialog.
     /// </summary>
     MalformedLet
+}
+
+/// <summary>
+///     Spec 0008 / PR 3 — workbook-name lookup the engine consults when
+///     deciding which bare identifiers in the formula are candidate
+///     defined-name references (and which should be excluded as LAMBDA
+///     names). The live adapter in <c>RefactorCommand</c> populates the
+///     dictionary once from <c>workbook.Names</c> AND the active sheet's
+///     <c>worksheet.Names</c>, unioned with case-insensitive collation.
+///     <see cref="WorkbookNames" /> maps name → <c>RefersTo</c> text;
+///     entries whose <c>RefersTo</c> starts with <c>=LAMBDA(</c> are
+///     filtered out by the engine via
+///     <see cref="LambdaSignatureParser.IsLambdaFormula" />. Tests pass an
+///     in-memory stub; callers that don't need promotable named ranges
+///     (e.g. PR 1's tracer tests) pass null.
+/// </summary>
+public interface IWorkbookContext
+{
+    IReadOnlyDictionary<string, string> WorkbookNames { get; }
 }

--- a/addin/lambda-boss/UI/RefactorToLetWindow.xaml
+++ b/addin/lambda-boss/UI/RefactorToLetWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:dd="urn:gong-wpf-dragdrop"
         Title="Lambda Boss — Refactor to LET"
-        Width="640" Height="640"
+        Width="640" Height="700"
         WindowStyle="ToolWindow"
         ShowInTaskbar="True"
         Topmost="True"
@@ -13,6 +13,8 @@
 
     <Grid Margin="12">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -57,7 +59,7 @@
                 Background="#252526"
                 BorderBrush="#3e3e3e"
                 BorderThickness="1"
-                MaxHeight="220">
+                MaxHeight="200">
             <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <ItemsControl x:Name="InputsList"
                               dd:DragDrop.IsDragSource="True"
@@ -129,8 +131,67 @@
             </ScrollViewer>
         </Border>
 
-        <TextBlock x:Name="CalcBindingsHeader"
+        <TextBlock x:Name="PromotablesHeader"
                    Grid.Row="4"
+                   Text="Promote to input"
+                   FontSize="13"
+                   FontWeight="Bold"
+                   Foreground="#dcdcaa"
+                   Margin="0,12,0,4"
+                   Visibility="Collapsed" />
+
+        <Border x:Name="PromotablesBorder"
+                Grid.Row="5"
+                Background="#252526"
+                BorderBrush="#3e3e3e"
+                BorderThickness="1"
+                MaxHeight="160"
+                Visibility="Collapsed">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ItemsControl x:Name="PromotablesList">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <DockPanel Margin="4,3">
+                                <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                                <CheckBox DockPanel.Dock="Left"
+                                          IsChecked="{Binding Promote, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                          VerticalAlignment="Center"
+                                          Margin="0,0,8,0"
+                                          Cursor="Hand"
+                                          ToolTip="Check to add this as a LAMBDA input binding" />
+                                <TextBlock DockPanel.Dock="Left"
+                                           Text="{Binding KindLabel}"
+                                           Foreground="#808080"
+                                           FontFamily="Consolas"
+                                           FontSize="11"
+                                           FontStyle="Italic"
+                                           VerticalAlignment="Center"
+                                           MinWidth="72"
+                                           Margin="0,0,8,0" />
+                                <TextBlock DockPanel.Dock="Right"
+                                           Text="{Binding OccurrencesLabel}"
+                                           Foreground="#808080"
+                                           FontFamily="Consolas"
+                                           FontSize="11"
+                                           VerticalAlignment="Center"
+                                           Margin="8,0,0,0" />
+                                <TextBlock Text="{Binding Token}"
+                                           Foreground="#cccccc"
+                                           FontFamily="Consolas"
+                                           FontSize="13"
+                                           VerticalAlignment="Center"
+                                           TextTrimming="CharacterEllipsis"
+                                           ToolTip="{Binding Token}" />
+                                <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
+                            </DockPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
+
+        <TextBlock x:Name="CalcBindingsHeader"
+                   Grid.Row="6"
                    Text="Calculation bindings"
                    FontSize="13"
                    FontWeight="Bold"
@@ -139,7 +200,7 @@
                    Visibility="Collapsed" />
 
         <Border x:Name="CalcBindingsBorder"
-                Grid.Row="5"
+                Grid.Row="7"
                 Background="#252526"
                 BorderBrush="#3e3e3e"
                 BorderThickness="1"
@@ -174,7 +235,7 @@
             </ScrollViewer>
         </Border>
 
-        <Grid Grid.Row="6" Margin="0,12,0,0">
+        <Grid Grid.Row="8" Margin="0,12,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -202,7 +263,7 @@
                      HorizontalScrollBarVisibility="Auto" />
         </Grid>
 
-        <DockPanel Grid.Row="7" Margin="0,12,0,0">
+        <DockPanel Grid.Row="9" Margin="0,12,0,0">
             <Button x:Name="CancelButton"
                     DockPanel.Dock="Right"
                     Content="Cancel"

--- a/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
+++ b/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
@@ -13,18 +13,19 @@ namespace LambdaBoss.UI;
 ///     Spec 0008 — the <c>/Refactor</c> dialog. Shows the active cell's
 ///     original formula, the engine-extracted / existing-LET input rows
 ///     (with editable names, Include checkbox, drag + Alt+Up/Down reorder),
-///     a read-only Calculation-bindings section (PR 2+), and a live
-///     preview of the synthesised LET. Save returns the preview text via
+///     the PR 3 promotable section (named ranges + external refs),
+///     a read-only Calculation-bindings section, and a live preview of
+///     the synthesised LET. Save returns the preview text via
 ///     <see cref="SavedFormula" />; Cancel discards.
 ///     The code-behind is intentionally thin: every row-state change
-///     (rename, Include toggle, reorder) calls back into the supplied
-///     <c>recompute</c> delegate (which wraps
+///     (rename, Include toggle, reorder, Promote toggle) calls back into
+///     the supplied <c>recompute</c> delegate (which wraps
 ///     <see cref="RefactorEngine.Recompute" />), and the result replaces
-///     the preview + the calc-binding list in place. Row Keys (not
-///     <c>FormulaRef</c>s) drive the identity round-trip with the engine
-///     so existing-LET value bindings whose RHS isn't a single cell ref
-///     (e.g. a literal or a named range) can be tracked alongside
-///     extracted refs.
+///     the preview + calc-binding list + promotables in place. Row Keys
+///     (not <c>FormulaRef</c>s) drive the identity round-trip with the
+///     engine so existing-LET value bindings whose RHS isn't a single
+///     cell ref (e.g. a literal or a named range) and promoted promotables
+///     can be tracked alongside extracted refs.
 /// </summary>
 public partial class RefactorToLetWindow
 {
@@ -39,6 +40,7 @@ public partial class RefactorToLetWindow
     // collide with one.
     private readonly IReadOnlyList<string> _calcBindingNames;
     private readonly ObservableCollection<RefactorCalcBindingVm> _calcRows = [];
+    private readonly ObservableCollection<RefactorPromotableRowVm> _promotables = [];
 
     private readonly Func<IReadOnlyList<RefactorRowState>, RefactorResult> _recompute;
     private readonly ObservableCollection<RefactorInputRowVm> _rows = [];
@@ -65,9 +67,11 @@ public partial class RefactorToLetWindow
         _calcBindingNames = initial.CalcBindings.Select(c => c.Name).ToList();
         BuildRowsFromInputs(initial.Inputs);
         UpdateCalcBindings(initial.CalcBindings);
+        UpdatePromotables(initial.Promotables);
         _rows.CollectionChanged += Rows_CollectionChanged;
         InputsList.ItemsSource = _rows;
         CalcBindingsList.ItemsSource = _calcRows;
+        PromotablesList.ItemsSource = _promotables;
 
         UpdateSaveButtonEnabled(RevalidateNames());
     }
@@ -173,6 +177,37 @@ public partial class RefactorToLetWindow
         CalcBindingsBorder.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
     }
 
+    /// <summary>
+    ///     Rebuilds the promotables collection from the engine's most recent
+    ///     result. The dialog doesn't track per-promotable user state besides
+    ///     the Promote toggle (which has just been processed by the engine),
+    ///     so a wholesale rebuild is safe.
+    /// </summary>
+    private void UpdatePromotables(IReadOnlyList<RefactorPromotableRow> promotables)
+    {
+        _suppressRecompute = true;
+        try
+        {
+            foreach (var vm in _promotables)
+                vm.PropertyChanged -= Promotable_PropertyChanged;
+            _promotables.Clear();
+            foreach (var p in promotables)
+            {
+                var vm = new RefactorPromotableRowVm(p);
+                vm.PropertyChanged += Promotable_PropertyChanged;
+                _promotables.Add(vm);
+            }
+        }
+        finally
+        {
+            _suppressRecompute = false;
+        }
+
+        var show = promotables.Count > 0;
+        PromotablesHeader.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+        PromotablesBorder.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+    }
+
     private void Rows_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         // Reorder via drag/drop or Alt+Up/Down fires Move; rerun the
@@ -190,6 +225,87 @@ public partial class RefactorToLetWindow
 
         UpdateSaveButtonEnabled(RevalidateNames());
         RecomputeAndRefresh();
+    }
+
+    /// <summary>
+    ///     When a promotable's Promote checkbox flips on/off, mutate
+    ///     <see cref="_rows" /> to add or remove the corresponding input
+    ///     row (Promote-on creates a fresh promoted input row with a
+    ///     locally allocated <c>inputN</c> name; Promote-off removes the
+    ///     row matched by Key), then recompute. The recompute pass
+    ///     overwrites <see cref="_promotables" /> from the engine's
+    ///     <see cref="RefactorResult.Promotables" />, so the VM that fired
+    ///     this event is replaced with a fresh one carrying the engine's
+    ///     authoritative state.
+    /// </summary>
+    private void Promotable_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_suppressRecompute) return;
+        if (e.PropertyName != nameof(RefactorPromotableRowVm.Promote)) return;
+        if (sender is not RefactorPromotableRowVm vm) return;
+
+        if (vm.Promote)
+        {
+            // Already present? Defensive — shouldn't happen since promotable
+            // VMs only show when un-promoted, but the engine's reconciliation
+            // is the source of truth so we tolerate it.
+            if (_rows.Any(r => string.Equals(r.Key, vm.Key, StringComparison.Ordinal)))
+                return;
+
+            var name = AllocateLocalAutoName();
+            var origin = vm.Kind == RefactorPromotableKind.NamedRange
+                ? RefactorRowOrigin.PromotedNamedRange
+                : RefactorRowOrigin.PromotedExternalRef;
+            var input = new RefactorInputRow(vm.Key, null, name, vm.Token, origin);
+            var rowVm = new RefactorInputRowVm(input);
+            rowVm.PropertyChanged += Row_PropertyChanged;
+            _suppressRecompute = true;
+            try
+            {
+                _rows.Add(rowVm);
+            }
+            finally
+            {
+                _suppressRecompute = false;
+            }
+        }
+        else
+        {
+            var row = _rows.FirstOrDefault(r => string.Equals(r.Key, vm.Key, StringComparison.Ordinal));
+            if (row != null)
+            {
+                _suppressRecompute = true;
+                try
+                {
+                    row.PropertyChanged -= Row_PropertyChanged;
+                    _rows.Remove(row);
+                }
+                finally
+                {
+                    _suppressRecompute = false;
+                }
+            }
+        }
+
+        UpdateSaveButtonEnabled(RevalidateNames());
+        RecomputeAndRefresh();
+    }
+
+    /// <summary>
+    ///     Picks the lowest free <c>inputN</c> name not already in use by an
+    ///     existing input row or a calc binding. Matches the engine's
+    ///     allocator so dialog-allocated and engine-allocated names land in
+    ///     the same sequence when the user mixes extracted refs with
+    ///     promoted promotables.
+    /// </summary>
+    private string AllocateLocalAutoName()
+    {
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var r in _rows) used.Add(r.Name);
+        foreach (var c in _calcBindingNames) used.Add(c);
+        var i = 1;
+        while (used.Contains("input" + i)) i++;
+        return "input" + i;
     }
 
     private void RecomputeAndRefresh()
@@ -213,6 +329,10 @@ public partial class RefactorToLetWindow
         {
             _suppressRecompute = false;
         }
+
+        // Reconcile promotables AFTER releasing the guard so the
+        // promotables update can rewire the per-VM property handlers.
+        UpdatePromotables(newResult.Promotables);
     }
 
     /// <summary>
@@ -314,6 +434,20 @@ public class RefactorInputRowVm : INotifyPropertyChanged
                 "; refs to those names were rewritten to use this one.";
             BadgeVisibility = Visibility.Visible;
         }
+        else if (input.Origin == RefactorRowOrigin.PromotedNamedRange)
+        {
+            BadgeText = "promoted name";
+            BadgeTooltip =
+                "Promoted from the named-range section. Uncheck Promote there to un-promote.";
+            BadgeVisibility = Visibility.Visible;
+        }
+        else if (input.Origin == RefactorRowOrigin.PromotedExternalRef)
+        {
+            BadgeText = "promoted ref";
+            BadgeTooltip =
+                "Promoted external-workbook ref. Uncheck Promote there to un-promote.";
+            BadgeVisibility = Visibility.Visible;
+        }
         else
         {
             BadgeText = string.Empty;
@@ -367,6 +501,57 @@ public class RefactorInputRowVm : INotifyPropertyChanged
     public Brush NameBrush => Include ? ActiveNameBrush : MutedBrush;
     public Brush RhsBrush => Include ? ActiveRhsBrush : MutedBrush;
     public Brush NameBorderBrush => IsNameValid ? DefaultNameBorderBrush : InvalidNameBorderBrush;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? prop = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+    }
+}
+
+/// <summary>
+///     Row view-model bound to <see cref="RefactorToLetWindow" />'s
+///     promote-to-input list. The dialog flips <see cref="Promote" /> in
+///     response to the user's checkbox toggle; the
+///     <c>PropertyChanged</c> handler on the window adds or removes the
+///     corresponding row in the inputs list. Read-only otherwise —
+///     <see cref="Token" /> and <see cref="OccurrencesLabel" /> come from
+///     the engine and don't change for the lifetime of this VM.
+/// </summary>
+public class RefactorPromotableRowVm : INotifyPropertyChanged
+{
+    private bool _promote;
+
+    public RefactorPromotableRowVm(RefactorPromotableRow row)
+    {
+        Key = row.Key;
+        Kind = row.Kind;
+        Token = row.Token;
+        Occurrences = row.Occurrences;
+        KindLabel = row.Kind == RefactorPromotableKind.NamedRange
+            ? "named range"
+            : "external ref";
+        OccurrencesLabel = row.Occurrences == 1 ? "1 use" : row.Occurrences + " uses";
+    }
+
+    public string Key { get; }
+    public RefactorPromotableKind Kind { get; }
+    public string Token { get; }
+    public int Occurrences { get; }
+    public string KindLabel { get; }
+    public string OccurrencesLabel { get; }
+
+    public bool Promote
+    {
+        get => _promote;
+        set
+        {
+            if (_promote == value) return;
+            _promote = value;
+            OnPropertyChanged();
+        }
+    }
 
     public event PropertyChangedEventHandler? PropertyChanged;
 


### PR DESCRIPTION
## Summary

- New `IWorkbookContext` interface + live adapter in `RefactorCommand` populates workbook + active-sheet defined names once when the dialog opens; engine consults it on every `Recompute`.
- External refs and workbook/worksheet-scoped defined names (excluding LAMBDA names via `LambdaSignatureParser.IsLambdaFormula`) appear as default-off rows in a new "Promote to input" section under the Inputs list. Toggling Promote materialises the row as a binding with an auto-allocated name; the synthesised LET swaps the original token for the binding name throughout the body.
- Cell refs and promoted external refs ride the existing `CellRefExtractor.Rewrite` path; promoted named-range identifiers ride a second-pass identifier rewriter that respects the same string / single-quoted-qualifier boundaries as `CellRefExtractor`.

Closes #204

## Test plan

- [x] Unit tests added — workbook-scoped name promoted, worksheet-scoped name promoted, LAMBDA name excluded (with and without trailing `(`), un-promoted name stays inline, external ref defaults to promotable, external ref promotion produces a binding, identifier-boundary correctness for `Help?Foo`.
- [x] Full unit suite green (968 / 968).
- [x] Manual Excel test (per the issue body): define workbook name `Tax_Rate = 0.2`, type `=A1 * Tax_Rate + Tax_Rate`, run `/Refactor`. Verify `Tax_Rate` appears in the promotable section with occurrences = 2; promote it; Save; confirm the LET evaluates.

## Notes

- The dialog moves a row out of the Promotables section when Promote is toggled on (engine returns it only in `RefactorResult.Inputs`). To un-promote in the current session, leave the row in Inputs and uncheck Include (the original token stays inline). A future iteration can add a dedicated unpromote control to mirror the Promote toggle bidirectionally.
- `RefactorResult.Promotables` is now part of the engine's public contract; existing callers passing no context get an empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)