### PR TITLE
Add THUNK lambda + new functional/ category

### DIFF
--- a/lambdas/functional/THUNK.lambda
+++ b/lambdas/functional/THUNK.lambda
@@ -1,0 +1,27 @@
+/*  FUNCTION NAME:      THUNK
+    DESCRIPTION:*//**Wraps a value in a zero-argument lambda (a "thunk") so it is returned only when the result is called with ().*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-17  Claude      Initial version
+*/
+THUNK = LAMBDA(
+//  Parameter Declarations
+    [x],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →THUNK(x)¶" &
+                "DESCRIPTION:   →Wraps a value in a zero-argument lambda (a ""thunk"") so it is returned only when the result is called with ().¶" &
+                "VERSION:       →Jun 17 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   x              →(Required) The value to defer. Captured by closure and returned when the thunk is called.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=THUNK(42)()¶" &
+                "Result         →42 (call the thunk with () to retrieve the value; =THUNK(42) on its own returns a function, shown as #CALC!)",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(x),
+    //  Procedure
+        result, LAMBDA(x),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/functional/THUNK.tests.yaml
+++ b/lambdas/functional/THUNK.tests.yaml
@@ -1,0 +1,9 @@
+# Coverage note: the test harness wraps every case as `=THUNK(args)` and cannot
+# append the `()` needed to invoke the returned thunk. Since `=THUNK(value)` yields
+# a function (rendered as #CALC! in a cell), the only behaviour we can assert here
+# is the help table. Verifying THUNK(42)()=42 requires a real worksheet and is a
+# known harness gap, not a missing test.
+tests:
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/functional/_library.yaml
+++ b/lambdas/functional/_library.yaml
@@ -1,0 +1,3 @@
+name: Functional
+description: General functional-programming primitives — deferred values, combinators, and higher-order helpers.
+default_prefix: functional


### PR DESCRIPTION
## What

Adds `THUNK(x)` — the canonical *deferred value* primitive. It wraps a value in a zero-argument lambda so the value is returned only when the result is called:

```
=THUNK(42)     -> a function (a cell shows #CALC!)
=THUNK(42)()   -> 42
```

Implemented as `result, LAMBDA(x)` inside the standard self-documenting shell — a nullary lambda whose body closes over the captured `x`.

Also introduces a new **`functional/`** category (`lambdas/functional/_library.yaml`) for general functional-programming primitives, with THUNK as its first member.

## Why minimal docs rather than the bare one-liner

The proposed `THUNK = LAMBDA(x, LAMBDA(x))` can't ship as-is. `LambdaFormatTests` (CI-enforced) requires every `.lambda` to carry the header comment, a `TEXTSPLIT` Help table, and a `Help?, ISOMITTED(...)` guard. The standard wrapper satisfies that *and* makes `=THUNK()` return help. The help text is deliberately short but calls out the gotcha that `=THUNK(42)` on its own returns a function, not a value.

## Testing

- `LambdaFormatTests` — 584 pass.
- Full `LambdaHarnessTests` suite — **618 pass, 0 fail** (includes the new help-text case).

**Known coverage gap (documented in the tests file):** the harness wraps every case as `=THUNK(args)` and cannot append the `()` that invokes the returned thunk. Since `=THUNK(value)` yields a function, the only assertable behaviour here is the help table. Verifying `THUNK(42)()=42` requires a live worksheet — it's a harness limitation, not a missing test.

No issue — created ad hoc at Tim's request.