### PR TITLE
Add CONSECCOUNT and RUNGROUPS array run-length lambdas

### DIFF
--- a/lambdas/array/CONSECCOUNT.lambda
+++ b/lambdas/array/CONSECCOUNT.lambda
@@ -1,0 +1,37 @@
+/*  FUNCTION NAME:      CONSECCOUNT
+    DESCRIPTION:*//**Returns a running consecutive-run counter at each position of a 1D array.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-12  Claude      Initial version
+*/
+CONSECCOUNT = LAMBDA(
+//  Parameter Declarations
+    [vector],
+    [match],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →CONSECCOUNT(vector, match)¶" &
+                "DESCRIPTION:   →Returns a running consecutive-run counter at each position of a 1D array.¶" &
+                "VERSION:       →Jun 12 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   vector         →(Required) A 1D array (row or column) of numbers or text.¶" &
+                "   match          →(Optional) If omitted: counter = previous count + 1 when an element equals its predecessor, else 1 (longest run of any value). If supplied: counter increments while an element equals match, resets to 0 otherwise (longest streak of that value).¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=CONSECCOUNT({""A"";""A"";""A"";""B"";""B"";""C""})¶" &
+                "Result         →{1;2;3;1;2;1}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(vector),
+        useMatch, NOT(ISOMITTED(match)),
+    //  Procedure
+        col, TOCOL(vector),
+        n, ROWS(col),
+        matchVal, IF(useMatch, match, ""),
+        runWith, SCAN(0, col, LAMBDA(acc, x, IF(x = matchVal, acc + 1, 0))),
+        boundaries, MAP(SEQUENCE(n), LAMBDA(i, IF(i = 1, 1, IF(INDEX(col, i) = INDEX(col, i - 1), 0, 1)))),
+        runNo, MAP(SEQUENCE(n), LAMBDA(i, i - MAX(SEQUENCE(i) * INDEX(boundaries, SEQUENCE(i))) + 1)),
+        running, IF(useMatch, runWith, runNo),
+        result, IF(COLUMNS(vector) > 1, TRANSPOSE(running), running),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/CONSECCOUNT.tests.yaml
+++ b/lambdas/array/CONSECCOUNT.tests.yaml
@@ -1,0 +1,28 @@
+tests:
+  - name: identical-neighbours mode on text column
+    args: ['={"A";"A";"A";"B";"B";"C";"C";"C";"C"}']
+    expected: [[1], [2], [3], [1], [2], [1], [2], [3], [4]]
+
+  - name: identical-neighbours mode on numbers
+    args: ['={5;5;7;7;7;5}']
+    expected: [[1], [2], [1], [2], [3], [1]]
+
+  - name: row orientation lifts back to a row
+    args: ['={"A","A","B"}']
+    expected: [[1, 2, 1]]
+
+  - name: with-match streak of target value
+    args: ['={1;1;0;1;1;1;0}', '=1']
+    expected: [[1], [2], [0], [1], [2], [3], [0]]
+
+  - name: with-match text target
+    args: ['={"x";"x";"y";"x"}', '="x"']
+    expected: [[1], [2], [0], [1]]
+
+  - name: single element returns 1
+    args: ['={"Z"}']
+    expected: 1
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/array/RUNGROUPS.lambda
+++ b/lambdas/array/RUNGROUPS.lambda
@@ -1,0 +1,35 @@
+/*  FUNCTION NAME:      RUNGROUPS
+    DESCRIPTION:*//**Run-length-encodes a 1D array into consecutive {value, length} segments.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-12  Claude      Initial version
+*/
+RUNGROUPS = LAMBDA(
+//  Parameter Declarations
+    [vector],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →RUNGROUPS(vector)¶" &
+                "DESCRIPTION:   →Run-length-encodes a 1D array into consecutive {value, length} segments.¶" &
+                "VERSION:       →Jun 12 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   vector         →(Required) A 1D array (row or column) of numbers or text.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=RUNGROUPS({""A"";""A"";""A"";""B"";""B"";""C""})¶" &
+                "Result         →{""A"",3;""B"",2;""C"",1}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(vector),
+    //  Procedure
+        col, TOCOL(vector),
+        n, ROWS(col),
+        isStart, MAP(SEQUENCE(n), LAMBDA(i, IF(i = 1, 1, IF(INDEX(col, i) = INDEX(col, i - 1), 0, 1)))),
+        startPositions, FILTER(SEQUENCE(n), isStart = 1),
+        m, ROWS(startPositions),
+        nextStarts, MAP(SEQUENCE(m), LAMBDA(k, IF(k = m, n + 1, INDEX(startPositions, k + 1)))),
+        lengths, nextStarts - startPositions,
+        values, INDEX(col, startPositions),
+        result, HSTACK(values, lengths),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/RUNGROUPS.tests.yaml
+++ b/lambdas/array/RUNGROUPS.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: text runs encode to value and length
+    args: ['={"A";"A";"A";"B";"B";"C";"C";"C";"C"}']
+    expected: [["A", 3], ["B", 2], ["C", 4]]
+
+  - name: numeric runs
+    args: ['={5;5;7;7;7;5}']
+    expected: [[5, 2], [7, 3], [5, 1]]
+
+  - name: row orientation produces same N-by-2
+    args: ['={"A","A","B"}']
+    expected: [["A", 2], ["B", 1]]
+
+  - name: single run
+    args: ['={"X";"X";"X"}']
+    expected: [["X", 3]]
+
+  - name: all distinct elements each length 1
+    args: ['={1;2;3}']
+    expected: [[1, 1], [2, 1], [3, 1]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Adds two array-based analogues of the string-only **CONSECGROUPS**, filling the consecutive-run gap for 1D arrays of numbers or category labels.

### CONSECCOUNT(vector, [match])
Running consecutive-run counter at each position, same shape as input.
- **No `match`:** counter = previous count + 1 when an element equals its predecessor, else resets to **1**. `MAX(...)` = longest run of any value.
- **With `match`:** counter increments while an element equals `match`, resets to **0** otherwise. `MAX(...)` = longest streak of that value.
- Auto-detects row vs column orientation (transposes back for row input).
- Per-row longest run across a grid: `=BYROW(grid, LAMBDA(r, MAX(CONSECCOUNT(r))))`.

### RUNGROUPS(vector)
Run-length-encodes a 1D array into an N-by-2 array of `{value, length}` segments — one row per consecutive run. `ROWS(RUNGROUPS(v))` = number of runs.

## Testing
- Format validation: 528 passed.
- Full AddIn harness suite: 545 passed (includes 7 CONSECCOUNT + 6 RUNGROUPS cases — both orientations, numeric and text, with/without match, single-element/single-run edge cases, help text).

Closes #232
Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)