### PR TITLE
Add multi-key column support to UNPIVOT

### DIFF
--- a/lambdas/array/UNPIVOT.lambda
+++ b/lambdas/array/UNPIVOT.lambda
@@ -1,45 +1,62 @@
 /*  FUNCTION NAME:      UNPIVOT
-    DESCRIPTION:*//**Reshapes a 2D crosstab into a tidy 3-column [RowHeading, ColHeading, Value] table.*/
+    DESCRIPTION:*//**Reshapes a 2D crosstab into a tidy [keys..., Column, Value] table; supports multiple key columns and separately-supplied keys/labels.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-06-02  Claude      Initial version
+                        2026-06-17  Claude      Add keyCols/colLabels for multi-key + separately-supplied headings
 */
 UNPIVOT = LAMBDA(
 //  Parameter Declarations
-    [range],
+    [valueGrid],
+    [keyCols],
+    [colLabels],
     [dropBlanks],
-    [headers],
+    [resultHeaders],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →UNPIVOT(range, dropBlanks, headers)¶" &
-                "DESCRIPTION:   →Reshapes a 2D crosstab into a tidy 3-column [RowHeading, ColHeading, Value] table.¶" &
-                "VERSION:       →Jun 02 2026¶" &
+                "FUNCTION:      →UNPIVOT(valueGrid, keyCols, colLabels, dropBlanks, resultHeaders)¶" &
+                "DESCRIPTION:   →Reshapes a 2D crosstab into a tidy [keys..., Column, Value] table.¶" &
+                "VERSION:       →Jun 17 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   range          →(Required) A 2D range whose first row and first column are headings; the top-left corner cell is ignored.¶" &
+                "   valueGrid      →(Required) The value matrix. When keyCols and/or colLabels are omitted, the embedded first column and/or first row carry the keys/labels (corner cell is ignored).¶" &
+                "   keyCols        →(Optional) H x K identifier column(s), repeated against each value. Omitted -> keys come from valueGrid's first column.¶" &
+                "   colLabels      →(Optional) 1 x W labels for the value columns; become the ""Column"" output values. Omitted -> labels come from valueGrid's first row.¶" &
                 "   dropBlanks     →(Optional) If TRUE, omit rows whose value cell is blank/empty (sparse crosstabs). Default FALSE.¶" &
-                "   headers        →(Optional) TRUE prepends a default header row (Row, Column, Value); or pass a 3-element array of custom column names. Default FALSE.¶" &
+                "   resultHeaders  →(Optional) TRUE prepends a default header row (Key1..KeyK, Column, Value); or pass a (K+2)-element array of custom column names. Default FALSE.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=UNPIVOT(A1:C3)¶" &
-                "Result         →4-row x 3-col table of (row heading, column heading, value) triples",
+                "Formula        →=UNPIVOT(D5:S26, B5:C26, D4:S4, , {""Jersey"",""Position"",""Team"",""Name""})¶" &
+                "Result         →(H*W) x 4 tidy table with two key columns plus team-code label and player-name value",
                 "→", "¶"
                 ),
     //  Check inputs
-        Help?, ISOMITTED(range),
+        Help?, ISOMITTED(valueGrid),
+        keysEmbed, ISOMITTED(keyCols),
+        labelsEmbed, ISOMITTED(colLabels),
     //  Procedure
+        keyBlock, IF(keysEmbed,
+                     DROP(TAKE(valueGrid, , 1), IF(labelsEmbed, 1, 0)),
+                     keyCols),
+        labelRow, IF(labelsEmbed,
+                     TOROW(DROP(TAKE(valueGrid, 1), , IF(keysEmbed, 1, 0))),
+                     TOROW(colLabels)),
+        vals, IF(keysEmbed,
+                 IF(labelsEmbed, DROP(DROP(valueGrid, 1), , 1), DROP(valueGrid, , 1)),
+                 IF(labelsEmbed, DROP(valueGrid, 1), valueGrid)),
+        nr, ROWS(vals),
+        nc, COLUMNS(vals),
+        nk, COLUMNS(keyBlock),
         drop?, IF(ISOMITTED(dropBlanks), FALSE, dropBlanks),
