### PR TITLE
Refactor to LET — PR 4: promotable literals + drop-input UX polish (spec 0008)

### DIFF
--- a/addin/lambda-boss.Tests/RefactorEngineTests.cs
+++ b/addin/lambda-boss.Tests/RefactorEngineTests.cs
@@ -550,13 +550,16 @@ public class RefactorEngineTests
         var ctx = new StubContext(("LocalRate", "=Sheet1!$D$10"));
         var initial = RefactorEngine.Refactor("=LocalRate * 2", Sheet, ctx);
 
-        var promo = Assert.Single(initial.Promotables);
+        var promo = Assert.Single(
+            initial.Promotables.Where(p => p.Kind == RefactorPromotableKind.NamedRange));
         Assert.Equal("LocalRate", promo.Token);
 
         var rowStates = new[] { new RefactorRowState(promo.Key, "rate") };
         var result = RefactorEngine.Recompute("=LocalRate * 2", Sheet, rowStates, ctx);
 
-        Assert.Empty(result.Promotables);
+        // The named range is gone from promotables (the literal `2` remains).
+        Assert.DoesNotContain(
+            result.Promotables, p => p.Kind == RefactorPromotableKind.NamedRange);
         var input = Assert.Single(result.Inputs);
         Assert.Equal("rate", input.Name);
         Assert.Equal("LocalRate", input.Rhs);
@@ -646,6 +649,242 @@ public class RefactorEngineTests
         var result = RefactorEngine.Refactor(
             "=LET(rate, A1, rate * 2)", Sheet, ctx);
 
