### PR TITLE
Add XV / XH — vertical & horizontal table lookups

### DIFF
--- a/lambdas/array/BIMAP.lambda
+++ b/lambdas/array/BIMAP.lambda
@@ -1,0 +1,48 @@
+/*  FUNCTION NAME:      BIMAP
+    DESCRIPTION:*//**Applies a LAMBDA to each element of an array and tiles each element's array result into a block grid, padding ragged blocks with blanks.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-27  Claude      Initial version
+*/
+BIMAP = LAMBDA(
+//  Parameter Declarations
+    [array],
+    [function],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →BIMAP(array, function)¶" &
+                "DESCRIPTION:   →Applies a LAMBDA to each element of an array and tiles each element's array result into a block grid, padding ragged blocks with blanks.¶" &
+                "VERSION:       →Jun 27 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   array          →(Required) A 2D array.¶" &
+                "   function       →(Required) A LAMBDA applied to each single element; may return a multi-cell array of any shape. Each result is laid into its own block, so an m-by-n input whose cells each return p-by-q yields an (m*p)-by-(n*q) grid. Ragged widths are padded to the per-column maximum and ragged heights to the per-row maximum, with blanks as filler.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=BIMAP({1,2}, LAMBDA(x, x*{1;10}))¶" &
+                "Result         →{1,2;10,20}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(array),
+    //  Procedure
+        th, MAP(array, LAMBDA(a, LAMBDA(function(a)))),
+        colWidth, IF(SEQUENCE(ROWS(array)), BYCOL(MAP(th, LAMBDA(t, IFERROR(COLUMNS((@t)()), 1))), MAX)),
+        tw, MAP(th, colWidth, LAMBDA(t, w, LAMBDA(HSTACK(t, w)))),
+        build, LAMBDA(build, a,
+                  LET(
+                      nRows, ROWS(a),
+                      nCols, COLUMNS(a),
+                      tx, (@a)(),
+                      IF(
+                          nRows = 1,
+                          IF(
+                              nCols = 1,
+                              EXPAND(IFERROR((@tx)(), ""), , INDEX(tx, 1, 2)),
+                              IFNA(HSTACK(build(build, TAKE(a, , nCols / 2)), build(build, DROP(a, , nCols / 2))), "")
+                          ),
+                          IFNA(VSTACK(build(build, TAKE(a, nRows / 2)), build(build, DROP(a, nRows / 2))), "")
+                      )
+                  )
+               ),
+        result, build(build, tw),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/BIMAP.tests.yaml
+++ b/lambdas/array/BIMAP.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: each element expands to a column, 1x2 in -> 2x2 out
+    args: ['={1,2}', '=LAMBDA(x, x*{1;10})']
+    expected: [[1, 2], [10, 20]]
+
+  - name: each cell returns a 2x2 block, 2x2 in -> 4x4 out
+    args: ['={1,2;3,4}', '=LAMBDA(x, x*{1,1;1,1})']
+    expected:
+      - [1, 1, 2, 2]
+      - [1, 1, 2, 2]
+      - [3, 3, 4, 4]
+      - [3, 3, 4, 4]
+
+  - name: scalar-returning function behaves like MAP
+    args: ['={1,2;3,4}', '=LAMBDA(x, x*10)']
+    expected: [[10, 20], [30, 40]]
+
+  - name: ragged heights in a column padded with blanks
+    args: ['={1;2}', '=LAMBDA(x, SEQUENCE(1, x))']
+    expected: [[1, ""], [1, 2]]
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/lookup/XH.lambda
+++ b/lambdas/lookup/XH.lambda
@@ -1,0 +1,51 @@
+/*  FUNCTION NAME:      XH
+    DESCRIPTION:*//**Horizontal table lookup that matches in one row and returns one or more rows by index, with case-sensitive matching and array-of-lookups support.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-26  Claude      Initial version
+*/
+XH = LAMBDA(
+//  Parameter Declarations
+    [Lookup_value],
+    [Table],
+    [Return_row_no],
+    [Lookup_row_no],
+    [If_not_found],
+    [Match_mode],
+    [Search_mode],
+    [Case_sensitive],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →XH(Lookup_value, Table, [Return_row_no], [Lookup_row_no], [If_not_found], [Match_mode], [Search_mode], [Case_sensitive])¶" &
+                "DESCRIPTION:   →Horizontal table lookup that matches in one row and returns one or more rows by index, with case-sensitive matching and array-of-lookups support.¶" &
+                "VERSION:       →Jun 26 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   Lookup_value   →(Required) Value to find in the lookup row. Also accepts an array of values — result lifts to one column per value.¶" &
+                "   Table          →(Required) Multi-row table of data (no header column needed).¶" &
+                "   Return_row_no  →(Optional) Row index(es) to return; negative counts from the bottom (-1 = last). Accepts a list like {3,1,4} for reordered/non-contiguous rows. Default -1.¶" &
+                "   Lookup_row_no  →(Optional) Row index to search; negative from bottom. Default: last row when returning row 1, else first row.¶" &
+                "   If_not_found   →(Optional) Value returned when no match is found. Default #N/A.¶" &
+                "   Match_mode     →(Optional) XMATCH match mode: (0) exact [default], (-1) exact-or-next-smaller, (1) exact-or-next-larger, (2) wildcard. Ignored when Case_sensitive is TRUE.¶" &
+                "   Search_mode    →(Optional) XMATCH search mode: (1) first-to-last [default], (-1) last-to-first, (2) binary ascending, (-2) binary descending. Ignored when Case_sensitive is TRUE.¶" &
+                "   Case_sensitive →(Optional) TRUE for case-sensitive exact match (R is not r). Exact match only. Default FALSE.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=XH(""Bravo"", A1:D3, {3,1})¶" &
+                "Result         →returns rows 3 and 1 from the column whose first row equals Bravo",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(Lookup_value),
+    //  Procedure
+        result, TRANSPOSE(
+                  XV(
+                    Lookup_value,
+                    TRANSPOSE(Table),
+                    IF(ISOMITTED(Return_row_no), -1, Return_row_no),
+                    IF(ISOMITTED(Lookup_row_no), 0, Lookup_row_no),
+                    IF(ISOMITTED(If_not_found), NA(), If_not_found),
+                    IF(ISOMITTED(Match_mode), 0, Match_mode),
+                    IF(ISOMITTED(Search_mode), 1, Search_mode),
+                    IF(ISOMITTED(Case_sensitive), FALSE, Case_sensitive)
+                  )),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/lookup/XH.tests.yaml
+++ b/lambdas/lookup/XH.tests.yaml
@@ -1,0 +1,69 @@
+tests:
+  - name: scalar lookup, default return (last row), default lookup row
+    setup:
+      cells:
+        - address: "G3:J5"
+          values:
+            - ["alpha", "bravo", "Bravo", "charlie"]
+            - [100, 200, 300, 400]
+            - ["x", "y", "z", "w"]
+      names:
+        - { name: "hTbl", refers_to: "G3:J5" }
+    args: ["bravo", "=hTbl"]
+    expected: "y"
+
+  - name: case-sensitive match finds Bravo not bravo
+    setup:
+      cells:
+        - address: "G3:J5"
+          values:
+            - ["alpha", "bravo", "Bravo", "charlie"]
+            - [100, 200, 300, 400]
+            - ["x", "y", "z", "w"]
+      names:
+        - { name: "hTbl", refers_to: "G3:J5" }
+    args: ["Bravo", "=hTbl", "=2", "=1", "=NA()", "=0", "=1", "=TRUE"]
+    expected: 300
+
+  - name: multi-row reordered return {3,1}
+    setup:
+      cells:
+        - address: "G3:J5"
+          values:
+            - ["alpha", "bravo", "Bravo", "charlie"]
+            - [100, 200, 300, 400]
+            - ["x", "y", "z", "w"]
+      names:
+        - { name: "hTbl", refers_to: "G3:J5" }
+    args: ["charlie", "=hTbl", "={3,1}"]
+    expected: [["w"], ["charlie"]]
+
+  - name: horizontal array of lookups, single return row
+    setup:
+      cells:
+        - address: "G3:J5"
+          values:
+            - ["alpha", "bravo", "Bravo", "charlie"]
+            - [100, 200, 300, 400]
+            - ["x", "y", "z", "w"]
+      names:
+        - { name: "hTbl", refers_to: "G3:J5" }
+    args: ['={"alpha","charlie"}', "=hTbl", "=2"]
+    expected: [[100, 400]]
+
+  - name: if_not_found returned on no match
+    setup:
+      cells:
+        - address: "G3:J5"
+          values:
+            - ["alpha", "bravo", "Bravo", "charlie"]
+            - [100, 200, 300, 400]
+            - ["x", "y", "z", "w"]
+      names:
+        - { name: "hTbl", refers_to: "G3:J5" }
+    args: ["zzz", "=hTbl", "=2", "=1", "missing"]
+    expected: "missing"
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/lookup/XV.lambda
+++ b/lambdas/lookup/XV.lambda
@@ -1,0 +1,58 @@
+/*  FUNCTION NAME:      XV
+    DESCRIPTION:*//**Vertical table lookup that matches in one column and returns one or more columns by index, with case-sensitive matching and array-of-lookups support.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-26  Claude      Initial version
+*/
+XV = LAMBDA(
+//  Parameter Declarations
+    [Lookup_value],
+    [Table],
+    [Return_col_no],
+    [Lookup_col_no],
+    [If_not_found],
+    [Match_mode],
+    [Search_mode],
+    [Case_sensitive],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →XV(Lookup_value, Table, [Return_col_no], [Lookup_col_no], [If_not_found], [Match_mode], [Search_mode], [Case_sensitive])¶" &
+                "DESCRIPTION:   →Vertical table lookup that matches in one column and returns one or more columns by index, with case-sensitive matching and array-of-lookups support.¶" &
+                "VERSION:       →Jun 26 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   Lookup_value   →(Required) Value to find in the lookup column. Also accepts an array of values — result lifts to one row per value.¶" &
+                "   Table          →(Required) Multi-column table of data (no header row needed).¶" &
+                "   Return_col_no  →(Optional) Column index(es) to return; negative counts from the right (-1 = last). Accepts a list like {3,1,4} for reordered/non-contiguous columns. Default -1.¶" &
+                "   Lookup_col_no  →(Optional) Column index to search; negative from right. Default: last column when returning column 1, else first column.¶" &
+                "   If_not_found   →(Optional) Value returned when no match is found. Default #N/A.¶" &
+                "   Match_mode     →(Optional) XMATCH match mode: (0) exact [default], (-1) exact-or-next-smaller, (1) exact-or-next-larger, (2) wildcard. Ignored when Case_sensitive is TRUE.¶" &
+                "   Search_mode    →(Optional) XMATCH search mode: (1) first-to-last [default], (-1) last-to-first, (2) binary ascending, (-2) binary descending. Ignored when Case_sensitive is TRUE.¶" &
+                "   Case_sensitive →(Optional) TRUE for case-sensitive exact match (R is not r). Exact match only. Default FALSE.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=XV(""Bravo"", A2:C5, {3,1})¶" &
+                "Result         →returns columns 3 and 1 from the row whose first column equals Bravo",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(Lookup_value),
+    //  Procedure
+        nCols, COLUMNS(Table),
+        retRaw, IF(ISOMITTED(Return_col_no), -1, Return_col_no),
+        retList, IF(ROWS(retRaw) > 1, TRANSPOSE(retRaw), retRaw),
+        retIdx, IF(retList < 0, nCols + retList + 1, retList),
+        retIsCol1, AND(ROWS(retIdx) = 1, COLUMNS(retIdx) = 1, INDEX(retIdx, 1, 1) = 1),
+        lkpDefault, IF(retIsCol1, nCols, 1),
+        lkpRaw, IF(ISOMITTED(Lookup_col_no), lkpDefault, IF(Lookup_col_no = 0, lkpDefault, Lookup_col_no)),
+        lkpIdx, IF(lkpRaw < 0, nCols + lkpRaw + 1, lkpRaw),
+        lookupCol, INDEX(Table, , lkpIdx),
+        notFound, IF(ISOMITTED(If_not_found), NA(), If_not_found),
+        matchMode, IF(ISOMITTED(Match_mode), 0, Match_mode),
+        searchMode, IF(ISOMITTED(Search_mode), 1, Search_mode),
+        caseSens, IF(ISOMITTED(Case_sensitive), FALSE, Case_sensitive),
+        lookupVals, IF(ROWS(Lookup_value) = 1, TRANSPOSE(Lookup_value), Lookup_value),
+        posOf, LAMBDA(v, IF(caseSens, MATCH(TRUE, EXACT(lookupCol, v), 0), XMATCH(v, lookupCol, matchMode, searchMode))),
+        multiLookup, OR(ROWS(lookupVals) > 1, COLUMNS(lookupVals) > 1),
+        posVec, IF(multiLookup, MAP(lookupVals, posOf), posOf(lookupVals)),
+        result, IFERROR(INDEX(Table, posVec, retIdx), notFound),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/lookup/XV.tests.yaml
+++ b/lambdas/lookup/XV.tests.yaml
@@ -83,6 +83,34 @@ tests:
     args: ['={"alpha";"charlie"}', "=testTbl", "={1,2}"]
     expected: [["alpha", 100], ["charlie", 400]]
 
+  - name: 3 lookups crossed with 3 reordered columns -> full 3x3 grid
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ['={"charlie";"alpha";"bravo"}', "=testTbl", "={3,1,2}"]
+    expected: [["w", "charlie", 400], ["x", "alpha", 100], ["y", "bravo", 200]]
+
+  - name: case-sensitive lookups crossed with multi-column return
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ['={"Bravo";"alpha"}', "=testTbl", "={1,2}", "=1", "=NA()", "=0", "=1", "=TRUE"]
+    expected: [["Bravo", 300], ["alpha", 100]]
+
   - name: reverse lookup via smart default (return col 1 looks up last col)
     setup:
       cells:

--- a/lambdas/lookup/XV.tests.yaml
+++ b/lambdas/lookup/XV.tests.yaml
@@ -1,0 +1,116 @@
+tests:
+  - name: scalar lookup, default return (last col), default lookup col
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ["bravo", "=testTbl"]
+    expected: "y"
+
+  - name: explicit return col and lookup col
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ["Bravo", "=testTbl", "=2", "=1"]
+    expected: 200
+
+  - name: case-sensitive match finds Bravo not bravo
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ["Bravo", "=testTbl", "=2", "=1", "=NA()", "=0", "=1", "=TRUE"]
+    expected: 300
+
+  - name: multi-column reordered return {3,1}
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ["charlie", "=testTbl", "={3,1}"]
+    expected: [["w", "charlie"]]
+
+  - name: vertical array of lookups, single return col
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ['={"alpha";"charlie"}', "=testTbl", "=2"]
+    expected: [[100], [400]]
+
+  - name: array of lookups crossed with multi-column return
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ['={"alpha";"charlie"}', "=testTbl", "={1,2}"]
+    expected: [["alpha", 100], ["charlie", 400]]
+
+  - name: reverse lookup via smart default (return col 1 looks up last col)
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ["z", "=testTbl", "=1"]
+    expected: "Bravo"
+
+  - name: if_not_found returned on no match
+    setup:
+      cells:
+        - address: "G3:I6"
+          values:
+            - ["alpha", 100, "x"]
+            - ["bravo", 200, "y"]
+            - ["Bravo", 300, "z"]
+            - ["charlie", 400, "w"]
+      names:
+        - { name: "testTbl", refers_to: "G3:I6" }
+    args: ["zzz", "=testTbl", "=2", "=1", "missing"]
+    expected: "missing"
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Adds the `XV` (vertical) and `XH` (horizontal) lookup twins reconstructed from the competitor "Collecting Scarves" workbook, plus `BIMAP` — a general shape-expanding element map that came directly out of the design discussion.

Signature, defaults, scope, and the case-sensitive approach were all confirmed with Tim before building (the issue flagged them as tentative).

```
=XV(Lookup_value, Table, [Return_col_no], [Lookup_col_no], [If_not_found], [Match_mode], [Search_mode], [Case_sensitive])
=XH( ... )   ' horizontal twin — rows instead of columns
```

## XV / XH — three functional wins over native XLOOKUP

1. **Case-sensitive exact match** (`R` ≠ `r`) — `MATCH(TRUE, EXACT(...))`. v1 is exact-match-only; `Match_mode`/`Search_mode` are ignored when `Case_sensitive=TRUE` (documented in help).
2. **Array-of-lookups × multi-column return** in one formula — `INDEX(Table, posVec, colVec)` broadcasts a column-vector of matched row positions against a row-vector of return columns, sidestepping the nested-array `#CALC!` without a thunked `BMap`.
3. **Non-contiguous / reordered return columns** via an index list (e.g. `{3,1,4}`); negatives count from the right; smart `Lookup_col_no` default (last col when returning col 1, else first).

`XH` is a thin transpose wrapper over `XV` (forwards resolved args to `XV(TRANSPOSE(Table), …)` and transposes the result), keeping `XV` as the single source of truth.

## BIMAP — new general utility (`lambdas/array/`)

Sibling to `BICOL`/`BIROW`. Applies a LAMBDA to each **element** of an array where the function may return a **multi-cell array**, tiling each result into its own block: an m×n input whose cells each return p×q yields an **(m·p)×(n·q)** grid; ragged widths/heights pad to the per-band max with blanks.

XV doesn't actually need `BIMAP` (its uniform multi-column return is covered by `INDEX` broadcast), but `BIMAP` is the right general tool for **ragged / computed** per-element expansion (e.g. split-and-stack, variable-length expansion). Adapted from the competitor's `BMap`: thunk each element to dodge `#CALC!`, measure block widths, then a recursive binary split reassembles with `HSTACK`/`VSTACK`, `EXPAND`-padding columns and `IFNA`-padding rows.

## Testing

- Format tests: 656 passed.
- XV harness: 11/11 — incl. case-sensitive disambiguation (`bravo` before `Bravo`), a non-symmetric 3×3 reordered grid, case-sensitive × multi-column, array-of-lookups × multi-column, reverse lookup via smart default, `if_not_found`.
- XH harness: 6/6.
- BIMAP harness: 5/5 — incl. 2×2→4×4 block tiling, scalar-return (acts like `MAP`), ragged heights padded with blanks.
- Full harness suite: 704 passed.

Closes #261