-        hdrCount, IF(ISOMITTED(headers), 0, ROWS(headers) * COLUMNS(headers)),
-        header?, IF(ISOMITTED(headers), FALSE, IF(hdrCount > 1, TRUE, N(headers))),
-        headerRow, IF(hdrCount > 1, TOROW(headers), HSTACK("Row", "Column", "Value")),
-        nr, ROWS(range) - 1,
-        nc, COLUMNS(range) - 1,
-        rh, DROP(TAKE(range, , 1), 1),
-        ch, TOROW(DROP(TAKE(range, 1), , 1)),
-        vals, DROP(DROP(range, 1), , 1),
+        hdrCount, IF(ISOMITTED(resultHeaders), 0, ROWS(resultHeaders) * COLUMNS(resultHeaders)),
+        header?, IF(ISOMITTED(resultHeaders), FALSE, IF(hdrCount > 1, TRUE, N(resultHeaders))),
+        defaultHeader, HSTACK("Key" & SEQUENCE(1, nk), "Column", "Value"),
+        headerRow, IF(hdrCount > 1, TOROW(resultHeaders), defaultHeader),
         idx, SEQUENCE(nr * nc, 1, 0),
-        rk, INDEX(rh, INT(idx / nc) + 1, 1),
-        ck, INDEX(ch, 1, MOD(idx, nc) + 1),
-        vv, TOCOL(vals),
-        full, HSTACK(rk, ck, vv),
-        body, IF(drop?, FILTER(full, LEN(vv & "") > 0), full),
+        rowIdx, INT(idx / nc) + 1,
+        colIdx, MOD(idx, nc) + 1,
+        keyRows, CHOOSEROWS(keyBlock, rowIdx),
+        labelCol, INDEX(labelRow, 1, colIdx),
+        valCol, TOCOL(vals),
+        full, HSTACK(keyRows, labelCol, valCol),
+        body, IF(drop?, FILTER(full, LEN(valCol & "") > 0), full),
         result, IF(header?, VSTACK(headerRow, body), body),
         IF(Help?, Help, result)
 )

--- a/lambdas/array/UNPIVOT.tests.yaml
+++ b/lambdas/array/UNPIVOT.tests.yaml
@@ -19,25 +19,25 @@ tests:
       - ["rows", "Two", 11]
       - ["rows", "Three", 12]
 
-  - name: dropBlanks omits empty value cells
-    args: ['={"","One","Two";"These",1,"";"are",3,4}', "=TRUE"]
+  - name: dropBlanks omits empty value cells (now position 4)
+    args: ['={"","One","Two";"These",1,"";"are",3,4}', "=", "=", "=TRUE"]
     expected: [["These", "One", 1], ["are", "One", 3], ["are", "Two", 4]]
 
   - name: dropBlanks FALSE keeps blank value rows
-    args: ['={"","One","Two";"These",1,"";"are",3,4}', "=FALSE"]
+    args: ['={"","One","Two";"These",1,"";"are",3,4}', "=", "=", "=FALSE"]
     expected: [["These", "One", 1], ["These", "Two", ""], ["are", "One", 3], ["are", "Two", 4]]
 
-  - name: headers prepends Row Column Value row
-    args: ['={"","One","Two";"These",1,2;"are",3,4}', "=FALSE", "=TRUE"]
+  - name: default resultHeaders prepends Key1 Column Value row
+    args: ['={"","One","Two";"These",1,2;"are",3,4}', "=", "=", "=FALSE", "=TRUE"]
     expected:
-      - ["Row", "Column", "Value"]
+      - ["Key1", "Column", "Value"]
       - ["These", "One", 1]
       - ["These", "Two", 2]
       - ["are", "One", 3]
       - ["are", "Two", 4]
 
-  - name: headers as custom names array
-    args: ['={"","One","Two";"These",1,2;"are",3,4}', "=FALSE", '={"Region","Metric","Amount"}']
+  - name: custom resultHeaders as 3-element array
+    args: ['={"","One","Two";"These",1,2;"are",3,4}', "=", "=", "=FALSE", '={"Region","Metric","Amount"}']
     expected:
       - ["Region", "Metric", "Amount"]
       - ["These", "One", 1]
@@ -48,6 +48,51 @@ tests:
   - name: single value cell crosstab
     args: ['={"","Col1";"Row1",42}']
     expected: [["Row1", "Col1", 42]]
