### PR TITLE
Add "Import All Lambdas (no prefix)" command

### DIFF
--- a/addin/lambda-boss/Commands/ImportAllLambdasCommand.cs
+++ b/addin/lambda-boss/Commands/ImportAllLambdasCommand.cs
@@ -11,12 +11,12 @@ namespace LambdaBoss.Commands;
 /// </summary>
 internal static class ImportAllLambdasCommand
 {
-    public static void Run()
+    public static void Run(bool applyPrefix = true)
     {
-        Task.Run(RunAsync);
+        Task.Run(() => RunAsync(applyPrefix));
     }
 
-    private static async Task RunAsync()
+    private static async Task RunAsync(bool applyPrefix)
     {
         IReadOnlyList<LibraryInfo> libraries;
         var libraryLambdas = new List<(LibraryInfo Info, IReadOnlyList<(string Name, string Formula)> Lambdas)>();
@@ -34,16 +34,20 @@ internal static class ImportAllLambdasCommand
             {
                 try
                 {
+                    // When applyPrefix is false, an empty prefix yields bare names with no
+                    // function-reference rewriting (see PrefixRewriter.Apply / FetchedLibrary.LoadWithPrefix).
+                    var prefix = applyPrefix ? info.DefaultPrefix : "";
+
                     IReadOnlyList<(string Name, string Formula)> lambdas;
                     if (info.IsLocal)
                     {
                         lambdas = provider.LoadLocalLibrary(
-                            info.LocalSourceConfig!, info.FolderName, info.DefaultPrefix);
+                            info.LocalSourceConfig!, info.FolderName, prefix);
                     }
                     else
                     {
                         lambdas = await provider.LoadLibraryAsync(
-                            info.RepoConfig, info.FolderName, info.DefaultPrefix);
+                            info.RepoConfig, info.FolderName, prefix);
                     }
                     libraryLambdas.Add((info, lambdas));
                 }
@@ -65,7 +69,7 @@ internal static class ImportAllLambdasCommand
         {
             try
             {
-                InjectAll(libraryLambdas, fetchFailures);
+                InjectAll(libraryLambdas, fetchFailures, applyPrefix);
             }
             catch (Exception ex)
             {
@@ -77,7 +81,8 @@ internal static class ImportAllLambdasCommand
 
     private static void InjectAll(
         IReadOnlyList<(LibraryInfo Info, IReadOnlyList<(string Name, string Formula)> Lambdas)> libraryLambdas,
-        IReadOnlyList<(string Label, string Error)> fetchFailures)
+        IReadOnlyList<(string Label, string Error)> fetchFailures,
+        bool applyPrefix)
     {
         if (libraryLambdas.Count == 0 && fetchFailures.Count == 0)
         {
@@ -113,7 +118,8 @@ internal static class ImportAllLambdasCommand
                 ? info.LocalSourceConfig!.Path
                 : info.RepoConfig.Url;
 
-            var comment = LambdaLoader.BuildComment(sourceLabel, info.FolderName, info.DefaultPrefix);
+            var prefix = applyPrefix ? info.DefaultPrefix : "";
+            var comment = LambdaLoader.BuildComment(sourceLabel, info.FolderName, prefix);
 
             var existing = alreadyLoaded.FirstOrDefault(s =>
                 string.Equals(s.LibraryName, info.FolderName, StringComparison.OrdinalIgnoreCase)

--- a/addin/lambda-boss/UI/LambdaPopup.xaml.cs
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml.cs
@@ -453,11 +453,19 @@ public partial class LambdaPopup
             }),
         new SlashCommand(
             "Import All Lambdas",
-            "Import every lambda from every configured library into the active workbook",
+            "Import every lambda from every configured library using each library's default prefix",
             () =>
             {
                 Hide();
                 ImportAllLambdasCommand.Run();
+            }),
+        new SlashCommand(
+            "Import All Lambdas (no prefix)",
+            "Import every lambda from every configured library with bare names (no prefix)",
+            () =>
+            {
+                Hide();
+                ImportAllLambdasCommand.Run(applyPrefix: false);
             }),
         new SlashCommand(
             "Settings",


### PR DESCRIPTION
## Summary

Adds a second command-palette entry, **"Import All Lambdas (no prefix)"**, that bulk-imports every lambda from every configured library with **bare names** — alongside the existing **"Import All Lambdas"**, which continues to apply each library's `default_prefix`.

Requested by Tim: an option to import all libraries without prefixes, surfaced smoothly in the popup. The command-palette idiom (a sibling entry) was chosen for discoverability and zero extra keystrokes.

## Changes

- `ImportAllLambdasCommand.Run` now takes an `applyPrefix` flag (default `true`). When `false`, it passes an empty prefix to the loaders — which yields bare names with no function-reference rewriting (`PrefixRewriter.Apply` / `FetchedLibrary.LoadWithPrefix`) — and stamps the cell comment with the empty prefix to match.
- New `SlashCommand` entry **"Import All Lambdas (no prefix)"** wired to `Run(applyPrefix: false)`.
- Clarified the existing command's description to "…using each library's default prefix".

## Behaviour note

With no prefix, if two libraries define a lambda with the same bare name (e.g. both expose `SUM`), the later import overwrites the earlier in the Name Manager. This is inherent to flattening and matches existing single-library no-prefix loads; the summary's "updated" count reflects it.

## Testing

- `dotnet build addin/lambda-boss.slnx` — succeeds.
- `dotnet test addin/lambda-boss.Tests` — 1002 passed, 0 failed.
- Empty-prefix → bare-name behaviour is already covered by `LoadLibraryAsync_EmptyPrefix_ReturnsBarenames`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
