### PR TITLE
Add repetition flag to PERMUTEINDICES / COMBININDICES / PERMUTATIONS / COMBINATIONS

### DIFF
--- a/lambdas/math/COMBINATIONS.lambda
+++ b/lambdas/math/COMBINATIONS.lambda
@@ -2,21 +2,24 @@
     DESCRIPTION:*//**Returns all unordered k-combinations of items, lexicographic order. With delim, joins each row into a single string.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-04-29  Claude      Initial version
+                        2026-06-27  Claude      Add optional repetition flag (forwarded to COMBININDICES)
 */
 COMBINATIONS = LAMBDA(
 //  Parameter Declarations
     [items],
     [k],
     [delim],
+    [repetition],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →COMBINATIONS(items, k, [delim])¶" &
+                "FUNCTION:      →COMBINATIONS(items, k, [delim], [repetition])¶" &
                 "DESCRIPTION:   →Returns all unordered k-combinations of items, lexicographic order. With delim, joins each row into a single string.¶" &
-                "VERSION:       →Apr 29 2026¶" &
+                "VERSION:       →Jun 27 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   items          →(Required) 1-D array of items (row or column).¶" &
-                "   k              →(Required) Combination size, 1 ≤ k ≤ count(items).¶" &
+                "   k              →(Required) Combination size. Without repetition, 1 ≤ k ≤ count(items). With repetition, any k ≥ 1.¶" &
                 "   delim          →(Optional) If provided, TEXTJOIN each combination row into a single string.¶" &
+                "   repetition     →(Optional) FALSE (default) = distinct items. TRUE = allow repeats (multisets), C(n+k-1, k) rows.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=COMBINATIONS({""A"";""B"";""C"";""D""}, 3, ""|"")¶" &
                 "Result         →4x1: {""A|B|C""; ""A|B|D""; ""A|C|D""; ""B|C|D""}¶" &
@@ -28,7 +31,8 @@ COMBINATIONS = LAMBDA(
     //  Procedure
         itemsCol, IF(ROWS(items) = 1, TRANSPOSE(items), items),
         nItems,   ROWS(itemsCol),
-        idx,      COMBININDICES(nItems, k),
+        rep,      IF(ISOMITTED(repetition), FALSE, repetition),
+        idx,      COMBININDICES(nItems, k, rep),
         vals,     INDEX(itemsCol, idx),
         result,   IF(ISOMITTED(delim),
                      vals,

--- a/lambdas/math/COMBINATIONS.tests.yaml
+++ b/lambdas/math/COMBINATIONS.tests.yaml
@@ -47,6 +47,24 @@ tests:
     expected:
       - ["A", "B", "C"]
 
+  - name: repetition gives multisets of size 2
+    args: ['={"A";"B";"C"}', "=2", "=", "=TRUE"]
+    expected:
+      - ["A", "A"]
+      - ["A", "B"]
+      - ["A", "C"]
+      - ["B", "B"]
+      - ["B", "C"]
+      - ["C", "C"]
+
+  - name: repetition with delim allows k greater than count
+    args: ['={"A";"B"}', "=3", "|", "=TRUE"]
+    expected:
+      - ["A|A|A"]
+      - ["A|A|B"]
+      - ["A|B|B"]
+      - ["B|B|B"]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/math/COMBININDICES.lambda
+++ b/lambdas/math/COMBININDICES.lambda
@@ -4,28 +4,32 @@
                         2026-04-29  Claude      Initial version
                         2026-04-29  Claude      Switch to broadcast+TOCOL extension for large-n performance
                         2026-04-29  Claude      Use IFS in place of IF+NA, TAKE in place of INDEX for first/last column
+                        2026-06-27  Claude      Add optional repetition flag (multisets, non-decreasing sequences)
 */
 COMBININDICES = LAMBDA(
 //  Parameter Declarations
     [n],
     [k],
+    [repetition],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →COMBININDICES(n, k)¶" &
+                "FUNCTION:      →COMBININDICES(n, k, [repetition])¶" &
                 "DESCRIPTION:   →Returns a C(n,k) by k matrix of unordered k-combination indices in 1..n, lexicographic order.¶" &
-                "VERSION:       →Apr 29 2026¶" &
+                "VERSION:       →Jun 27 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   n              →(Required) Population size. Positive integer.¶" &
-                "   k              →(Required) Combination size, 1 ≤ k ≤ n.¶" &
+                "   k              →(Required) Combination size. Without repetition, 1 ≤ k ≤ n. With repetition, any k ≥ 1.¶" &
+                "   repetition     →(Optional) FALSE (default) = distinct indices. TRUE = allow repeats (multisets), giving non-decreasing sequences, C(n+k-1, k) rows.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=COMBININDICES(5, 3)¶" &
                 "Result         →10x3 matrix: {1,2,3; 1,2,4; ...; 3,4,5}¶" &
-                "NOTE:          →Pair with COMBINATIONS for value lookup. Returns NA() when n<1, k<1, k>n, or either argument is non-integer.",
+                "NOTE:          →Pair with COMBINATIONS for value lookup. Returns NA() when n<1, k<1, k>n (without repetition), or either argument is non-integer.",
                 "→", "¶"
                 ),
     //  Check inputs
         Help?, ISOMITTED(n),
-        valid?, AND(n >= 1, k >= 1, k <= n, n = INT(n), k = INT(k)),
+        rep,   IF(ISOMITTED(repetition), FALSE, repetition),
+        valid?, AND(n >= 1, k >= 1, OR(rep, k <= n), n = INT(n), k = INT(k)),
     //  Procedure
         result, IF(NOT(valid?), NA(),
                    IF(k = 1, SEQUENCE(n),
@@ -33,7 +37,7 @@ COMBININDICES = LAMBDA(
                           LET(
                               kPrev,    targetK - 1,
                               newCol,   SEQUENCE(1, n),
-                              mask,     newCol > TAKE(prev, , -1),
+                              mask,     IF(rep, newCol >= TAKE(prev, , -1), newCol > TAKE(prev, , -1)),
                               buildCol, LAMBDA(srcCol, TOCOL(IFS(mask, srcCol), 2)),
                               seed,     buildCol(TAKE(prev, , 1)),
                               prevPart, IF(kPrev = 1, seed,

--- a/lambdas/math/COMBININDICES.tests.yaml
+++ b/lambdas/math/COMBININDICES.tests.yaml
@@ -56,6 +56,34 @@ tests:
     args: ["=5", "=2.5"]
     expected: -2146826246
 
+  - name: repetition FALSE matches default behaviour
+    args: ["=4", "=2", "=FALSE"]
+    expected:
+      - [1, 2]
+      - [1, 3]
+      - [1, 4]
+      - [2, 3]
+      - [2, 4]
+      - [3, 4]
+
+  - name: repetition n=3 k=2 gives non-decreasing multisets
+    args: ["=3", "=2", "=TRUE"]
+    expected:
+      - [1, 1]
+      - [1, 2]
+      - [1, 3]
+      - [2, 2]
+      - [2, 3]
+      - [3, 3]
+
+  - name: repetition allows k greater than n
+    args: ["=2", "=3", "=TRUE"]
+    expected:
+      - [1, 1, 1]
+      - [1, 1, 2]
+      - [1, 2, 2]
+      - [2, 2, 2]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/math/PERMUTATIONS.lambda
+++ b/lambdas/math/PERMUTATIONS.lambda
@@ -2,21 +2,24 @@
     DESCRIPTION:*//**Returns all ordered k-permutations of items, lexicographic order. With delim, joins each row into a single string.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-06-16  Claude      Initial version
+                        2026-06-27  Claude      Add optional repetition flag (forwarded to PERMUTEINDICES)
 */
 PERMUTATIONS = LAMBDA(
 //  Parameter Declarations
     [items],
     [k],
     [delim],
+    [repetition],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →PERMUTATIONS(items, k, [delim])¶" &
+                "FUNCTION:      →PERMUTATIONS(items, k, [delim], [repetition])¶" &
                 "DESCRIPTION:   →Returns all ordered k-permutations of items, lexicographic order. With delim, joins each row into a single string.¶" &
-                "VERSION:       →Jun 16 2026¶" &
+                "VERSION:       →Jun 27 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   items          →(Required) 1-D array of items (row or column).¶" &
-                "   k              →(Optional) Permutation length, 1 ≤ k ≤ count(items). Default = count(items).¶" &
+                "   k              →(Optional) Permutation length. Without repetition, 1 ≤ k ≤ count(items); default = count(items). With repetition, any k ≥ 1.¶" &
                 "   delim          →(Optional) If provided, TEXTJOIN each permutation row into a single string.¶" &
+                "   repetition     →(Optional) FALSE (default) = distinct items. TRUE = allow repeats, giving the full n^k cartesian product.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=PERMUTATIONS({""A"";""B"";""C""}, 2, ""|"")¶" &
                 "Result         →6x1: {""A|B""; ""A|C""; ""B|A""; ""B|C""; ""C|A""; ""C|B""}¶" &
@@ -29,7 +32,8 @@ PERMUTATIONS = LAMBDA(
         itemsCol, IF(ROWS(items) = 1, TRANSPOSE(items), items),
         nItems,   ROWS(itemsCol),
         kEff,     IF(ISOMITTED(k), nItems, k),
-        idx,      PERMUTEINDICES(nItems, kEff),
+        rep,      IF(ISOMITTED(repetition), FALSE, repetition),
+        idx,      PERMUTEINDICES(nItems, kEff, rep),
         vals,     INDEX(itemsCol, idx),
         result,   IF(ISOMITTED(delim),
                      vals,

--- a/lambdas/math/PERMUTATIONS.tests.yaml
+++ b/lambdas/math/PERMUTATIONS.tests.yaml
@@ -31,6 +31,18 @@ tests:
     args: ['={"A";"B"}', "=3"]
     expected: -2146826246
 
+  - name: repetition gives AA AB BA BB
+    args: ['={"A";"B"}', "=2", "=", "=TRUE"]
+    expected:
+      - ["A", "A"]
+      - ["A", "B"]
+      - ["B", "A"]
+      - ["B", "B"]
+
+  - name: repetition with delim joins each row
+    args: ['={"A";"B"}', "=2", "|", "=TRUE"]
+    expected: [["A|A"], ["A|B"], ["B|A"], ["B|B"]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/math/PERMUTEINDICES.lambda
+++ b/lambdas/math/PERMUTEINDICES.lambda
@@ -2,29 +2,33 @@
     DESCRIPTION:*//**Returns a P(n,k) by k matrix of ordered k-permutation indices in 1..n, lexicographic order.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-06-16  Claude      Initial version
+                        2026-06-27  Claude      Add optional repetition flag (full n^k cartesian product)
 */
 PERMUTEINDICES = LAMBDA(
 //  Parameter Declarations
     [n],
     [k],
+    [repetition],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →PERMUTEINDICES(n, k)¶" &
+                "FUNCTION:      →PERMUTEINDICES(n, k, [repetition])¶" &
                 "DESCRIPTION:   →Returns a P(n,k) by k matrix of ordered k-permutation indices in 1..n, lexicographic order.¶" &
-                "VERSION:       →Jun 16 2026¶" &
+                "VERSION:       →Jun 27 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   n              →(Required) Population size. Positive integer.¶" &
-                "   k              →(Optional) Permutation length, 1 ≤ k ≤ n. Default = n (full permutations).¶" &
+                "   k              →(Optional) Permutation length. Without repetition, 1 ≤ k ≤ n; default = n (full permutations). With repetition, any k ≥ 1.¶" &
+                "   repetition     →(Optional) FALSE (default) = distinct indices. TRUE = allow repeats, giving the full n^k cartesian product.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=PERMUTEINDICES(3)¶" &
                 "Result         →6x3 matrix: {1,2,3; 1,3,2; 2,1,3; 2,3,1; 3,1,2; 3,2,1}¶" &
-                "NOTE:          →Pair with PERMUTATIONS for value lookup. Returns NA() when n<1, k<1, k>n, or either argument is non-integer.",
+                "NOTE:          →Pair with PERMUTATIONS for value lookup. Returns NA() when n<1, k<1, k>n (without repetition), or either argument is non-integer.",
                 "→", "¶"
                 ),
     //  Check inputs
         Help?, ISOMITTED(n),
-        kEff, IF(ISOMITTED(k), n, k),
-        valid?, AND(n >= 1, kEff >= 1, kEff <= n, n = INT(n), kEff = INT(kEff)),
+        rep,   IF(ISOMITTED(repetition), FALSE, repetition),
+        kEff,  IF(ISOMITTED(k), n, k),
+        valid?, AND(n >= 1, kEff >= 1, OR(rep, kEff <= n), n = INT(n), kEff = INT(kEff)),
     //  Procedure
         result, IF(NOT(valid?), NA(),
                    IF(kEff = 1, SEQUENCE(n),
@@ -32,8 +36,9 @@ PERMUTEINDICES = LAMBDA(
                           LET(
                               kPrev,    targetK - 1,
                               newCol,   SEQUENCE(1, n),
-                              mask,     REDUCE(1, SEQUENCE(kPrev), LAMBDA(acc, colNum,
-                                            acc * (INDEX(prev, , colNum) <> newCol))),
+                              mask,     IF(rep, SEQUENCE(ROWS(prev), n, 1, 0),
+                                            REDUCE(1, SEQUENCE(kPrev), LAMBDA(acc, colNum,
+                                                acc * (INDEX(prev, , colNum) <> newCol)))),
                               buildCol, LAMBDA(srcCol, TOCOL(IFS(mask, srcCol), 2)),
                               seed,     buildCol(TAKE(prev, , 1)),
                               prevPart, IF(kPrev = 1, seed,

--- a/lambdas/math/PERMUTEINDICES.tests.yaml
+++ b/lambdas/math/PERMUTEINDICES.tests.yaml
@@ -31,6 +31,26 @@ tests:
     args: ["=3.5"]
     expected: -2146826246
 
+  - name: repetition FALSE matches default behaviour
+    args: ["=3", "=2", "=FALSE"]
+    expected: [[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]
+
+  - name: repetition n=2 k=2 is full cartesian product
+    args: ["=2", "=2", "=TRUE"]
+    expected: [[1, 1], [1, 2], [2, 1], [2, 2]]
+
+  - name: repetition allows k greater than n (n^k tuples)
+    args: ["=2", "=3", "=TRUE"]
+    expected:
+      - [1, 1, 1]
+      - [1, 1, 2]
+      - [1, 2, 1]
+      - [1, 2, 2]
+      - [2, 1, 1]
+      - [2, 1, 2]
+      - [2, 2, 1]
+      - [2, 2, 2]
+
   - name: help text
     args: []
     expected_type: array


### PR DESCRIPTION
## Summary

Adds a single optional `[repetition]` boolean (default `FALSE` = current behaviour) to the four enumeration lambdas, surfacing permutations-with-repetition and combinations-with-repetition (multisets) without splitting into separate functions.

```
=PERMUTEINDICES(n, k, [repetition])
=COMBININDICES(n, k, [repetition])
=PERMUTATIONS(items, [k], [delim], [repetition])
=COMBINATIONS(items, [k], [delim], [repetition])
```

## What changed (small delta to the existing engines)

- **COMBININDICES** — when `repetition` is TRUE, relax the per-column filter from `newCol > last` (strictly increasing → distinct) to `newCol >= last` (non-decreasing → multisets). Yields `C(n+k-1, k)` rows.
- **PERMUTEINDICES** — when `repetition` is TRUE, drop the exclude-already-used mask so the result is the full `n^k` cartesian product.
- Both relax the `k <= n` validity rule when `repetition` is TRUE, so `k > n` is allowed with repeats (e.g. all 3-digit codes from 2 symbols).
- **PERMUTATIONS / COMBINATIONS** decode `[repetition]` and forward it to their index engine (4th arg, after `delim`).

Default `FALSE` preserves all current behaviour, ordering, and the `k > n → NA()` guard for the distinct case. Fully backward compatible.

## Examples

| Formula | Result |
| --- | --- |
| `=PERMUTEINDICES(2, 3, TRUE)` | 8 rows — full cartesian product |
| `=COMBININDICES(3, 2, TRUE)` | 6 rows — non-decreasing multisets |
| `=PERMUTATIONS({"A";"B"}, 2, , TRUE)` | AA, AB, BA, BB |
| `=COMBINATIONS({"A";"B";"C"}, 2, , TRUE)` | AA, AB, AC, BB, BC, CC |

## Testing

- Format validation: 656 passed.
- AddIn harness: full suite **714 passed**, including new repetition cases on each of the four lambdas (distinct-default regression, multiset/cartesian shape, and `k > n` with repeats).

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)