+
+  - name: supplied keyCols only (labels still embedded)
+    args: ['={"One","Two";1,2;3,4}', '={"A";"B"}']
+    expected: [["A", "One", 1], ["A", "Two", 2], ["B", "One", 3], ["B", "Two", 4]]
+
+  - name: supplied colLabels only (keys still embedded)
+    args: ['={"A",1,2;"B",3,4}', "=", '={"One","Two"}']
+    expected: [["A", "One", 1], ["A", "Two", 2], ["B", "One", 3], ["B", "Two", 4]]
+
+  - name: both keyCols and colLabels supplied; valueGrid is values only
+    args: ['={10,20;30,40}', '={"X";"Y"}', '={"One","Two"}']
+    expected: [["X", "One", 10], ["X", "Two", 20], ["Y", "One", 30], ["Y", "Two", 40]]
+
+  - name: multi-key (K=2) with values-only grid
+    args: ['={10,20;30,40}', '={"X","P";"Y","Q"}', '={"Mon","Tue"}']
+    expected:
+      - ["X", "P", "Mon", 10]
+      - ["X", "P", "Tue", 20]
+      - ["Y", "Q", "Mon", 30]
+      - ["Y", "Q", "Tue", 40]
+
+  - name: multi-key default resultHeaders prepends Key1 Key2 Column Value
+    args: ['={10,20;30,40}', '={"X","P";"Y","Q"}', '={"Mon","Tue"}', "=", "=TRUE"]
+    expected:
+      - ["Key1", "Key2", "Column", "Value"]
+      - ["X", "P", "Mon", 10]
+      - ["X", "P", "Tue", 20]
+      - ["Y", "Q", "Mon", 30]
+      - ["Y", "Q", "Tue", 40]
+
+  - name: multi-key custom (K+2)-element resultHeaders
+    args: ['={10,20;30,40}', '={"X","P";"Y","Q"}', '={"Mon","Tue"}', "=", '={"Region","Product","Day","Sales"}']
+    expected:
+      - ["Region", "Product", "Day", "Sales"]
+      - ["X", "P", "Mon", 10]
+      - ["X", "P", "Tue", 20]
+      - ["Y", "Q", "Mon", 30]
+      - ["Y", "Q", "Tue", 40]
+
+  - name: multi-key with dropBlanks omits empty value cells
+    args: ['={10,"";30,40}', '={"X","P";"Y","Q"}', '={"Mon","Tue"}', "=TRUE"]
+    expected:
+      - ["X", "P", "Mon", 10]
+      - ["Y", "Q", "Mon", 30]
+      - ["Y", "Q", "Tue", 40]
 
   - name: help text
     args: []


### PR DESCRIPTION
## Summary

Upgrades `UNPIVOT` to support **multiple key columns** and to accept keys / labels as **separately-supplied ranges or arrays**, rather than requiring them to be embedded in the value grid.

New signature:

```
=UNPIVOT(valueGrid, [keyCols], [colLabels], [dropBlanks], [resultHeaders])
```

Four modes (depending on which of `keyCols` / `colLabels` are omitted):

| keyCols | colLabels | `valueGrid` contains |
| --- | --- | --- |
| omitted | omitted | keys = first col, labels = first row (today's behaviour) |
| omitted | supplied | first col = keys, rest = values |
| supplied | omitted | first row = labels, rest = values |
| supplied | supplied | values only |

Output is always **K + 2** columns: `[key1 ... keyK, Column, Value]`, where `K = COLUMNS(keyCols)` (or 1 in embedded mode). Multi-key support falls out of passing a wider `keyCols`.

## Backward compatibility

- Bare `=UNPIVOT(range)` is **byte-identical** to before — embedded-keys-and-labels path resolves to the same `DROP/TAKE` expressions.
- `dropBlanks` / `resultHeaders` (formerly `headers`) move to positions 4 / 5. Old calls that positionally passed `dropBlanks` or `headers` at positions 2 / 3 must be updated — the issue calls this trade-off out and accepts it.
- Default header row when `resultHeaders=TRUE` is now `Key1 ... KeyK, Column, Value` (was `Row, Column, Value` for the K=1 case). Custom header arrays — already the recommended path — are unchanged.

## Test plan

- [x] `LambdaFormatTests` — 576 / 576 pass
- [x] UNPIVOT-filtered harness — 15 / 15 pass (covers all four modes, multi-key with default + custom headers, `dropBlanks`, single-cell grid, help text)
- [x] Full lambda harness — 617 / 617 pass (no regressions elsewhere)

Closes #245