+        // 'rate' is a local binding, not a promotable named range (the
+        // literal `2` is a separate promotable and unaffected here).
+        Assert.DoesNotContain(
+            result.Promotables, p => p.Kind == RefactorPromotableKind.NamedRange);
+    }
+
+    // ---------- PR 4 — promotable literals ----------
+
+    [Fact]
+    public void Refactor_NumericLiteral_AppearsAsPromotable_NotInputByDefault_NoContextNeeded()
+    {
+        // No workbook context: literals are purely textual.
+        var result = RefactorEngine.Refactor("=A1 * 100 + 100", Sheet, context: null);
+
+        Assert.Null(result.Diagnostic);
+        var lit = Assert.Single(result.Promotables);
+        Assert.Equal(RefactorPromotableKind.Literal, lit.Kind);
+        Assert.Equal("100", lit.Token);
+        Assert.Equal(2, lit.Occurrences);
+
+        // Un-promoted: only A1 is a binding; literals stay inline.
+        var input = Assert.Single(result.Inputs);
+        Assert.Equal("A1", input.Rhs);
+        Assert.Contains("input1 * 100 + 100", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_NumericLiteralPromoted_ReplacedEverywhere()
+    {
+        var formula = "=A1 * 10 + B1 * 10";
+        var initial = RefactorEngine.Refactor(formula, Sheet);
+        var lit = initial.Promotables.Single(p => p.Kind == RefactorPromotableKind.Literal);
+        Assert.Equal(2, lit.Occurrences);
+
+        var rowStates = new[]
+        {
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
+            new RefactorRowState(initial.Inputs[1].Key, initial.Inputs[1].Name),
+            new RefactorRowState(lit.Key, "ten"),
+        };
+        var result = RefactorEngine.Recompute(formula, Sheet, rowStates);
+
         Assert.Empty(result.Promotables);
+        var promoted = result.Inputs.Single(r => r.Origin == RefactorRowOrigin.PromotedLiteral);
+        Assert.Equal("ten", promoted.Name);
+        Assert.Equal("10", promoted.Rhs);
+        Assert.Contains("ten, 10", result.SynthesisedLet);
+        Assert.Contains("input1 * ten + input2 * ten", result.SynthesisedLet);
+        AssertRoundTrips(result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_StringLiteralWithEmbeddedQuotes_PromotesAsOneRow()
+    {
+        // The "" inside the string is an escaped double-quote; both copies
+        // share a value and dedupe to one promotable. Token keeps the
+        // original (escaped) spelling.
+        const string formula = "=IF(A1, \"say \"\"hi\"\"\", \"say \"\"hi\"\"\")";
+        var initial = RefactorEngine.Refactor(formula, Sheet);
+
+        var lit = initial.Promotables.Single(p => p.Kind == RefactorPromotableKind.Literal);
+        Assert.Equal("\"say \"\"hi\"\"\"", lit.Token);
+        Assert.Equal(2, lit.Occurrences);
+
+        var rowStates = new[]
+        {
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
+            new RefactorRowState(lit.Key, "greeting"),
+        };
+        var result = RefactorEngine.Recompute(formula, Sheet, rowStates);
+
+        var promoted = result.Inputs.Single(r => r.Origin == RefactorRowOrigin.PromotedLiteral);
+        Assert.Equal("\"say \"\"hi\"\"\"", promoted.Rhs);
+        Assert.Contains("IF(input1, greeting, greeting)", result.SynthesisedLet);
+        AssertRoundTrips(result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_BooleanLiteral_PromotesAndReplaces()
+    {
+        const string formula = "=IF(A1, TRUE, TRUE)";
+        var initial = RefactorEngine.Refactor(formula, Sheet);
+
+        var lit = initial.Promotables.Single(p => p.Kind == RefactorPromotableKind.Literal);
+        Assert.Equal("TRUE", lit.Token);
+        Assert.Equal(2, lit.Occurrences);
+
+        var rowStates = new[]
+        {
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
+            new RefactorRowState(lit.Key, "flag"),
+        };
+        var result = RefactorEngine.Recompute(formula, Sheet, rowStates);
+
+        var promoted = result.Inputs.Single(r => r.Origin == RefactorRowOrigin.PromotedLiteral);
+        Assert.Equal("TRUE", promoted.Rhs);
+        Assert.Contains("IF(input1, flag, flag)", result.SynthesisedLet);
+        AssertRoundTrips(result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_TwoDistinctNumerics_StayDistinctRows()
+    {
+        var result = RefactorEngine.Refactor("=A1 * 10 + B1 * 20", Sheet);
+
+        var lits = result.Promotables
+            .Where(p => p.Kind == RefactorPromotableKind.Literal)
+            .ToList();
+        Assert.Equal(2, lits.Count);
+        Assert.Equal("10", lits[0].Token);
+        Assert.Equal("20", lits[1].Token);
+    }
+
+    [Fact]
+    public void Refactor_NumericLiterals_DedupeByValue_FirstSpellingWins()
+    {
+        // 0.20 and 0.2 parse to the same value → one promotable; the first
+        // occurrence's spelling (0.20) is preserved.
+        var result = RefactorEngine.Refactor("=A1 * 0.20 + B1 * 0.2", Sheet);
+
+        var lit = Assert.Single(result.Promotables.Where(p => p.Kind == RefactorPromotableKind.Literal));
+        Assert.Equal("0.20", lit.Token);
+        Assert.Equal(2, lit.Occurrences);
+    }
+
+    [Fact]
+    public void Refactor_DigitsInsideIdentifier_NotTreatedAsLiteral()
+    {
+        // The '1' in the named range 'Cell1' must not surface as a numeric
+        // literal; only the standalone 5 does.
+        var ctx = new StubContext(("Cell1", "=Sheet1!$Z$9"));
+        var result = RefactorEngine.Refactor("=Cell1 * 5", Sheet, ctx);
+
+        var lit = Assert.Single(result.Promotables.Where(p => p.Kind == RefactorPromotableKind.Literal));
+        Assert.Equal("5", lit.Token);
+    }
+
+    [Fact]
+    public void Refactor_ManualExample_SurfacesAllLiterals_InSourceOrder()
+    {
+        // Issue 205 manual-test formula. Literals dedupe by value; the
+        // duplicate 100 collapses, leaving source-order tokens.
+        const string formula =
+            "=IF(A1 > 100, \"high\", IF(A1 > 50, \"medium\", \"low\")) + IF(B1 > 100, 1, 0)";
+        var result = RefactorEngine.Refactor(formula, Sheet);
+
+        var literals = result.Promotables
+            .Where(p => p.Kind == RefactorPromotableKind.Literal)
+            .Select(p => p.Token)
+            .ToList();
+        Assert.Equal(
+            new[] { "100", "\"high\"", "50", "\"medium\"", "\"low\"", "1", "0" },
+            literals);
+
+        var hundred = result.Promotables.Single(
+            p => p.Kind == RefactorPromotableKind.Literal && p.Token == "100");
+        Assert.Equal(2, hundred.Occurrences);
+    }
+
+    [Fact]
+    public void Recompute_PromotedLiteralThenDropped_RestoresLiteralInline()
+    {
+        // Promote 10, then untick Include — every occurrence returns to the
+        // inline literal and no binding is emitted.
+        const string formula = "=A1 * 10 + 10";
+        var initial = RefactorEngine.Refactor(formula, Sheet);
+        var lit = initial.Promotables.Single(p => p.Kind == RefactorPromotableKind.Literal);
+
+        var rowStates = new[]
+        {
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
+            new RefactorRowState(lit.Key, "ten", Include: false),
+        };
+        var result = RefactorEngine.Recompute(formula, Sheet, rowStates);
+
+        Assert.DoesNotContain(result.Inputs, r => r.Origin == RefactorRowOrigin.PromotedLiteral);
+        Assert.Contains("input1 * 10 + 10", result.SynthesisedLet);
+        Assert.DoesNotContain("ten", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_PromotedNamedRangeThenDropped_RestoresIdentifierInline()
+    {
+        var ctx = new StubContext(("Tax_Rate", "=0.2"));
+        const string formula = "=A1 * Tax_Rate + Tax_Rate";
+        var initial = RefactorEngine.Refactor(formula, Sheet, ctx);
+        var promo = initial.Promotables.Single(p => p.Kind == RefactorPromotableKind.NamedRange);
+
+        var rowStates = new[]
+        {
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
+            new RefactorRowState(promo.Key, "rate", Include: false),
+        };
+        var result = RefactorEngine.Recompute(formula, Sheet, rowStates, ctx);
+
+        Assert.DoesNotContain(result.Inputs, r => r.Origin == RefactorRowOrigin.PromotedNamedRange);
+        Assert.Contains("input1 * Tax_Rate + Tax_Rate", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Refactor_ExistingLet_LiteralsInCalcAndBody_Promotable_ValueBindingRhsNot()
+    {
+        // The "x" value binding's RHS literal must NOT be promotable; the
+        // calc binding's 0.1 and the body's 2 should be.
+        const string formula =
+            "=LET(x, 100, factor, A1 * 0.1, x * 2 + factor)";
+        var result = RefactorEngine.Refactor(formula, Sheet);
+
+        var litTokens = result.Promotables
+            .Where(p => p.Kind == RefactorPromotableKind.Literal)
+            .Select(p => p.Token)
+            .ToList();
+        Assert.DoesNotContain("100", litTokens); // value-binding RHS, not scanned
+        Assert.Contains("0.1", litTokens);
+        Assert.Contains("2", litTokens);
+    }
+
+    [Fact]
+    public void Recompute_ExistingLet_PromoteLiteralFromBody_AddsBinding()
+    {
+        const string formula = "=LET(a, A1, a * 100 + 100)";
+        var initial = RefactorEngine.Refactor(formula, Sheet);
+        var lit = initial.Promotables.Single(p => p.Kind == RefactorPromotableKind.Literal);
+        Assert.Equal(2, lit.Occurrences);
+
+        var rowStates = new[]
+        {
+            new RefactorRowState(initial.Inputs[0].Key, initial.Inputs[0].Name),
+            new RefactorRowState(lit.Key, "scale"),
+        };
+        var result = RefactorEngine.Recompute(formula, Sheet, rowStates);
+
+        var promoted = result.Inputs.Single(r => r.Origin == RefactorRowOrigin.PromotedLiteral);
+        Assert.Equal("scale", promoted.Name);
+        Assert.Equal("100", promoted.Rhs);
+        Assert.Contains("a * scale + scale", result.SynthesisedLet);
+        AssertRoundTrips(result.SynthesisedLet);
     }
 }

--- a/addin/lambda-boss/CellRefExtractor.cs
+++ b/addin/lambda-boss/CellRefExtractor.cs
@@ -154,6 +154,43 @@ internal static class CellRefExtractor
     }
 
     /// <summary>
+    ///     Returns the <c>[Start, End)</c> character spans of every cell-ref
+    ///     token in <paramref name="formula" /> (string literals skipped),
+    ///     in source order. Spec 0008 / PR 4's literal tokenizer uses this to
+    ///     mask out cell-ref ranges before walking for promotable numeric /
+    ///     string / boolean literals — so the row digits of <c>A1</c> aren't
+    ///     mistaken for a numeric literal. Spans are non-overlapping and
+    ///     anchored to the original string's indices.
+    /// </summary>
+    public static IReadOnlyList<(int Start, int End)> MatchSpans(string formula)
+    {
+        if (string.IsNullOrEmpty(formula))
+            return Array.Empty<(int, int)>();
+
+        var spans = new List<(int, int)>();
+        var i = 0;
+        while (i < formula.Length)
+        {
+            if (formula[i] == '"')
+            {
+                i = SkipString(formula, i);
+                continue;
+            }
+
+            var nextQuote = formula.IndexOf('"', i);
+            var segEnd = nextQuote < 0 ? formula.Length : nextQuote;
+            var segment = formula[i..segEnd];
+
+            foreach (Match m in CellRefPattern.Matches(segment))
+                spans.Add((i + m.Index, i + m.Index + m.Length));
+
+            i = segEnd;
+        }
+
+        return spans;
+    }
+
+    /// <summary>
     ///     Rewrites every in-scope ref in <paramref name="formula" /> to the
     ///     binding name supplied by <paramref name="lookup" />. Refs not in
     ///     <paramref name="lookup" /> (out-of-scope cells, named ranges,

--- a/addin/lambda-boss/RefactorEngine.cs
+++ b/addin/lambda-boss/RefactorEngine.cs
@@ -58,6 +58,25 @@ public static class RefactorEngine
         @"(?<![A-Za-z0-9_.!:'\]#?])[A-Za-z_][A-Za-z0-9_.?]*(?![A-Za-z0-9_.?(!])",
         RegexOptions.CultureInvariant);
 
+    // Numeric-literal matcher (PR 4), anchored at the scan position via \G.
+    // Accepts an optional integer/decimal mantissa with an optional
+    // scientific exponent (the exponent carries its own sign — we never
+    // capture a leading +/- because that's an operator in formula text, so
+    // `A1*-5` correctly promotes `5` and keeps the `-` inline). The
+    // lookbehind rejects digits sitting inside an identifier (`input1`); the
+    // lookahead rejects a trailing identifier char so we don't truncate a
+    // longer token.
+    private static readonly Regex NumericLiteralPattern = new(
+        @"\G(?<![A-Za-z0-9_.])(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?(?![A-Za-z0-9_.])",
+        RegexOptions.CultureInvariant);
+
+    // Boolean-literal matcher (PR 4). Case-insensitive TRUE / FALSE that
+    // isn't part of a larger identifier and isn't a function call (`TRUE(`)
+    // or sheet qualifier (`TRUE!`).
+    private static readonly Regex BooleanLiteralPattern = new(
+        @"\G(?<![A-Za-z0-9_.])(?:TRUE|FALSE)(?![A-Za-z0-9_.(!])",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
     /// <summary>
     ///     Runs the initial refactor over <paramref name="formula" />.
     ///     Existing LETs are parsed and merged/extracted per spec 0008;
@@ -168,10 +187,11 @@ public static class RefactorEngine
         var keptRows = materialised.Where(r => r.IsIncluded).ToList();
 
         var identifierSubs = BuildPromotedNamedRangeSubstitutions(keptRows);
+        var literalSubs = BuildPromotedLiteralSubstitutions(keptRows);
 
         var synthesisedLet = BuildSynthesisedLet(
             formula, activeSheet, keptRows, Array.Empty<RefactorCalcBindingRow>(),
-            false, null, identifierSubs);
+            false, null, identifierSubs, literalSubs);
 
         return new RefactorResult(
             formula,
@@ -300,12 +320,14 @@ public static class RefactorEngine
         foreach (var kv in BuildPromotedNamedRangeSubstitutions(keptRows))
             identifierSubs[kv.Key] = kv.Value;
 
+        var literalSubs = BuildPromotedLiteralSubstitutions(keptRows);
+
         var rewrittenCalcs = RewriteCalcBindings(
-            calcBindings, activeSheet, keptRows, identifierSubs);
+            calcBindings, activeSheet, keptRows, identifierSubs, literalSubs);
 
         var synthesisedLet = BuildSynthesisedLet(
             formula, activeSheet, keptRows, rewrittenCalcs,
-            true, parsed.Body, identifierSubs);
+            true, parsed.Body, identifierSubs, literalSubs);
 
         return new RefactorResult(
             formula,
@@ -451,6 +473,28 @@ public static class RefactorEngine
         return subs;
     }
 
+    /// <summary>
+    ///     Builds the literal-value → binding-name subs for promoted literals
+    ///     among <paramref name="keptRows" />. The key is the parsed-value
+    ///     key (so every occurrence of the value rewrites, regardless of
+    ///     spelling) — re-derived from the row's RHS (the original token
+    ///     text) by re-tokenising it.
+    /// </summary>
+    private static Dictionary<string, string> BuildPromotedLiteralSubstitutions(
+        IReadOnlyList<MaterialisedRow> keptRows)
+    {
+        var subs = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var r in keptRows)
+        {
+            if (r.Row.Origin != RefactorRowOrigin.PromotedLiteral) continue;
+            var key = LiteralValueKeyOf(r.Row.Rhs);
+            if (key != null)
+                subs[key] = r.Row.Name;
+        }
+
+        return subs;
+    }
+
     // ---------------- ref extraction (calc bindings + body) ----------------
 
     private static void ExtractNewRefs(
@@ -572,6 +616,34 @@ public static class RefactorEngine
             }
         }
 
+        // Literals — numeric / string / boolean, deduped by parsed value
+        // (not spelling, so `0.20` and `0.2` collapse). First occurrence's
+        // text and position win for display + order. Independent of the
+        // workbook context: literals are purely textual.
+        var litCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var litFirstText = new Dictionary<string, string>(StringComparer.Ordinal);
+        var litOrder = new List<string>(); // value keys, first-seen order
+        foreach (var scope in identifierScopes)
+        foreach (var tok in WalkLiterals(scope))
+        {
+            if (!litCounts.ContainsKey(tok.ValueKey))
+            {
+                litOrder.Add(tok.ValueKey);
+                litFirstText[tok.ValueKey] = tok.Text;
+            }
+
+            litCounts[tok.ValueKey] = litCounts.TryGetValue(tok.ValueKey, out var c) ? c + 1 : 1;
+        }
+
+        foreach (var vk in litOrder)
+        {
+            promotables.Add(new RefactorPromotableRow(
+                BuildLiteralKey(vk),
+                RefactorPromotableKind.Literal,
+                litFirstText[vk],
+                litCounts[vk]));
+        }
+
         return promotables;
     }
 
@@ -629,6 +701,7 @@ public static class RefactorEngine
             switch (p.Kind)
             {
                 case RefactorPromotableKind.NamedRange:
+                case RefactorPromotableKind.Literal:
                     byKey[p.Key] = new PromotedInfo(p, null);
                     break;
                 case RefactorPromotableKind.ExternalRef:
@@ -741,6 +814,13 @@ public static class RefactorEngine
                     name,
                     info.Row.Token,
                     RefactorRowOrigin.PromotedExternalRef);
+            case RefactorPromotableKind.Literal:
+                return new RefactorInputRow(
+                    info.Row.Key,
+                    Source: null,
+                    name,
+                    info.Row.Token,
+                    RefactorRowOrigin.PromotedLiteral);
             default:
                 throw new InvalidOperationException(
                     $"Unknown promotable kind: {info.Row.Kind}");
@@ -764,7 +844,8 @@ public static class RefactorEngine
         IReadOnlyList<LetBinding> calcBindings,
         string activeSheet,
         IReadOnlyList<MaterialisedRow> keptRows,
-        IReadOnlyDictionary<string, string> identifierSubs)
+        IReadOnlyDictionary<string, string> identifierSubs,
+        IReadOnlyDictionary<string, string> literalSubs)
     {
         if (calcBindings.Count == 0)
             return Array.Empty<RefactorCalcBindingRow>();
@@ -773,7 +854,7 @@ public static class RefactorEngine
         var result = new List<RefactorCalcBindingRow>(calcBindings.Count);
         foreach (var c in calcBindings)
         {
-            var rewritten = RewriteText(c.RhsText, activeSheet, refLookup, identifierSubs);
+            var rewritten = RewriteText(c.RhsText, activeSheet, refLookup, identifierSubs, literalSubs);
             result.Add(new RefactorCalcBindingRow(c.Name, rewritten));
         }
 
@@ -791,24 +872,32 @@ public static class RefactorEngine
     }
 
     /// <summary>
-    ///     Runs the cell-ref rewrite (replacing in-scope <see cref="FormulaRef" />s
-    ///     with their kept binding names) followed by the identifier
-    ///     rewrite (renaming merged-away binding names, inlining the RHS
-    ///     of dropped existing-LET value bindings, or swapping a promoted
-    ///     named range's identifier for its binding name).
+    ///     Runs, in order: the cell-ref rewrite (replacing in-scope
+    ///     <see cref="FormulaRef" />s with their kept binding names), the
+    ///     identifier rewrite (renaming merged-away binding names, inlining
+    ///     the RHS of dropped existing-LET value bindings, or swapping a
+    ///     promoted named range's identifier for its binding name), and
+    ///     finally the literal rewrite (swapping promoted numeric / string /
+    ///     boolean literals for their binding name). Literals run last so
+    ///     the earlier passes — which skip string contents — never see a
+    ///     promoted-string binding name as a candidate identifier.
     /// </summary>
     private static string RewriteText(
         string text,
         string activeSheet,
         IReadOnlyDictionary<FormulaRef, string> refLookup,
-        IReadOnlyDictionary<string, string> identifierSubs)
+        IReadOnlyDictionary<string, string> identifierSubs,
+        IReadOnlyDictionary<string, string> literalSubs)
     {
         var afterRefs = refLookup.Count > 0
             ? CellRefExtractor.Rewrite(text, activeSheet, refLookup)
             : text;
-        if (identifierSubs.Count == 0)
-            return afterRefs;
-        return RewriteIdentifiers(afterRefs, identifierSubs);
+        var afterIds = identifierSubs.Count > 0
+            ? RewriteIdentifiers(afterRefs, identifierSubs)
+            : afterRefs;
+        return literalSubs.Count > 0
+            ? RewriteLiterals(afterIds, literalSubs)
+            : afterIds;
     }
 
     private static string RewriteIdentifiers(
@@ -850,6 +939,166 @@ public static class RefactorEngine
         }
 
         return sb.ToString();
+    }
+
+    // ---------------- literal tokenizer & rewrite (PR 4) ----------------
+
+    /// <summary>
+    ///     One literal occurrence found by <see cref="WalkLiterals" />:
+    ///     its <see cref="Start" /> / <see cref="Length" /> within the
+    ///     scanned text, the original <see cref="Text" /> (preserving
+    ///     spelling), and a value-based <see cref="ValueKey" /> used to
+    ///     dedupe occurrences and to look up promotion substitutions
+    ///     (so <c>0.20</c> and <c>0.2</c> share a key).
+    /// </summary>
+    private readonly record struct LiteralToken(
+        int Start, int Length, string Text, string ValueKey);
+
+    /// <summary>
+    ///     Walks <paramref name="text" /> left-to-right yielding every
+    ///     numeric / string / boolean literal occurrence in source order.
+    ///     Cell-ref tokens are pre-masked (via
+    ///     <see cref="CellRefExtractor.MatchSpans" />) so the row digits of
+    ///     <c>A1</c> aren't surfaced as a numeric literal; single-quoted
+    ///     sheet / workbook qualifiers are skipped wholesale. String
+    ///     literals are recognised directly (with embedded <c>""</c>
+    ///     un-escaped for the value key).
+    /// </summary>
+    private static IEnumerable<LiteralToken> WalkLiterals(string text)
+    {
+        if (string.IsNullOrEmpty(text)) yield break;
+
+        var masked = BuildCellRefMask(text);
+        var i = 0;
+        while (i < text.Length)
+        {
+            var c = text[i];
+
+            if (c == '"')
+            {
+                var end = SkipString(text, i);
+                // Only a properly-closed string is a literal; an unterminated
+                // quote (malformed formula) is skipped, not promoted.
+                if (end - i >= 2 && text[end - 1] == '"')
+                {
+                    var original = text.Substring(i, end - i);
+                    yield return new LiteralToken(
+                        i, end - i, original, "str:" + UnescapeString(original));
+                }
+
+                i = end;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                i = SkipSingleQuoted(text, i);
+                continue;
+            }
+
+            if (masked[i])
+            {
+                i++;
+                continue;
+            }
+
+            var numeric = NumericLiteralPattern.Match(text, i);
+            if (numeric.Success && numeric.Index == i
+                && !SpanTouchesMask(masked, i, numeric.Length)
+                && double.TryParse(
+                    numeric.Value,
+                    System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var val))
+            {
+                yield return new LiteralToken(
+                    i, numeric.Length, numeric.Value,
+                    "num:" + val.ToString("R", System.Globalization.CultureInfo.InvariantCulture));
+                i += numeric.Length;
+                continue;
+            }
+
+            var boolean = BooleanLiteralPattern.Match(text, i);
+            if (boolean.Success && boolean.Index == i
+                && !SpanTouchesMask(masked, i, boolean.Length))
+            {
+                var isTrue = string.Equals(boolean.Value, "TRUE", StringComparison.OrdinalIgnoreCase);
+                yield return new LiteralToken(
+                    i, boolean.Length, boolean.Value, "bool:" + (isTrue ? "true" : "false"));
+                i += boolean.Length;
+                continue;
+            }
+
+            i++;
+        }
+    }
+
+    /// <summary>
+    ///     Rewrites promoted literals to their binding names. Each
+    ///     occurrence whose value key is in <paramref name="subs" /> is
+    ///     replaced; everything else (including un-promoted literals) is
+    ///     left verbatim. Runs after the cell-ref and identifier passes;
+    ///     it re-derives the cell-ref mask from the text it's handed, so
+    ///     it's order-independent.
+    /// </summary>
+    private static string RewriteLiterals(
+        string text, IReadOnlyDictionary<string, string> subs)
+    {
+        if (string.IsNullOrEmpty(text) || subs.Count == 0) return text;
+
+        var sb = new StringBuilder(text.Length);
+        var pos = 0;
+        foreach (var tok in WalkLiterals(text))
+        {
+            if (!subs.TryGetValue(tok.ValueKey, out var name)) continue;
+            sb.Append(text, pos, tok.Start - pos);
+            sb.Append(name);
+            pos = tok.Start + tok.Length;
+        }
+
+        sb.Append(text, pos, text.Length - pos);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    ///     Re-tokenises a promoted literal row's RHS (its original token
+    ///     text) back to the value key used in the substitution map.
+    ///     Returns null when the text isn't a recognisable literal (which
+    ///     shouldn't happen for a row the engine itself materialised).
+    /// </summary>
+    private static string? LiteralValueKeyOf(string token)
+    {
+        foreach (var t in WalkLiterals(token))
+            return t.ValueKey;
+        return null;
+    }
+
+    private static bool[] BuildCellRefMask(string text)
+    {
+        var mask = new bool[text.Length];
+        foreach (var (start, end) in CellRefExtractor.MatchSpans(text))
+            for (var k = start; k < end && k < mask.Length; k++)
+                mask[k] = true;
+        return mask;
+    }
+
+    private static bool SpanTouchesMask(bool[] mask, int start, int length)
+    {
+        for (var k = start; k < start + length && k < mask.Length; k++)
+            if (mask[k])
+                return true;
+        return false;
+    }
+
+    /// <summary>
+    ///     Strips the surrounding double quotes from a string literal and
+    ///     un-escapes embedded <c>""</c> to a single <c>"</c>, giving the
+    ///     value used for dedupe.
+    /// </summary>
+    private static string UnescapeString(string quoted)
+    {
+        if (quoted.Length < 2) return quoted;
+        return quoted.Substring(1, quoted.Length - 2).Replace("\"\"", "\"");
     }
 
     private static int IndexOfAny(string text, int start, char a, char b)
@@ -913,7 +1162,8 @@ public static class RefactorEngine
         IReadOnlyList<RefactorCalcBindingRow> rewrittenCalcs,
         bool isExistingLet,
         string? body,
-        IReadOnlyDictionary<string, string>? identifierSubstitutions)
+        IReadOnlyDictionary<string, string>? identifierSubstitutions,
+        IReadOnlyDictionary<string, string>? literalSubstitutions)
     {
         // No work to do — nothing extracted and nothing merged.
         if (!isExistingLet && keptInputs.Count == 0)
@@ -929,12 +1179,15 @@ public static class RefactorEngine
         // collapses to its body — the dialog still synthesises a valid
         // formula so the user can save (matches PR 1's "all dropped"
         // behaviour).
+        var idSubs = identifierSubstitutions ?? new Dictionary<string, string>();
+        var litSubs = literalSubstitutions ?? new Dictionary<string, string>();
+
         if (isExistingLet && keptInputs.Count == 0 && rewrittenCalcs.Count == 0)
         {
             var rewrittenBody = RewriteText(
                 body!, activeSheet,
                 BuildFormulaRefLookup(keptInputs),
-                identifierSubstitutions ?? new Dictionary<string, string>());
+                idSubs, litSubs);
             return "=" + rewrittenBody;
         }
 
