### PR TITLE
Fix MOSTOF #VALUE! error on single-value input

### DIFF
--- a/lambdas/array/MOSTOF.lambda
+++ b/lambdas/array/MOSTOF.lambda
@@ -2,6 +2,7 @@
     DESCRIPTION:*//**Returns a value/tally table for an array, sorted largest tally first.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-06-23  Claude      Initial version
+                        2026-06-24  Claude      Pass explicit field_headers (0) to GROUPBY; blank arg threw #VALUE! on single-value input
 */
 MOSTOF = LAMBDA(
 //  Parameter Declarations
@@ -12,7 +13,7 @@ MOSTOF = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →MOSTOF(values, [weights], [function])¶" &
                 "DESCRIPTION:   →Returns a two-column table of distinct values and their tally, sorted by tally descending (largest first). A simpler GROUPBY for the common most-common case.¶" &
-                "VERSION:       →Jun 23 2026¶" &
+                "VERSION:       →Jun 24 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   values         →(Required) A 1D array of values to group and tally.¶" &
                 "   weights        →(Optional) A 1D array, same length as values, aggregated per group. Omit to tally a simple count of occurrences.¶" &
@@ -29,7 +30,7 @@ MOSTOF = LAMBDA(
         _keys, IF(ROWS(values)=1, TRANSPOSE(values), values),
         _vals, IF(HasWeights?, IF(ROWS(weights)=1, TRANSPOSE(weights), weights), _keys),
         _fn, IF(ISOMITTED(function), IF(HasWeights?, SUM, ROWS), function),
-        result, GROUPBY(_keys, _vals, _fn, , 0, -2),
+        result, GROUPBY(_keys, _vals, _fn, 0, 0, -2),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/array/MOSTOF.tests.yaml
+++ b/lambdas/array/MOSTOF.tests.yaml
@@ -22,3 +22,11 @@ tests:
   - name: help text
     args: []
     expected_type: array
+
+  - name: single value array
+    args: ['={"A"}']
+    expected: [["A", 1]]
+
+  - name: single distinct value, multiple rows
+    args: ['={"A";"A";"A"}']
+    expected: [["A", 3]]


### PR DESCRIPTION
## Problem

`=MOSTOF({"A"})` — and any array that collapses to a single value/row — returned `#VALUE!` instead of the expected `[["A", 1]]` tally table.

## Root cause

MOSTOF called GROUPBY with a **blank `field_headers` argument**:

```
GROUPBY(_keys, _vals, _fn, , 0, -2)
```

Excel tolerates the omitted argument for multi-row inputs, but returns `#VALUE!` when the input is a single value/row. Passing `field_headers` explicitly as `0` (no headers) fixes it:

```
GROUPBY(_keys, _vals, _fn, 0, 0, -2)
```

## Changes

- MOSTOF.lambda: explicit `field_headers = 0` in the GROUPBY call; revision-log entry and help `VERSION` bump.
- MOSTOF.tests.yaml: regression tests for a single-value array (`={"A"}`) and a single distinct value over multiple rows (`={"A";"A";"A"}`).

## Testing

Full harness suite green: **663/663 passing**.