### PR TITLE
Add UNQ array lambda — auto-orienting UNIQUE wrapper

### DIFF
--- a/lambdas/array/UNQ.lambda
+++ b/lambdas/array/UNQ.lambda
@@ -1,0 +1,29 @@
+/*  FUNCTION NAME:      UNQ
+    DESCRIPTION:*//**Returns the unique values of an array, auto-orienting: a row stays a row, a column stays a column, a 2D grid flattens to one column.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-26  Claude      Initial version
+*/
+UNQ = LAMBDA(
+//  Parameter Declarations
+    [array],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →UNQ(array)¶" &
+                "DESCRIPTION:   →Returns the unique values of an array, auto-orienting by shape.¶" &
+                "VERSION:       →Jun 26 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   array         →(Required) A 1D row, 1D column, or 2D array. A row returns a row of distinct values, a column returns a column, and a 2D grid flattens (row by row) into a single column of distinct values.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=UNQ({1,2,2,3})¶" &
+                "Result         →{1,2,3}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(array),
+    //  Procedure
+        result, IF(ROWS(array) = 1, UNIQUE(array, TRUE),
+                   IF(COLUMNS(array) = 1, UNIQUE(array),
+                      UNIQUE(TOCOL(array)))),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/UNQ.tests.yaml
+++ b/lambdas/array/UNQ.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: horizontal row stays a row
+    args: ['={1,2,2,3}']
+    expected: [[1, 2, 3]]
+
+  - name: vertical column stays a column
+    args: ['={1;2;2;3}']
+    expected: [[1], [2], [3]]
+
+  - name: 2D grid flattens to a column
+    args: ['={1,2;2,3}']
+    expected: [[1], [2], [3]]
+
+  - name: string row deduplicates
+    args: ['={"a","b","a"}']
+    expected: [["a", "b"]]
+
+  - name: single value returns scalar
+    args: ['={5}']
+    expected: 5
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Adds `UNQ(array)` — a shape-aware wrapper around `UNIQUE` that needs no extra arguments, per issue #259.

- **Row in → row out** (`UNIQUE(array, TRUE)`)
- **Column in → column out** (`UNIQUE(array)`)
- **2D grid in → single column out**, flattened row-by-row (`UNIQUE(TOCOL(array))`)

Lives in the `array` library.

## Design note

The issue named the function `U`, but single-letter names risk Excel injection failures (`C`/`R` are reserved R1C1 shortcuts). Tim chose **UNQ** instead — short to type, no collision risk, injects cleanly in the harness.

## Testing

- Format tests: pass (616).
- Functional harness (UNQ-scoped): 6/6 pass — row, column, 2D flatten, string dedup, single-value scalar, help text.
- Full harness suite: 669/669 pass.

Closes #259