@@ -949,18 +1202,18 @@ public static class RefactorEngine
             bodyText = RewriteText(
                 body!, activeSheet,
                 BuildFormulaRefLookup(keptInputs),
-                identifierSubstitutions ?? new Dictionary<string, string>());
+                idSubs, litSubs);
         }
         else
         {
             // Non-LET: the original formula's content (sans leading '=') is
-            // the LET body, with cell refs and (PR 3) promoted named
-            // ranges rewritten to kept binding names.
+            // the LET body, with cell refs, promoted named ranges (PR 3) and
+            // promoted literals (PR 4) rewritten to kept binding names.
             bodyText = RewriteText(
                 StripLeadingEquals(originalFormula),
                 activeSheet,
                 BuildFormulaRefLookup(keptInputs),
-                identifierSubstitutions ?? new Dictionary<string, string>());
+                idSubs, litSubs);
         }
 
         var sb = new StringBuilder();
@@ -992,6 +1245,11 @@ public static class RefactorEngine
     private static string BuildNamedRangeKey(string identifier)
     {
         return "named:" + identifier;
+    }
+
+    private static string BuildLiteralKey(string valueKey)
+    {
+        return "lit:" + valueKey;
     }
 
     /// <summary>

--- a/addin/lambda-boss/RefactorTypes.cs
+++ b/addin/lambda-boss/RefactorTypes.cs
@@ -9,15 +9,18 @@ namespace LambdaBoss;
 ///     or marked as the survivor of a merge. PR 3 adds
 ///     <see cref="PromotedNamedRange" /> and <see cref="PromotedExternalRef" />:
 ///     rows that were originally promotable but the user (or the dialog's
