### PR TITLE
Add PERMUTATIONS / PERMUTEINDICES lambdas (ordered k-permutations)

### DIFF
--- a/lambdas/math/PERMUTATIONS.lambda
+++ b/lambdas/math/PERMUTATIONS.lambda
@@ -1,0 +1,39 @@
+/*  FUNCTION NAME:      PERMUTATIONS
+    DESCRIPTION:*//**Returns all ordered k-permutations of items, lexicographic order. With delim, joins each row into a single string.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-16  Claude      Initial version
+*/
+PERMUTATIONS = LAMBDA(
+//  Parameter Declarations
+    [items],
+    [k],
+    [delim],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →PERMUTATIONS(items, k, [delim])¶" &
+                "DESCRIPTION:   →Returns all ordered k-permutations of items, lexicographic order. With delim, joins each row into a single string.¶" &
+                "VERSION:       →Jun 16 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   items          →(Required) 1-D array of items (row or column).¶" &
+                "   k              →(Optional) Permutation length, 1 ≤ k ≤ count(items). Default = count(items).¶" &
+                "   delim          →(Optional) If provided, TEXTJOIN each permutation row into a single string.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=PERMUTATIONS({""A"";""B"";""C""}, 2, ""|"")¶" &
+                "Result         →6x1: {""A|B""; ""A|C""; ""B|A""; ""B|C""; ""C|A""; ""C|B""}¶" &
+                "NOTE:          →Thin wrapper over PERMUTEINDICES — splits the unranking math from value lookup so callers can reuse indices.",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(items),
+    //  Procedure
+        itemsCol, IF(ROWS(items) = 1, TRANSPOSE(items), items),
+        nItems,   ROWS(itemsCol),
+        kEff,     IF(ISOMITTED(k), nItems, k),
+        idx,      PERMUTEINDICES(nItems, kEff),
+        vals,     INDEX(itemsCol, idx),
+        result,   IF(ISOMITTED(delim),
+                     vals,
+                     BYROW(vals, LAMBDA(rowVec, TEXTJOIN(delim, FALSE, rowVec)))),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/math/PERMUTATIONS.tests.yaml
+++ b/lambdas/math/PERMUTATIONS.tests.yaml
@@ -1,0 +1,36 @@
+tests:
+  - name: full permutations of 3 letters
+    args: ['={"A";"B";"C"}']
+    expected:
+      - ["A", "B", "C"]
+      - ["A", "C", "B"]
+      - ["B", "A", "C"]
+      - ["B", "C", "A"]
+      - ["C", "A", "B"]
+      - ["C", "B", "A"]
+
+  - name: k-permutations 2 of 3
+    args: ['={"A";"B";"C"}', "=2"]
+    expected:
+      - ["A", "B"]
+      - ["A", "C"]
+      - ["B", "A"]
+      - ["B", "C"]
+      - ["C", "A"]
+      - ["C", "B"]
+
+  - name: delim joins each row
+    args: ['={"A";"B";"C"}', "=2", "|"]
+    expected: [["A|B"], ["A|C"], ["B|A"], ["B|C"], ["C|A"], ["C|B"]]
+
+  - name: row vector input is normalised to column
+    args: ['={"A","B"}']
+    expected: [["A", "B"], ["B", "A"]]
+
+  - name: k greater than count returns NA
+    args: ['={"A";"B"}', "=3"]
+    expected: -2146826246
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/math/PERMUTEINDICES.lambda
+++ b/lambdas/math/PERMUTEINDICES.lambda
@@ -1,0 +1,50 @@
+/*  FUNCTION NAME:      PERMUTEINDICES
+    DESCRIPTION:*//**Returns a P(n,k) by k matrix of ordered k-permutation indices in 1..n, lexicographic order.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-16  Claude      Initial version
+*/
+PERMUTEINDICES = LAMBDA(
+//  Parameter Declarations
+    [n],
+    [k],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →PERMUTEINDICES(n, k)¶" &
+                "DESCRIPTION:   →Returns a P(n,k) by k matrix of ordered k-permutation indices in 1..n, lexicographic order.¶" &
+                "VERSION:       →Jun 16 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   n              →(Required) Population size. Positive integer.¶" &
+                "   k              →(Optional) Permutation length, 1 ≤ k ≤ n. Default = n (full permutations).¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=PERMUTEINDICES(3)¶" &
+                "Result         →6x3 matrix: {1,2,3; 1,3,2; 2,1,3; 2,3,1; 3,1,2; 3,2,1}¶" &
+                "NOTE:          →Pair with PERMUTATIONS for value lookup. Returns NA() when n<1, k<1, k>n, or either argument is non-integer.",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(n),
+        kEff, IF(ISOMITTED(k), n, k),
+        valid?, AND(n >= 1, kEff >= 1, kEff <= n, n = INT(n), kEff = INT(kEff)),
+    //  Procedure
+        result, IF(NOT(valid?), NA(),
+                   IF(kEff = 1, SEQUENCE(n),
+                      REDUCE(SEQUENCE(n), SEQUENCE(kEff - 1, 1, 2), LAMBDA(prev, targetK,
+                          LET(
+                              kPrev,    targetK - 1,
+                              newCol,   SEQUENCE(1, n),
+                              mask,     REDUCE(1, SEQUENCE(kPrev), LAMBDA(acc, colNum,
+                                            acc * (INDEX(prev, , colNum) <> newCol))),
+                              buildCol, LAMBDA(srcCol, TOCOL(IFS(mask, srcCol), 2)),
+                              seed,     buildCol(TAKE(prev, , 1)),
+                              prevPart, IF(kPrev = 1, seed,
+                                           REDUCE(seed,
+                                                  SEQUENCE(kPrev - 1, 1, 2),
+                                                  LAMBDA(acc, colIdx,
+                                                      HSTACK(acc, buildCol(INDEX(prev, , colIdx)))))),
+                              HSTACK(prevPart, buildCol(newCol))
+                          )
+                      ))
+                   )),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/math/PERMUTEINDICES.tests.yaml
+++ b/lambdas/math/PERMUTEINDICES.tests.yaml
@@ -1,0 +1,36 @@
+tests:
+  - name: full permutations of 3
+    args: ["=3"]
+    expected: [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
+
+  - name: k-permutations P(3,2)
+    args: ["=3", "=2"]
+    expected: [[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]
+
+  - name: full permutations of 2
+    args: ["=2"]
+    expected: [[1, 2], [2, 1]]
+
+  - name: k equals 1 returns a column
+    args: ["=4", "=1"]
+    expected: [[1], [2], [3], [4]]
+
+  - name: single element
+    args: ["=1"]
+    expected: 1
+
+  - name: k greater than n returns NA
+    args: ["=3", "=4"]
+    expected: -2146826246
+
+  - name: n less than 1 returns NA
+    args: ["=0"]
+    expected: -2146826246
+
+  - name: non-integer n returns NA
+    args: ["=3.5"]
+    expected: -2146826246
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Adds the permutation counterpart to the existing `COMBINATIONS` / `COMBININDICES` pair, closing a gap in the combinatorics family (the library covered unordered selection and Cartesian products, but had no way to generate *orderings*).

- **`PERMUTEINDICES(n, [k])`** — returns a P(n,k) × k matrix of 1-based indices in lexicographic order. `k` defaults to `n` (full permutations). Returns `NA()` when `n<1`, `k<1`, `k>n`, or either argument is non-integer.
- **`PERMUTATIONS(items, [k], [delim])`** — thin `INDEX`-into-items wrapper over `PERMUTEINDICES`. `k` defaults to the item count; `delim` `TEXTJOIN`s each permutation row into a single string.

Both live in `lambdas/math/`.

## Implementation

Mirrors `COMBININDICES` exactly — same broadcast + `TOCOL` column-extension approach (chosen there for large-n performance over per-rank `REDUCE`). The only semantic change is the extension mask: instead of "candidate strictly greater than the last column" (which keeps combinations sorted and distinct), permutations use "candidate value not already used in this row" — a product of `INDEX(prev,,colNum) <> newCol` across all prior columns. All `buildCol` calls share the same mask, so rows stay aligned and lexicographic order is preserved.

Replaces the old workaround of generating the full n^n Cartesian product (`EXPANDDIMENSIONS`) and filtering out rows with repeats — e.g. 4 items collapses from 256 generated / 24 kept to a single `=PERMUTATIONS(cities)` call.

## Testing

- Format validation: `LambdaFormatTests` — 576 passed.
- Functional harness: full suite **610 passed**, 0 failed (15 of those are the new PERMUT cases). Coverage includes full permutations, k-permutations (k<n), `k=1`, single-element, row-vector normalisation, `delim` joining, and the `NA()` edge cases (k>n, n<1, non-integer).

Closes #242