### PR TITLE
Add MOSTOF array tally lambda

### DIFF
--- a/lambdas/array/MOSTOF.lambda
+++ b/lambdas/array/MOSTOF.lambda
@@ -1,0 +1,31 @@
+/*  FUNCTION NAME:      MOSTOF
+    DESCRIPTION:*//**Returns a value/count table for an array, sorted most-frequent first.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-23  Claude      Initial version
+*/
+MOSTOF = LAMBDA(
+//  Parameter Declarations
+    [values],
+    [function],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →MOSTOF(values, [function])¶" &
+                "DESCRIPTION:   →Returns a two-column table of distinct values and their tally, sorted by tally descending (most-frequent first).¶" &
+                "VERSION:       →Jun 23 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   values         →(Required) A 1D array of values to tally.¶" &
+                "   function       →(Optional) Aggregation applied per group. Defaults to ROWS (a count). Pass a built-in by name (SUM, AVERAGE, MAX, ...) to aggregate the values instead.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=MOSTOF({""A"",""A"",""B"",""B"",""B"",""C""})¶" &
+                "Result         →B 3 / A 2 / C 1",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(values),
+    //  Procedure
+        _arr, IF(ROWS(values)=1, TRANSPOSE(values), values),
+        _fn, IF(ISOMITTED(function), ROWS, function),
+        result, GROUPBY(_arr, _arr, _fn, , 0, -2),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/MOSTOF.lambda
+++ b/lambdas/array/MOSTOF.lambda
@@ -1,20 +1,22 @@
 /*  FUNCTION NAME:      MOSTOF
-    DESCRIPTION:*//**Returns a value/count table for an array, sorted most-frequent first.*/
+    DESCRIPTION:*//**Returns a value/tally table for an array, sorted largest tally first.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-06-23  Claude      Initial version
 */
 MOSTOF = LAMBDA(
 //  Parameter Declarations
     [values],
+    [weights],
     [function],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →MOSTOF(values, [function])¶" &
-                "DESCRIPTION:   →Returns a two-column table of distinct values and their tally, sorted by tally descending (most-frequent first).¶" &
+                "FUNCTION:      →MOSTOF(values, [weights], [function])¶" &
+                "DESCRIPTION:   →Returns a two-column table of distinct values and their tally, sorted by tally descending (largest first). A simpler GROUPBY for the common most-common case.¶" &
                 "VERSION:       →Jun 23 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   values         →(Required) A 1D array of values to tally.¶" &
-                "   function       →(Optional) Aggregation applied per group. Defaults to ROWS (a count). Pass a built-in by name (SUM, AVERAGE, MAX, ...) to aggregate the values instead.¶" &
+                "   values         →(Required) A 1D array of values to group and tally.¶" &
+                "   weights        →(Optional) A 1D array, same length as values, aggregated per group. Omit to tally a simple count of occurrences.¶" &
+                "   function       →(Optional) Aggregation applied per group. Defaults to ROWS (a count) when weights is omitted, or SUM when weights is supplied. Pass a built-in by name (SUM, AVERAGE, MAX, ...) to override.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=MOSTOF({""A"",""A"",""B"",""B"",""B"",""C""})¶" &
                 "Result         →B 3 / A 2 / C 1",
@@ -22,10 +24,12 @@ MOSTOF = LAMBDA(
                 ),
     //  Check inputs
         Help?, ISOMITTED(values),
+        HasWeights?, NOT(ISOMITTED(weights)),
     //  Procedure
-        _arr, IF(ROWS(values)=1, TRANSPOSE(values), values),
-        _fn, IF(ISOMITTED(function), ROWS, function),
-        result, GROUPBY(_arr, _arr, _fn, , 0, -2),
+        _keys, IF(ROWS(values)=1, TRANSPOSE(values), values),
+        _vals, IF(HasWeights?, IF(ROWS(weights)=1, TRANSPOSE(weights), weights), _keys),
+        _fn, IF(ISOMITTED(function), IF(HasWeights?, SUM, ROWS), function),
+        result, GROUPBY(_keys, _vals, _fn, , 0, -2),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/array/MOSTOF.tests.yaml
+++ b/lambdas/array/MOSTOF.tests.yaml
@@ -1,0 +1,20 @@
+tests:
+  - name: letters tallied most-frequent first
+    args: ['={"A","A","B","B","B","C"}']
+    expected: [["B", 3], ["A", 2], ["C", 1]]
+
+  - name: numbers tallied most-frequent first
+    args: ["={1,2,2,3,3,3}"]
+    expected: [[3, 3], [2, 2], [1, 1]]
+
+  - name: vertical array input
+    args: ['={"A";"B";"B"}']
+    expected: [["B", 2], ["A", 1]]
+
+  - name: custom function aggregates values with SUM
+    args: ["={1,2,2,3,3,3}", "=SUM"]
+    expected: [[3, 9], [2, 4], [1, 1]]
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/array/MOSTOF.tests.yaml
+++ b/lambdas/array/MOSTOF.tests.yaml
@@ -1,9 +1,9 @@
 tests:
-  - name: letters tallied most-frequent first
+  - name: letters counted, largest tally first
     args: ['={"A","A","B","B","B","C"}']
     expected: [["B", 3], ["A", 2], ["C", 1]]
 
-  - name: numbers tallied most-frequent first
+  - name: numbers counted, largest tally first
     args: ["={1,2,2,3,3,3}"]
     expected: [[3, 3], [2, 2], [1, 1]]
 
@@ -11,9 +11,13 @@ tests:
     args: ['={"A";"B";"B"}']
     expected: [["B", 2], ["A", 1]]
 
-  - name: custom function aggregates values with SUM
-    args: ["={1,2,2,3,3,3}", "=SUM"]
-    expected: [[3, 9], [2, 4], [1, 1]]
+  - name: weights sum per group by default
+    args: ['={"A","B","A","B","A"}', "={10,5,20,3,1}"]
+    expected: [["A", 31], ["B", 8]]
+
+  - name: weights with explicit AVERAGE function
+    args: ['={"A","B","A"}', "={10,20,40}", "=AVERAGE"]
+    expected: [["A", 25], ["B", 20]]
 
   - name: help text
     args: []


### PR DESCRIPTION
## Summary

Adds `MOSTOF(values, [weights], [function])` — a friendlier `GROUPBY` for the common "what occurs most / which category is biggest" question. Returns a two-column **value / tally** table sorted largest-tally first.

```
=MOSTOF({"A","A","B","B","B","C"})   ->   B  3
                                          A  2
                                          C  1
```

Complements `MAXOCCUR` / `MINOCCUR`, which return only the single most/least common value; `MOSTOF` gives the full ranked table.

### Tally semantics

- **No weights** — tallies a plain count of occurrences (`ROWS`).
- **Weights supplied** — aggregates the weights column per group, defaulting to `SUM` (e.g. `MOSTOF(category, amount)` = total amount per category, sorted descending).
- **`function`** — overrides the default aggregation either way; pass any built-in by name (`AVERAGE`, `MAX`, `COUNT`, ...).

Row-shaped inputs are normalised to a column so `GROUPBY` groups one value per row.

## Tests

6 harness cases: letter/number counts, vertical input, default-`SUM` weighted aggregation, explicit `AVERAGE` over weights, and help text. Format suite (608) and full harness suite (655) both green.

Closes #255