-///     initial state) has promoted into the inputs section. The dialog
-///     uses the badge to communicate the row's provenance.
+///     initial state) has promoted into the inputs section. PR 4 adds
+///     <see cref="PromotedLiteral" /> for promoted numeric / string /
+///     boolean literals. The dialog uses the badge to communicate the
+///     row's provenance.
 /// </summary>
 public enum RefactorRowOrigin
 {
     Extracted,
     ExistingLetValue,
     PromotedNamedRange,
-    PromotedExternalRef
+    PromotedExternalRef,
+    PromotedLiteral
 }
 
 /// <summary>
@@ -78,7 +81,16 @@ public enum RefactorPromotableKind
     NamedRange,
 
     /// <summary>An external-workbook ref (<c>[Wb.xlsx]Sheet!A1</c>, etc.).</summary>
-    ExternalRef
+    ExternalRef,
+
+    /// <summary>
+    ///     A numeric, string, or boolean literal (spec 0008 / PR 4). The
+    ///     <see cref="RefactorPromotableRow.Token" /> is the original text of
+    ///     the first occurrence (preserving formatting like <c>0.20</c>);
+    ///     occurrences dedupe by parsed value, not spelling. Promoting it
+    ///     replaces every occurrence with the binding name.
+    /// </summary>
+    Literal
 }
 
 /// <summary>

