### PR TITLE
TROW + TFILTER lambdas

### DIFF
--- a/lambdas/lookup/TFILTER.lambda
+++ b/lambdas/lookup/TFILTER.lambda
@@ -1,0 +1,32 @@
+/*  FUNCTION NAME:      TFILTER
+    DESCRIPTION:*//**Filters a table by a predicate mask and returns a table-object closure; call it with a header name to read that whole column across all kept rows.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-08  Claude      Initial version
+*/
+TFILTER = LAMBDA(
+//  Parameter Declarations
+    [Table],
+    [Keep],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →TFILTER(Table, Keep)¶" &
+                "DESCRIPTION:   →Filters a table by a predicate mask and returns a table-object closure; call it with a header name to read that whole column across all kept rows.¶" &
+                "VERSION:       →Jun 08 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   Table          →(Required) Full table including its header row (e.g. tblData[#All]).¶" &
+                "   Keep           →(Required) Boolean mask, one value per data row, selecting which rows to keep (e.g. tblData[Age] > 30).¶" &
+                "RETURNS:       →A closure: call result(Header) for the whole column under that header. Pass an array of headers (e.g. HSTACK(""Person"",""City"")) to project several columns at once.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=LET(t, TFILTER(tblData[#All], tblData[Age] > 30), HSTACK(t(""Person""), t(""City"")))¶" &
+                "Result         →(Person and City columns for every row where Age > 30)",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(Table),
+    //  Procedure
+        headers, CHOOSEROWS(Table, 1),
+        kept, FILTER(DROP(Table, 1), Keep),
+        result, LAMBDA(Header, CHOOSECOLS(kept, XMATCH(Header, headers))),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/lookup/TROW.lambda
+++ b/lambdas/lookup/TROW.lambda
@@ -1,0 +1,34 @@
+/*  FUNCTION NAME:      TROW
+    DESCRIPTION:*//**Looks up one row in a table (first match) and returns a row-object closure; call it with a header name to read that column's value.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-08  Claude      Initial version
+*/
+TROW = LAMBDA(
+//  Parameter Declarations
+    [Table],
+    [Item],
+    [LookupCol],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →TROW(Table, Item, LookupCol)¶" &
+                "DESCRIPTION:   →Looks up one row in a table (first match) and returns a row-object closure; call it with a header name to read that column's value.¶" &
+                "VERSION:       →Jun 08 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   Table          →(Required) Full table including its header row (e.g. tblData[#All]).¶" &
+                "   Item           →(Required) Value to find in LookupCol to identify the row. First match wins; duplicates are silently ignored.¶" &
+                "   LookupCol      →(Required) Column to search for Item (e.g. tblData[Person]), excluding headers.¶" &
+                "RETURNS:       →A closure: call result(Header) to read the scalar value under that header for the matched row.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=LET(tim, TROW(tblData[#All], ""Tim"", tblData[Person]), tim(""Age""))¶" &
+                "Result         →42",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(Table),
+    //  Procedure
+        headers, CHOOSEROWS(Table, 1),
+        row, XLOOKUP(Item, LookupCol, DROP(Table, 1)),
+        result, LAMBDA(Header, INDEX(row, XMATCH(Header, headers))),
+        IF(Help?, Help, result)
+)
+);


### PR DESCRIPTION
Add TROW + TFILTER closure-based table accessors (lambdas only)

TROW looks up one row (first match, XLOOKUP semantics) and returns a row-object closure: call result(Header) for the scalar under that header.

TFILTER filters a table by a predicate mask and returns a table-object closure: call result(Header) for the whole column across kept rows; pass an array of headers to project several columns at once.

Lambda files only for now (per #226) so they can be exercised in Excel. Formal .tests.yaml + harness formula: override to follow once the behaviour is confirmed.

Closes #226 