### PR TITLE
Add EXCEPT lambda (set difference) + fix net48 harness xll path

### DIFF
--- a/addin/lambda-boss.AddinTests/ExcelAddinFixture.cs
+++ b/addin/lambda-boss.AddinTests/ExcelAddinFixture.cs
@@ -93,7 +93,7 @@ public sealed class ExcelAddinFixture : IDisposable
         foreach (var config in new[] { "Debug", "Release" })
         {
             var xllPath = Path.Combine(repoRoot, "lambda-boss", "bin", config,
-                "net6.0-windows", "lambda-boss64.xll");
+                "net48", "lambda-boss64.xll");
             if (File.Exists(xllPath))
             {
                 return xllPath;

--- a/lambdas/array/EXCEPT.lambda
+++ b/lambdas/array/EXCEPT.lambda
@@ -1,0 +1,34 @@
+/*  FUNCTION NAME:      EXCEPT
+    DESCRIPTION:*//**Returns the elements of a 1-D array that are not present in another set (set difference), preserving order and orientation.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-05-29  Claude      Initial version
+*/
+EXCEPT = LAMBDA(
+//  Parameter Declarations
+    [array],
+    [except],
+    [if_empty],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →EXCEPT(array, except, [if_empty])¶" &
+                "DESCRIPTION:   →Returns the elements of array not present in except (set difference), preserving order and orientation.¶" &
+                "VERSION:       →May 29 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   array          →(Required) 1-D array (row or column) to filter. Orientation is auto-detected and preserved.¶" &
+                "   except         →(Required) A value or 1-D array of values to remove from array.¶" &
+                "   if_empty       →(Optional) Value to return when every element is excluded. If omitted, returns #CALC!.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=EXCEPT({1;2;3;4}, {2;4})¶" &
+                "Result         →{1;3}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(array),
+    //  Procedure
+        keep, NOT(CONTAINS(array, except)),
+        result, IF(ISOMITTED(if_empty),
+                    FILTER(array, keep),
+                    FILTER(array, keep, if_empty)),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/EXCEPT.tests.yaml
+++ b/lambdas/array/EXCEPT.tests.yaml
@@ -1,0 +1,28 @@
+tests:
+  - name: vertical column set difference
+    args: ["={1;2;3;4}", "={2;4}"]
+    expected: [[1], [3]]
+
+  - name: horizontal row preserves orientation
+    args: ["={1,2,3,4}", "={2,4}"]
+    expected: [[1, 3]]
+
+  - name: scalar except value
+    args: ["={1;2;3}", "=2"]
+    expected: [[1], [3]]
+
+  - name: string elements
+    args: ['={"a";"b";"c"}', '={"b"}']
+    expected: [["a"], ["c"]]
+
+  - name: nothing excluded returns array unchanged
+    args: ["={1;2;3}", "={9}"]
+    expected: [[1], [2], [3]]
+
+  - name: all excluded falls back to if_empty
+    args: ["={1;2}", "={1;2}", "none"]
+    expected: "none"
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Adds the **EXCEPT** LAMBDA — a set difference over 1-D arrays — and fixes a stale path that was blocking the entire AddinTests harness.

### `EXCEPT(array, except, [if_empty])`

Returns the elements of `array` that are **not** present in `except`, preserving the original order and orientation (row or column).

- Reuses the existing **CONTAINS** lambda for the membership test (`CONTAINS` lifts element-wise via `XMATCH`, preserving the orientation of its first arg) and `FILTER` for the difference — so both vertical and horizontal inputs work and keep their shape, matching the `INSERTAT` / `REVERSEARRAY` convention.
- `except` accepts a scalar or a 1-D array.
- Optional `if_empty` fallback: returned when every element is excluded. If omitted, an all-excluded result yields Excel's native `#CALC!` (FILTER's default).

```
=EXCEPT({1;2;3;4}, {2;4})   → {1;3}
=EXCEPT({1,2,3,4}, {2,4})   → {1,3}   (orientation preserved)
```

### Tests

7 harness cases: vertical/horizontal orientation, scalar `except`, string elements, no-exclusion passthrough, `if_empty` fallback, and help text. All pass.

## Drive-by fix (please note)

`ExcelAddinFixture.FindXllPath` still pointed at the pre-port `net6.0-windows` output directory and could not locate the packed XLL under `net48`. This left commit since #9 and the net48 port (spec 0007) never updated it — it was throwing `FileNotFoundException` on fixture init, blocking **all** AddinTests harness runs, not just this lambda's. One-line change to `net48`.

Folded into this PR because the new lambda's tests can't be validated (locally or by anyone re-running) without it. Happy to split it into its own PR if you'd prefer it isolated.

- Format tests: 480 passed
- Full harness suite: 507 passed (was previously un-runnable)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)