--- a/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
+++ b/addin/lambda-boss/UI/RefactorToLetWindow.xaml.cs
@@ -29,9 +29,6 @@ namespace LambdaBoss.UI;
 /// </summary>
 public partial class RefactorToLetWindow
 {
-    private const string DefaultStatusText =
-        "Save writes the LET into the active cell · Esc to cancel";
-
     private const string InvalidNameStatusText =
         "Fix invalid names before saving";
 
@@ -46,6 +43,10 @@ public partial class RefactorToLetWindow
     private readonly ObservableCollection<RefactorInputRowVm> _rows = [];
 
     private RefactorResult _result;
+
+    // Tracks the last name-validation outcome so the status bar can decide
+    // between a validation error and the summary count.
+    private bool _namesValid = true;
 
     // Reentrancy guard: rebuilding the row list during a Recompute fires
     // INotifyPropertyChanged on each VM, which would re-enter the change
@@ -253,9 +254,13 @@ public partial class RefactorToLetWindow
                 return;
 
             var name = AllocateLocalAutoName();
-            var origin = vm.Kind == RefactorPromotableKind.NamedRange
-                ? RefactorRowOrigin.PromotedNamedRange
-                : RefactorRowOrigin.PromotedExternalRef;
+            var origin = vm.Kind switch
+            {
+                RefactorPromotableKind.NamedRange => RefactorRowOrigin.PromotedNamedRange,
+                RefactorPromotableKind.ExternalRef => RefactorRowOrigin.PromotedExternalRef,
+                RefactorPromotableKind.Literal => RefactorRowOrigin.PromotedLiteral,
+                _ => RefactorRowOrigin.PromotedNamedRange
+            };
             var input = new RefactorInputRow(vm.Key, null, name, vm.Token, origin);
             var rowVm = new RefactorInputRowVm(input);
             rowVm.PropertyChanged += Row_PropertyChanged;
@@ -333,6 +338,11 @@ public partial class RefactorToLetWindow
         // Reconcile promotables AFTER releasing the guard so the
         // promotables update can rewire the per-VM property handlers.
         UpdatePromotables(newResult.Promotables);
+
+        // Refresh the summary now that _result + _promotables reflect the
+        // engine's latest output (the earlier validation pass ran against
+        // the stale counts).
+        RefreshStatusText();
     }
 
     /// <summary>
