### PR TITLE
Add PAIROP lambda (binary op over consecutive pairs)

### DIFF
--- a/lambdas/array/PAIROP.lambda
+++ b/lambdas/array/PAIROP.lambda
@@ -1,0 +1,48 @@
+/*  FUNCTION NAME:      PAIROP
+    DESCRIPTION:*//**Applies a binary op to consecutive pairs (odd vs even), collapsing each pair to one value.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-09  Claude      Initial version
+*/
+PAIROP = LAMBDA(
+//  Parameter Declarations
+    [array],
+    [op],
+    [byRow],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →PAIROP(array, op, byRow)¶" &
+                "DESCRIPTION:   →Applies a binary op to consecutive pairs (odd vs even element), collapsing each pair to one value. If the count is odd, the last unpaired element passes through unchanged.¶" &
+                "VERSION:       →Jun 09 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   array          →(Required) Values to pair. A vector pairs along its length (either orientation); a 2D array pairs adjacent columns by default.¶" &
+                "   op             →(Optional) LAMBDA(a, b) applied to each pair — a is the odd element (1st, 3rd, …), b the even (2nd, 4th, …). Default LAMBDA(a, b, a - b).¶" &
+                "   byRow          →(Optional) For 2D arrays, TRUE pairs adjacent rows instead of columns. Ignored for vectors. Default FALSE.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=PAIROP({10,3,8,5})¶" &
+                "Result         →{7, 3}  (10-3, 8-5)",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(array),
+    //  Procedure
+        f, IF(ISOMITTED(op), LAMBDA(a, b, a - b), op),
+        by?, IF(ISOMITTED(byRow), FALSE, byRow),
+        nr, ROWS(array),
+        nc, COLUMNS(array),
+        vector?, OR(nr = 1, nc = 1),
+        pairRows?, IF(vector?, nc = 1, by?),
+        data, IF(pairRows?, TRANSPOSE(array), array),
+        m, ROWS(data),
+        n, COLUMNS(data),
+        p, INT((n + 1) / 2),
+        rowIdx, SEQUENCE(m),
+        aIdx, SEQUENCE(1, p, 1, 2),
+        bIdx, SEQUENCE(1, p, 2, 2),
+        aGrid, INDEX(data, rowIdx, aIdx),
+        bGrid, INDEX(data, rowIdx, IF(bIdx > n, n, bIdx)),
+        orphanGrid, (rowIdx * 0) + (bIdx > n),
+        paired, MAP(aGrid, bGrid, orphanGrid, LAMBDA(a, b, orph, IF(orph, a, f(a, b)))),
+        result, IF(pairRows?, TRANSPOSE(paired), paired),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/PAIROP.tests.yaml
+++ b/lambdas/array/PAIROP.tests.yaml
@@ -1,0 +1,36 @@
+tests:
+  - name: horizontal vector default odd-even diff
+    args: ['={10,3,8,5}']
+    expected: [[7, 3]]
+
+  - name: vertical vector pairs along length and returns vertical
+    args: ['={10;3;8;5}']
+    expected: [[7], [3]]
+
+  - name: two-element array returns a single value
+    args: ['={10,3}']
+    expected: 7
+
+  - name: odd count passes the last element through unchanged
+    args: ['={10,3,8}']
+    expected: [[7, 8]]
+
+  - name: custom op pairwise sum
+    args: ['={10,3,8,5}', '=LAMBDA(a,b,a+b)']
+    expected: [[13, 13]]
+
+  - name: custom op reverses direction (even minus odd)
+    args: ['={10,3}', '=LAMBDA(a,b,b-a)']
+    expected: -7
+
+  - name: 2D defaults to pairing adjacent columns
+    args: ['={10,3,8,5;20,6,16,10}']
+    expected: [[7, 3], [14, 6]]
+
+  - name: 2D byRow pairs adjacent rows
+    args: ['={10,3;8,5;2,1;9,9}', '=LAMBDA(a,b,a-b)', '=TRUE']
+    expected: [[2, -2], [-7, -8]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Adds `PAIROP` — a small array primitive that applies a binary `LAMBDA(a, b)` to consecutive odd/even pairs of an array, collapsing each pair to a single value.

```
PAIROP(array, [op], [byRow])
```

The motivating annoyance: a formula returns a small array like `{a, b}` and you just want `a - b` without `INDEX`-ing the values apart. A bare `=PAIROP(range)` does exactly that.

## Behaviour

- **Default op is `LAMBDA(a, b, a - b)`** — odd element minus even element. `=PAIROP({10,3,8,5})` → `{7, 3}`.
- **Custom op subsumes direction and any pairwise combine.** Pass `LAMBDA(a, b, b - a)` to reverse, or `a + b` / `a * b` / `MAX` etc. Applied via `MAP`, so the op always sees scalars — aggregating ops like `MAX`/`MIN`/concat lift correctly too.
- **Vectors pair along their length** in either orientation and return in the same orientation, so a vertical `{a; b}` works without setting `byRow`. `byRow` only disambiguates genuine 2D arrays (default pairs adjacent columns; `TRUE` pairs adjacent rows).
- **Odd counts** pass the final unpaired element through unchanged.

## Testing

- Format validation: 512 passed.
- Lambda harness, full suite: **532 passed, 0 failed.**

Functional cases cover horizontal/vertical vectors, the 2-element scalar return, odd-length pass-through, custom ops (sum + reversed direction), 2D column pairing, and 2D `byRow` row pairing.

## Notes

Scoped deliberately to the pairs (`n = 2`) case. A future `CHUNKREDUCE`-style "groups of n" generalisation is left as its own lambda to keep the `(a, b)` ergonomics clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