@@ -375,18 +385,54 @@ public partial class RefactorToLetWindow
 
     private void UpdateSaveButtonEnabled(bool allValid)
     {
+        _namesValid = allValid;
         // An existing LET with every input dropped still produces a valid
         // formula (the bare body), so Save stays enabled when calc
         // bindings exist OR at least one row is kept.
         var hasKeptRows = _rows.Any(r => r.Include);
         var hasCalcBindings = _calcBindingNames.Count > 0;
         SaveButton.IsEnabled = allValid && (hasKeptRows || hasCalcBindings);
-        if (!allValid)
+        RefreshStatusText();
+    }
+
+    /// <summary>
+    ///     Drives the status bar: validation errors take priority, then the
+    ///     "nothing to refactor" guard, then a summary count of the bindings
+    ///     plus any merge note. Reads the engine's latest <see cref="_result" />
+    ///     for promotable / calc-binding / merge counts and the live row
+    ///     collection for the included-input count.
+    /// </summary>
+    private void RefreshStatusText()
+    {
+        if (!_namesValid)
+        {
             StatusText.Text = InvalidNameStatusText;
-        else if (!hasKeptRows && !hasCalcBindings)
+            return;
+        }
+
+        var inputCount = _rows.Count(r => r.Include);
+        var calcCount = _calcBindingNames.Count;
+
+        if (inputCount == 0 && calcCount == 0)
+        {
             StatusText.Text = "No bindings selected — nothing to refactor";
-        else
-            StatusText.Text = DefaultStatusText;
+            return;
+        }
+
+        var promotableCount = _promotables.Count;
+        var mergeCount = _result.Inputs.Count(i => i.MergedFrom is { Count: > 0 });
+
+        var parts = new List<string>
+        {
+            inputCount == 1 ? "1 input" : inputCount + " inputs",
+            promotableCount + " promotable",
+            calcCount == 1 ? "1 calculation binding" : calcCount + " calculation bindings"
+        };
+        var summary = string.Join(", ", parts);
+        if (mergeCount > 0)
+            summary += mergeCount == 1 ? " · 1 merged" : $" · {mergeCount} merged";
+
+        StatusText.Text = summary;
     }
 }
 
@@ -446,6 +492,13 @@ public class RefactorInputRowVm : INotifyPropertyChanged
             BadgeText = "promoted ref";
             BadgeTooltip =
                 "Promoted external-workbook ref. Uncheck Promote there to un-promote.";
+            BadgeVisibility = Visibility.Visible;
+        }
+        else if (input.Origin == RefactorRowOrigin.PromotedLiteral)
+        {
+            BadgeText = "promoted literal";
+            BadgeTooltip =
+                "Promoted literal. Uncheck Promote there to un-promote.";
             BadgeVisibility = Visibility.Visible;
         }
         else
@@ -529,9 +582,13 @@ public class RefactorPromotableRowVm : INotifyPropertyChanged
         Kind = row.Kind;
         Token = row.Token;
         Occurrences = row.Occurrences;
-        KindLabel = row.Kind == RefactorPromotableKind.NamedRange
-            ? "named range"
-            : "external ref";
+        KindLabel = row.Kind switch
+        {
+            RefactorPromotableKind.NamedRange => "named range",
+            RefactorPromotableKind.ExternalRef => "external ref",
+            RefactorPromotableKind.Literal => "literal",
+            _ => "promotable"
+        };
         OccurrencesLabel = row.Occurrences == 1 ? "1 use" : row.Occurrences + " uses";
     }
 


### PR DESCRIPTION
## Summary

Final slice of the **Refactor to LET** feature (spec 0008). Adds **literal promotion** to the promotable section and polishes the drop-input UX + dialog status bar.

Closes #205 · Part of #201

## What changed

### Literal tokenizer (`RefactorEngine.WalkLiterals`)
Walks the formula text in source order, **masking cell-ref token spans** (new `CellRefExtractor.MatchSpans`) so the row digits of `A1` aren't mistaken for a literal, and skipping string contents / sheet qualifiers. Yields:

- **Numeric** literals (`100`, `0.20`, `1.5e-10`) — dedupe by parsed value, so `0.20` and `0.2` collapse to one row (first spelling preserved). No leading sign is captured, so `A1*-5` correctly promotes `5` and keeps `-` inline.
- **String** literals — dedupe by un-escaped value (embedded `""` handled); token keeps the original escaped spelling.
- **Boolean** literals — `TRUE`/`FALSE` case-insensitive, excluding function calls (`TRUE(`) and sheet qualifiers.

Each unique value becomes a default-off `RefactorPromotableRow(kind: Literal)` with an occurrence count.

### Promotion + rewrite
Promoting a literal materialises an input binding whose RHS is the **original token text** (preserves `0.20` vs `0.2`). A new `RewriteLiterals` pass — run **after** the cell-ref and identifier passes so a promoted-string binding name is never re-scanned as an identifier — swaps every occurrence for the binding name.

### Drop-input UX
Unticking a promoted literal or named range drops it from the rewrite map, restoring the original token inline everywhere (no warning even if it reintroduces duplication). Covered by new tests.

### Status bar
Now shows a summary count — `3 inputs, 2 promotable, 1 calculation binding` — plus a `· N merged` note, with validation errors taking priority.

## Note on ordering
Literals are surfaced in **source order**, matching the first-occurrence convention used everywhere else in the engine. For the manual-test formula this means `50` appears between `"high"` and `"medium"` rather than after `"low"` as the issue's example listing sketched — the source-order placement is the principled one.

## Tests
12 new `RefactorEngineTests` cover: numeric/string(with `""`)/boolean promotion, two distinct numerics staying distinct, value-dedupe (`0.20`/`0.2`), digits-inside-identifier safety, the issue's manual-example token set, drop-input restoring literals + named ranges, existing-LET literal scoping (value-binding RHS excluded), and round-trip safety via `LetParser` + `LetToLambdaBuilder`. Two pre-existing promotable tests were narrowed to their kind (their formulas now also surface a literal). Full suite: **980 passing**.

## Manual Excel test (for Tim)
Type `=IF(A1 > 100, "high", IF(A1 > 50, "medium", "low")) + IF(B1 > 100, 1, 0)`, run `/Refactor`. The promotable section should list `100` (2 uses), `"high"`, `50`, `"medium"`, `"low"`, `1`, `0`. Promote `100` only, Save, and confirm both `100`s were replaced and the formula evaluates identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
