### PR TITLE
Add recursive-descent Excel formula parser (AST) — #270

### DIFF
--- a/addin/lambda-boss.Tests/FormulaParserTests.cs
+++ b/addin/lambda-boss.Tests/FormulaParserTests.cs
@@ -1,0 +1,366 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+public class FormulaParserTests
+{
+    private static FormulaNode Root(string formula) => FormulaParser.Parse(formula).Root;
+
+    private static void AssertRoundTrips(string formula) =>
+        Assert.Equal(formula, FormulaParser.Parse(formula).ToFormula());
+
+    // ----------------------------------------------------------- Round-trip
+
+    [Theory]
+    // Literals
+    [InlineData("=1")]
+    [InlineData("=100")]
+    [InlineData("=.5")]
+    [InlineData("=1.5E-3")]
+    [InlineData("=1E3")]
+    [InlineData("=-2.5")]
+    [InlineData("=TRUE")]
+    [InlineData("=FALSE")]
+    [InlineData("=\"hello\"")]
+    [InlineData("=\"he said \"\"hi\"\"\"")]
+    [InlineData("=\"a, b; c\"")]
+    // Error literals
+    [InlineData("=#N/A")]
+    [InlineData("=#REF!")]
+    [InlineData("=#DIV/0!")]
+    [InlineData("=#VALUE!")]
+    [InlineData("=#NAME?")]
+    [InlineData("=#NULL!")]
+    [InlineData("=#NUM!")]
+    [InlineData("=#SPILL!")]
+    [InlineData("=#CALC!")]
+    // Array constants
+    [InlineData("={1,2,3}")]
+    [InlineData("={1,2;3,4}")]
+    [InlineData("={1,\"a\",TRUE;2,#N/A,FALSE}")]
+    [InlineData("={\"↑\";\"↓\";\"←\";\"→\"}")]
+    // Cell refs
+    [InlineData("=A1")]
+    [InlineData("=$A$1")]
+    [InlineData("=$A1")]
+    [InlineData("=A$1")]
+    [InlineData("=Sheet1!A1")]
+    [InlineData("='My Sheet'!A1")]
+    [InlineData("=Sheet1:Sheet3!A1")]
+    [InlineData("=[Book.xlsx]Sheet1!A1")]
+    [InlineData("='[Book.xlsx]My Sheet'!A1")]
+    [InlineData("=A:A")]
+    [InlineData("=1:1")]
+    [InlineData("=A1#")]
+    [InlineData("=$A$1:$B$10")]
+    // Structured table refs
+    [InlineData("=t[City]")]
+    [InlineData("=t[[X-Coordinates]:[Y-Coordinates]]")]
+    [InlineData("=[@Column]")]
+    [InlineData("=t[@Column]")]
+    [InlineData("=t[[#Headers],[City]]")]
+    [InlineData("=t[#All]")]
+    [InlineData("=t[#Data]")]
+    [InlineData("=t[#Headers]")]
+    [InlineData("=t[#Totals]")]
+    [InlineData("=t[[#This Row],[City]]")]
+    [InlineData("=t[Column With Spaces]")]
+    [InlineData("=t['[Bracketed]")]
+    [InlineData("=t['#Hashed]")]
+    // Operators & precedence
+    [InlineData("=A1+B1")]
+    [InlineData("=A1-B1-C1")]
+    [InlineData("=A1*B1+C1")]
+    [InlineData("=A1+B1*C1")]
+    [InlineData("=2^3^2")]
+    [InlineData("=-A1^2")]
+    [InlineData("=A1&B1&C1")]
+    [InlineData("=A1<=B1")]
+    [InlineData("=A1<>B1")]
+    [InlineData("=A1>=B1")]
+    [InlineData("=A1=B1")]
+    [InlineData("=50%")]
+    [InlineData("=A1%+B1")]
+    [InlineData("=@A1")]
+    [InlineData("=@INDEX(arr,1,1)")]
+    [InlineData("=(A1:A3,B1:B3)")]
+    [InlineData("=A1:A10 B1:B10")]
+    [InlineData("=(A1+B1)*C1")]
+    // Function calls
+    [InlineData("=SUM(A1:A10)")]
+    [InlineData("=SUM(A1,B1,C1)")]
+    [InlineData("=SUM(A1,,A3)")]
+    [InlineData("=SUM()")]
+    [InlineData("=ROUND(SQRT(SUMSQ(A1)),0)")]
+    [InlineData("=_xlfn.XLOOKUP(H94,t[City],t[Pop])")]
+    [InlineData("=LET(x,1,x+1)")]
+    [InlineData("=LAMBDA(x,x*2)")]
+    // Whitespace / newlines preserved
+    [InlineData("= SUM( A1 , B1 ) ")]
+    [InlineData("=SUM(\n    A1,\n    B1\n)")]
+    [InlineData("=A1 + B1")]
+    public void Parse_RoundTrips(string formula) => AssertRoundTrips(formula);
+
+    [Fact]
+    public void Parse_WorkedExample_RoundTrips()
+    {
+        const string f =
+            "=ROUND(SQRT(SUMSQ(XLOOKUP(H94, t[City], t[[X-Coordinates]:[Y-Coordinates]]) " +
+            "- $I$92:$J$92)) * 100, 0)";
+        AssertRoundTrips(f);
+    }
+
+    // ------------------------------------------------------- Structure: leaves
+
+    [Theory]
+    [InlineData("=t[City]")]
+    [InlineData("=t[[X-Coordinates]:[Y-Coordinates]]")]
+    [InlineData("=[@Column]")]
+    [InlineData("=t[[#Headers],[City]]")]
+    [InlineData("=t[#All]")]
+    [InlineData("=$A$1")]
+    [InlineData("=Sheet1!A1")]
+    [InlineData("='My Sheet'!A1")]
+    [InlineData("=Sheet1:Sheet3!A1")]
+    [InlineData("=[Book.xlsx]Sheet1!A1")]
+    [InlineData("={1,2;3,4}")]
+    [InlineData("=#N/A")]
+    [InlineData("=42")]
+    [InlineData("=\"text\"")]
+    [InlineData("=myNamedRange")]
+    public void Parse_AtomicLeaf_IsOpaqueLeafNode(string formula)
+    {
+        var leaf = Assert.IsType<LeafNode>(Root(formula));
+        Assert.Equal(formula[1..], leaf.Text);
+    }
+
+    [Fact]
+    public void Parse_SpillRef_IsPostfixOverLeaf_NotAStep()
+    {
+        var postfix = Assert.IsType<PostfixNode>(Root("=A1#"));
+        Assert.Equal("#", postfix.Operator);
+        Assert.IsType<LeafNode>(postfix.Operand);
+    }
+
+    [Fact]
+    public void Parse_Range_IsRangeBinaryOverLeaves()
+    {
+        var binary = Assert.IsType<BinaryNode>(Root("=A1:B10"));
+        Assert.Equal(":", binary.Operator);
+        Assert.IsType<LeafNode>(binary.Left);
+        Assert.IsType<LeafNode>(binary.Right);
+    }
+
+    // --------------------------------------------------- Structure: function calls
+
+    [Fact]
+    public void Parse_FunctionCall_CapturesNameAndArgs()
+    {
+        var call = Assert.IsType<FunctionCallNode>(Root("=XLOOKUP(H94, t[City], t[Pop])"));
+        Assert.Equal("XLOOKUP", call.Name);
+        Assert.Equal(3, call.Arguments.Count);
+        Assert.All(call.Arguments, a => Assert.IsType<LeafNode>(a));
+    }
+
+    [Fact]
+    public void Parse_EmptyArgument_IsEmptyArgNode()
+    {
+        var call = Assert.IsType<FunctionCallNode>(Root("=SUM(A1,,A3)"));
+        Assert.Equal(3, call.Arguments.Count);
+        Assert.IsType<LeafNode>(call.Arguments[0]);
+        Assert.IsType<EmptyArgNode>(call.Arguments[1]);
+        Assert.IsType<LeafNode>(call.Arguments[2]);
+        Assert.Equal(2, call.Commas.Count);
+    }
+
+    [Fact]
+    public void Parse_ZeroArgCall_HasNoArguments()
+    {
+        var call = Assert.IsType<FunctionCallNode>(Root("=NOW()"));
+        Assert.Empty(call.Arguments);
+        Assert.Empty(call.Commas);
+    }
+
+    [Fact]
+    public void Parse_NestedCall_NestsFunctionNodes()
+    {
+        var round = Assert.IsType<FunctionCallNode>(Root("=ROUND(SQRT(SUMSQ(A1)), 0)"));
+        Assert.Equal("ROUND", round.Name);
+        var sqrt = Assert.IsType<FunctionCallNode>(round.Arguments[0]);
+        Assert.Equal("SQRT", sqrt.Name);
+        var sumsq = Assert.IsType<FunctionCallNode>(sqrt.Arguments[0]);
+        Assert.Equal("SUMSQ", sumsq.Name);
+        Assert.IsType<LeafNode>(sumsq.Arguments[0]);
+    }
+
+    [Fact]
+    public void Parse_XlfnPrefixedFunction_KeepsPrefixInName()
+    {
+        var call = Assert.IsType<FunctionCallNode>(Root("=_xlfn.SINGLE(A1)"));
+        Assert.Equal("_xlfn.SINGLE", call.Name);
+    }
+
+    // ---------------------------------------------------- Structure: precedence
+
+    [Fact]
+    public void Parse_MultiplicationBindsTighterThanAddition()
+    {
+        var add = Assert.IsType<BinaryNode>(Root("=a+b*c"));
+        Assert.Equal("+", add.Operator);
+        Assert.IsType<LeafNode>(add.Left);
+        var mul = Assert.IsType<BinaryNode>(add.Right);
+        Assert.Equal("*", mul.Operator);
+    }
+
+    [Fact]
+    public void Parse_SubtractionIsLeftAssociative()
+    {
+        var outer = Assert.IsType<BinaryNode>(Root("=a-b-c"));
+        Assert.Equal("-", outer.Operator);
+        var inner = Assert.IsType<BinaryNode>(outer.Left);
+        Assert.Equal("-", inner.Operator);
+        Assert.IsType<LeafNode>(outer.Right);
+    }
+
+    [Fact]
+    public void Parse_ExponentIsLeftAssociative()
+    {
+        // Excel: 2^3^2 == (2^3)^2.
+        var outer = Assert.IsType<BinaryNode>(Root("=2^3^2"));
+        Assert.Equal("^", outer.Operator);
+        Assert.IsType<BinaryNode>(outer.Left);
+        Assert.IsType<LeafNode>(outer.Right);
+    }
+
+    [Fact]
+    public void Parse_UnaryMinusIsLooserThanExponent()
+    {
+        // -A1^2 == -(A1^2).
+        var unary = Assert.IsType<UnaryNode>(Root("=-A1^2"));
+        Assert.Equal("-", unary.Operator);
+        Assert.IsType<BinaryNode>(unary.Operand);
+    }
+
+    [Fact]
+    public void Parse_ComparisonIsLoosestOperator()
+    {
+        // a&b=c == (a&b)=c.
+        var eq = Assert.IsType<BinaryNode>(Root("=a&b=c"));
+        Assert.Equal("=", eq.Operator);
+        var concat = Assert.IsType<BinaryNode>(eq.Left);
+        Assert.Equal("&", concat.Operator);
+    }
+
+    [Fact]
+    public void Parse_RangeBindsTighterThanIntersection()
+    {
+        // A1:A10 B1:B10 == (A1:A10) ∩ (B1:B10).
+        var intersect = Assert.IsType<BinaryNode>(Root("=A1:A10 B1:B10"));
+        Assert.Equal(" ", intersect.Operator);
+        Assert.Null(intersect.OperatorToken);
+        Assert.Equal(":", Assert.IsType<BinaryNode>(intersect.Left).Operator);
+        Assert.Equal(":", Assert.IsType<BinaryNode>(intersect.Right).Operator);
+    }
+
+    [Fact]
+    public void Parse_Union_IsMultiItemParen()
+    {
+        var paren = Assert.IsType<ParenNode>(Root("=(A1:A3,B1:B3)"));
+        Assert.True(paren.IsUnion);
+        Assert.Equal(2, paren.Items.Count);
+    }
+
+    [Fact]
+    public void Parse_AtPrefix_IsUnaryOverCall()
+    {
+        var at = Assert.IsType<UnaryNode>(Root("=@INDEX(arr,1,1)"));
+        Assert.Equal("@", at.Operator);
+        Assert.IsType<FunctionCallNode>(at.Operand);
+    }
+
+    [Fact]
+    public void Parse_GroupingParen_IsSingleItemParen()
+    {
+        var product = Assert.IsType<BinaryNode>(Root("=(A1+B1)*C1"));
+        Assert.Equal("*", product.Operator);
+        var paren = Assert.IsType<ParenNode>(product.Left);
+        Assert.False(paren.IsUnion);
+        Assert.Single(paren.Items);
+        Assert.Equal("+", Assert.IsType<BinaryNode>(paren.Items[0]).Operator);
+    }
+
+    // ------------------------------------------------------------- Spans
+
+    [Fact]
+    public void Parse_NodeSpan_MatchesSourceText()
+    {
+        const string f = "=ROUND(SQRT(A1), 0)";
+        var round = Assert.IsType<FunctionCallNode>(Root(f));
+        var sqrt = round.Arguments[0];
+        Assert.Equal("SQRT(A1)", f[sqrt.Start..sqrt.End]);
+    }
+
+    // ------------------------------------------------------------- Errors
+
+    [Theory]
+    [InlineData("=SUM(A1")]          // unbalanced paren
+    [InlineData("=\"abc")]            // unterminated string
+    [InlineData("=t[City")]           // unterminated bracket
+    [InlineData("=")]                 // nothing after marker
+    [InlineData("=,")]                // stray comma
+    [InlineData("=)")]                // stray close paren
+    [InlineData("=A1 B1 +")]          // dangling operator
+    [InlineData("=A1 + + ")]          // dangling operator
+    public void Parse_Malformed_ThrowsFormatException(string formula)
+    {
+        Assert.Throws<FormatException>(() => FormulaParser.Parse(formula));
+    }
+
+    [Fact]
+    public void Parse_Null_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => FormulaParser.Parse(null!));
+    }
+
+    [Fact]
+    public void Parse_NoLeadingEquals_StillParses()
+    {
+        var ast = FormulaParser.Parse("SUM(A1,B1)");
+        Assert.Null(ast.EqualsToken);
+        Assert.IsType<FunctionCallNode>(ast.Root);
+        Assert.Equal("SUM(A1,B1)", ast.ToFormula());
+    }
+
+    // ------------------------------------------------- Golden round-trip corpus
+
+    public static IEnumerable<object[]> LibraryFormulas()
+    {
+        var lambdasDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "..", "lambdas"));
+
+        foreach (var file in Directory.EnumerateFiles(lambdasDir, "*.lambda", SearchOption.AllDirectories))
+        {
+            (string Name, string Formula) parsed;
+            try
+            {
+                parsed = LambdaParser.ParseFile(file);
+            }
+            catch (FormatException)
+            {
+                continue; // not a parseable .lambda definition; skip
+            }
+
+            yield return new object[] { Path.GetFileName(file), parsed.Formula };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LibraryFormulas))]
+    public void Parse_EveryLibraryFormula_RoundTripsIdentically(string fileName, string formula)
+    {
+        // fileName is included so a failure names the offending .lambda file.
+        Assert.NotNull(fileName);
+        var ast = FormulaParser.Parse(formula);
+        Assert.Equal(formula, ast.ToFormula());
+    }
+}

--- a/addin/lambda-boss/FormulaAst.cs
+++ b/addin/lambda-boss/FormulaAst.cs
@@ -1,0 +1,382 @@
+using System.Text;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     Lexical category of a <see cref="FormulaToken" />. The parser only needs
+///     coarse categories — it never re-interprets a token's text, so a cell ref,
+///     defined name, and function name all arrive as <see cref="Name" /> and are
+///     told apart structurally (a <see cref="Name" /> immediately followed by
+///     <see cref="LParen" /> is a call; otherwise it is an opaque leaf).
+/// </summary>
+internal enum FormulaTokenType
+{
+    /// <summary>A numeric literal, incl. scientific (<c>1.5E-3</c>) and leading-dot (<c>.5</c>).</summary>
+    Number,
+
+    /// <summary>A double-quoted string literal, with <c>""</c> escapes.</summary>
+    String,
+
+    /// <summary>An error literal (<c>#N/A</c>, <c>#REF!</c>, <c>#DIV/0!</c>, …).</summary>
+    Error,
+
+    /// <summary>
+    ///     A reference / defined name / function name token — read greedily so a
+    ///     sheet-qualified, bracketed, or 3-D reference is a single opaque token
+    ///     (<c>'My Sheet'!$A$1</c>, <c>t[[X]:[Y]]</c>, <c>Sheet1:Sheet3!A1</c>).
+    /// </summary>
+    Name,
+
+    /// <summary>An array constant <c>{1,2;3,4}</c>, kept whole and opaque.</summary>
+    Array,
+
+    /// <summary>An operator: <c>^ * / + - &amp; = &lt;&gt; &lt; &lt;= &gt; &gt;= : % # @</c>.</summary>
+    Operator,
+
+    /// <summary>An opening parenthesis.</summary>
+    LParen,
+
+    /// <summary>A closing parenthesis.</summary>
+    RParen,
+
+    /// <summary>An argument / union separator comma.</summary>
+    Comma,
+
+    /// <summary>End of input. Carries any trailing whitespace in <see cref="FormulaToken.Lead" />.</summary>
+    Eof,
+}
+
+/// <summary>
+///     A lexed token plus the whitespace that preceded it (<see cref="Lead" />).
+///     Keeping leading trivia on every token lets the AST re-serialise the exact
+///     source — including cosmetic whitespace, newlines, and the spaces Excel
+///     treats as the intersection operator — so a parse → serialise round-trip is
+///     character-for-character identical.
+/// </summary>
+internal sealed class FormulaToken
+{
+    public FormulaToken(FormulaTokenType type, string lead, string text, int start)
+    {
+        Type = type;
+        Lead = lead;
+        Text = text;
+        Start = start;
+    }
+
+    public FormulaTokenType Type { get; }
+
+    /// <summary>Whitespace immediately preceding <see cref="Text" /> in the source.</summary>
+    public string Lead { get; }
+
+    /// <summary>The exact source text of the token (no surrounding whitespace).</summary>
+    public string Text { get; }
+
+    /// <summary>Index of <see cref="Text" />'s first character in the source (after <see cref="Lead" />).</summary>
+    public int Start { get; }
+
+    /// <summary>Index one past <see cref="Text" />'s last character.</summary>
+    public int End => Start + Text.Length;
+
+    internal void Write(StringBuilder sb) => sb.Append(Lead).Append(Text);
+}
+
+/// <summary>
+///     A node in the parsed expression tree produced by <see cref="FormulaParser" />.
+///     Every node can re-emit its exact source via <see cref="Write" /> /
+///     <see cref="ToFormula" />, and exposes its <see cref="Start" />/<see cref="End" />
+///     span (excluding leading whitespace) for callers that splice source text.
+/// </summary>
+internal abstract class FormulaNode
+{
+    /// <summary>Index of the node's first source character (after its leading whitespace).</summary>
+    public abstract int Start { get; }
+
+    /// <summary>Index one past the node's last source character.</summary>
+    public abstract int End { get; }
+
+    /// <summary>Re-emits the node (including its first token's leading whitespace) into <paramref name="sb" />.</summary>
+    internal abstract void Write(StringBuilder sb);
+
+    /// <summary>The node's source text, including the leading whitespace of its first token.</summary>
+    public string ToFormula()
+    {
+        var sb = new StringBuilder();
+        Write(sb);
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+///     An opaque atomic leaf — a cell reference, structured table reference,
+///     defined name, numeric/string/boolean literal, error literal, or array
+///     constant. Leaves are never descended into and never become LET steps.
+/// </summary>
+internal sealed class LeafNode : FormulaNode
+{
+    public LeafNode(FormulaToken token) => Token = token;
+
+    public FormulaToken Token { get; }
+
+    /// <summary>The lexical category of the leaf's single token.</summary>
+    public FormulaTokenType TokenType => Token.Type;
+
+    /// <summary>The leaf's exact text (no leading whitespace).</summary>
+    public string Text => Token.Text;
+
+    public override int Start => Token.Start;
+    public override int End => Token.End;
+
+    internal override void Write(StringBuilder sb) => Token.Write(sb);
+}
+
+/// <summary>
+///     A function-call node: a name token immediately followed by a
+///     parenthesised, comma-separated argument list. Empty argument slots
+///     (<c>SUM(A1,,A3)</c>) are present as <see cref="EmptyArgNode" /> entries so
+///     <see cref="Arguments" /> and <see cref="Commas" /> stay positionally aligned.
+/// </summary>
+internal sealed class FunctionCallNode : FormulaNode
+{
+    public FunctionCallNode(
+        FormulaToken nameToken,
+        FormulaToken openParen,
+        IReadOnlyList<FormulaNode> arguments,
+        IReadOnlyList<FormulaToken> commas,
+        FormulaToken closeParen)
+    {
+        NameToken = nameToken;
+        OpenParen = openParen;
+        Arguments = arguments;
+        Commas = commas;
+        CloseParen = closeParen;
+    }
+
+    public FormulaToken NameToken { get; }
+
+    /// <summary>The (possibly sheet-qualified) function name as written.</summary>
+    public string Name => NameToken.Text;
+
+    public FormulaToken OpenParen { get; }
+    public IReadOnlyList<FormulaNode> Arguments { get; }
+    public IReadOnlyList<FormulaToken> Commas { get; }
+    public FormulaToken CloseParen { get; }
+
+    public override int Start => NameToken.Start;
+    public override int End => CloseParen.End;
+
+    internal override void Write(StringBuilder sb)
+    {
+        NameToken.Write(sb);
+        OpenParen.Write(sb);
+        WriteSeparatedList(sb, Arguments, Commas);
+        CloseParen.Write(sb);
+    }
+
+    internal static void WriteSeparatedList(
+        StringBuilder sb,
+        IReadOnlyList<FormulaNode> items,
+        IReadOnlyList<FormulaToken> commas)
+    {
+        for (var i = 0; i < items.Count; i++)
+        {
+            items[i].Write(sb);
+            if (i < commas.Count)
+                commas[i].Write(sb);
+        }
+    }
+}
+
+/// <summary>
+///     A binary-operator expression: arithmetic (<c>+ - * / ^</c>), concatenation
+///     (<c>&amp;</c>), comparison (<c>= &lt;&gt; …</c>), the range operator
+///     (<c>:</c>), and the intersection operator (a single space). Intersection
+///     has no operator token — the space is carried as the right operand's leading
+///     whitespace — so <see cref="OperatorToken" /> is <c>null</c> in that case.
+/// </summary>
+internal sealed class BinaryNode : FormulaNode
+{
+    public BinaryNode(FormulaNode left, string @operator, FormulaToken? operatorToken, FormulaNode right)
+    {
+        Left = left;
+        Operator = @operator;
+        OperatorToken = operatorToken;
+        Right = right;
+    }
+
+    public FormulaNode Left { get; }
+
+    /// <summary>The operator symbol — e.g. <c>+</c>, <c>&lt;=</c>, <c>:</c>, or a single space for intersection.</summary>
+    public string Operator { get; }
+
+    /// <summary>The operator's token, or <c>null</c> for the space-as-operator intersection.</summary>
+    public FormulaToken? OperatorToken { get; }
+
+    public FormulaNode Right { get; }
+
+    public override int Start => Left.Start;
+    public override int End => Right.End;
+
+    internal override void Write(StringBuilder sb)
+    {
+        Left.Write(sb);
+        OperatorToken?.Write(sb);
+        Right.Write(sb);
+    }
+}
+
+/// <summary>
+///     A prefix-operator expression: unary plus/minus (<c>-A1</c>, <c>+x</c>) or
+///     the implicit-intersection prefix (<c>@A1</c>). Unary expressions are never
+///     LET steps — they stay inline with their operand.
+/// </summary>
+internal sealed class UnaryNode : FormulaNode
+{
+    public UnaryNode(FormulaToken operatorToken, FormulaNode operand)
+    {
+        OperatorToken = operatorToken;
+        Operand = operand;
+    }
+
+    public FormulaToken OperatorToken { get; }
+
+    /// <summary>The operator symbol — <c>+</c>, <c>-</c>, or <c>@</c>.</summary>
+    public string Operator => OperatorToken.Text;
+
+    public FormulaNode Operand { get; }
+
+    public override int Start => OperatorToken.Start;
+    public override int End => Operand.End;
+
+    internal override void Write(StringBuilder sb)
+    {
+        OperatorToken.Write(sb);
+        Operand.Write(sb);
+    }
+}
+
+/// <summary>
+///     A postfix-operator expression: percent (<c>50%</c>) or spill (<c>A1#</c>).
+///     Postfix expressions are never LET steps — they stay inline with their operand.
+/// </summary>
+internal sealed class PostfixNode : FormulaNode
+{
+    public PostfixNode(FormulaNode operand, FormulaToken operatorToken)
+    {
+        Operand = operand;
+        OperatorToken = operatorToken;
+    }
+
+    public FormulaNode Operand { get; }
+    public FormulaToken OperatorToken { get; }
+
+    /// <summary>The operator symbol — <c>%</c> or <c>#</c>.</summary>
+    public string Operator => OperatorToken.Text;
+
+    public override int Start => Operand.Start;
+    public override int End => OperatorToken.End;
+
+    internal override void Write(StringBuilder sb)
+    {
+        Operand.Write(sb);
+        OperatorToken.Write(sb);
+    }
+}
+
+/// <summary>
+///     A parenthesised group. A single item is ordinary grouping (<c>(a + b)</c>);
+///     multiple comma-separated items are the union reference operator
+///     (<c>(A1:A3,B1:B3)</c>), kept structurally distinct from a function-call
+///     argument list by the absence of a leading name.
+/// </summary>
+internal sealed class ParenNode : FormulaNode
+{
+    public ParenNode(
+        FormulaToken openParen,
+        IReadOnlyList<FormulaNode> items,
+        IReadOnlyList<FormulaToken> commas,
+        FormulaToken closeParen)
+    {
+        OpenParen = openParen;
+        Items = items;
+        Commas = commas;
+        CloseParen = closeParen;
+    }
+
+    public FormulaToken OpenParen { get; }
+    public IReadOnlyList<FormulaNode> Items { get; }
+    public IReadOnlyList<FormulaToken> Commas { get; }
+    public FormulaToken CloseParen { get; }
+
+    /// <summary>True when the parens hold a comma-separated union of references.</summary>
+    public bool IsUnion => Items.Count > 1;
+
+    public override int Start => OpenParen.Start;
+    public override int End => CloseParen.End;
+
+    internal override void Write(StringBuilder sb)
+    {
+        OpenParen.Write(sb);
+        FunctionCallNode.WriteSeparatedList(sb, Items, Commas);
+        CloseParen.Write(sb);
+    }
+}
+
+/// <summary>
+///     A missing argument slot, e.g. the middle argument of <c>SUM(A1,,A3)</c>.
+///     Writes nothing; any whitespace around it is carried by the surrounding
+///     comma / close-paren tokens.
+/// </summary>
+internal sealed class EmptyArgNode : FormulaNode
+{
+    public EmptyArgNode(int position) => Position = position;
+
+    /// <summary>The source index where the empty slot sits.</summary>
+    public int Position { get; }
+
+    public override int Start => Position;
+    public override int End => Position;
+
+    internal override void Write(StringBuilder sb)
+    {
+        // Intentionally emits nothing.
+    }
+}
+
+/// <summary>
+///     A fully parsed formula: the leading <c>=</c> marker (if present), the root
+///     expression, and any trailing whitespace. <see cref="ToFormula" /> reproduces
+///     the original source character-for-character.
+/// </summary>
+internal sealed class FormulaAst
+{
+    public FormulaAst(string source, FormulaToken? equalsToken, FormulaNode root, FormulaToken eofToken)
+    {
+        Source = source;
+        EqualsToken = equalsToken;
+        Root = root;
+        EofToken = eofToken;
+    }
+
+    /// <summary>The original formula text, exactly as parsed.</summary>
+    public string Source { get; }
+
+    /// <summary>The leading <c>=</c> marker token, or <c>null</c> if the input had none.</summary>
+    public FormulaToken? EqualsToken { get; }
+
+    /// <summary>The root expression node.</summary>
+    public FormulaNode Root { get; }
+
+    /// <summary>The end-of-input token; its <see cref="FormulaToken.Lead" /> holds any trailing whitespace.</summary>
+    public FormulaToken EofToken { get; }
+
+    /// <summary>Re-serialises the AST. For a successful parse this equals <see cref="Source" />.</summary>
+    public string ToFormula()
+    {
+        var sb = new StringBuilder(Source.Length);
+        EqualsToken?.Write(sb);
+        Root.Write(sb);
+        // Trailing whitespace is carried as the EOF token's leading trivia.
+        sb.Append(EofToken.Lead);
+        return sb.ToString();
+    }
+}

--- a/addin/lambda-boss/FormulaParser.cs
+++ b/addin/lambda-boss/FormulaParser.cs
@@ -1,0 +1,624 @@
+using System.Text;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     A recursive-descent parser for the canonical US form of an Excel formula —
+///     the comma-separated, US-function-named text that <c>Range.Formula2</c>
+///     returns. It builds an expression tree (<see cref="FormulaAst" />) for
+///     structure-aware rewriting (spec 0009 <c>/Unnest</c>); it never evaluates.
+///
+///     The grammar is deliberately conservative: lexing of strings, brackets, and
+///     references is exact and opaque (a sheet-qualified / structured / 3-D
+///     reference stays a single leaf token), while genuinely ambiguous corners
+///     (comma-as-union, space-as-intersection) are accepted structurally without
+///     trying to resolve their semantics. A successful parse round-trips
+///     character-for-character via <see cref="FormulaAst.ToFormula" />.
+///
+///     Operator precedence, tightest-binding first:
+///     reference <c>:</c> · intersection (space) · spill <c>#</c> · <c>@</c> ·
+///     <c>%</c> · <c>^</c> · unary <c>+ -</c> · <c>* /</c> · <c>+ -</c> ·
+///     <c>&amp;</c> · comparisons. Exponentiation is left-associative
+///     (<c>2^3^2</c> = <c>(2^3)^2</c>), matching Excel.
+/// </summary>
+internal static class FormulaParser
+{
+    private static readonly string[] ErrorLiterals =
+    {
+        // Longest-first so a prefix match never shadows a longer literal.
+        "#GETTING_DATA", "#DIV/0!", "#SPILL!", "#BLOCKED!", "#CONNECT!",
+        "#UNKNOWN!", "#EXTERNAL!", "#FIELD!", "#VALUE!", "#NULL!", "#NAME?",
+        "#CALC!", "#BUSY!", "#REF!", "#NUM!", "#N/A",
+    };
+
+    /// <summary>
+    ///     Parses <paramref name="formula" /> (with or without a leading <c>=</c>)
+    ///     into an expression tree.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="formula" /> is null.</exception>
+    /// <exception cref="FormatException">The formula is malformed (unexpected token, unbalanced brackets, …).</exception>
+    public static FormulaAst Parse(string formula)
+    {
+        if (formula is null)
+            throw new ArgumentNullException(nameof(formula));
+
+        var tokens = Lex(formula);
+        var parser = new Parser(formula, tokens);
+        return parser.ParseFormula();
+    }
+
+    // ---------------------------------------------------------------- Lexer
+
+    private static List<FormulaToken> Lex(string s)
+    {
+        var tokens = new List<FormulaToken>();
+        var i = 0;
+        var n = s.Length;
+
+        while (true)
+        {
+            var leadStart = i;
+            while (i < n && IsWhitespace(s[i])) i++;
+            var lead = s[leadStart..i];
+
+            if (i >= n)
+            {
+                tokens.Add(new FormulaToken(FormulaTokenType.Eof, lead, "", i));
+                break;
+            }
+
+            var start = i;
+            var c = s[i];
+
+            // String literal.
+            if (c == '"')
+            {
+                i = SkipString(s, i);
+                tokens.Add(new FormulaToken(FormulaTokenType.String, lead, s[start..i], start));
+                continue;
+            }
+
+            // Array constant {…} — opaque, balanced, strings skipped inside.
+            if (c == '{')
+            {
+                i = SkipArray(s, i);
+                tokens.Add(new FormulaToken(FormulaTokenType.Array, lead, s[start..i], start));
+                continue;
+            }
+
+            // Error literal, else a bare '#' (spill postfix).
+            if (c == '#')
+            {
+                var err = MatchErrorLiteral(s, i);
+                if (err > 0)
+                {
+                    i += err;
+                    tokens.Add(new FormulaToken(FormulaTokenType.Error, lead, s[start..i], start));
+                }
+                else
+                {
+                    i++;
+                    tokens.Add(new FormulaToken(FormulaTokenType.Operator, lead, "#", start));
+                }
+                continue;
+            }
+
+            if (c == '(') { i++; tokens.Add(new FormulaToken(FormulaTokenType.LParen, lead, "(", start)); continue; }
+            if (c == ')') { i++; tokens.Add(new FormulaToken(FormulaTokenType.RParen, lead, ")", start)); continue; }
+            if (c == ',') { i++; tokens.Add(new FormulaToken(FormulaTokenType.Comma, lead, ",", start)); continue; }
+
+            // Numeric literal (incl. leading-dot and scientific).
+            if (char.IsDigit(c) || (c == '.' && i + 1 < n && char.IsDigit(s[i + 1])))
+            {
+                i = ReadNumber(s, i);
+                tokens.Add(new FormulaToken(FormulaTokenType.Number, lead, s[start..i], start));
+                continue;
+            }
+
+            // Reference / name / function name — quoted qualifier, leading
+            // workbook/structured bracket, or a bare identifier/address.
+            if (c == '\'' || c == '[' || IsNameStart(c))
+            {
+                i = ReadReference(s, i);
+                tokens.Add(new FormulaToken(FormulaTokenType.Name, lead, s[start..i], start));
+                continue;
+            }
+
+            // Multi-character comparison operators.
+            if (c == '<')
+            {
+                if (i + 1 < n && (s[i + 1] == '=' || s[i + 1] == '>')) { i += 2; }
+                else i++;
+                tokens.Add(new FormulaToken(FormulaTokenType.Operator, lead, s[start..i], start));
+                continue;
+            }
+            if (c == '>')
+            {
+                if (i + 1 < n && s[i + 1] == '=') { i += 2; } else i++;
+                tokens.Add(new FormulaToken(FormulaTokenType.Operator, lead, s[start..i], start));
+                continue;
+            }
+
+            // Single-character operators.
+            if (IsOperatorChar(c))
+            {
+                i++;
+                tokens.Add(new FormulaToken(FormulaTokenType.Operator, lead, s[start..i], start));
+                continue;
+            }
+
+            throw new FormatException($"Unexpected character '{c}' at position {i} in formula.");
+        }
+
+        return tokens;
+    }
+
+    private static bool IsWhitespace(char c) => c is ' ' or '\t' or '\r' or '\n';
+
+    private static bool IsOperatorChar(char c) =>
+        c is '+' or '-' or '*' or '/' or '^' or '&' or '=' or '<' or '>' or ':' or '%' or '@' or ';';
+
+    private static bool IsNameStart(char c) =>
+        char.IsLetter(c) || c == '_' || c == '$' || c == '?' || c == '\\';
+
+    private static bool IsNameChar(char c) =>
+        char.IsLetterOrDigit(c) || c == '_' || c == '.' || c == '?' || c == '$' || c == '\\';
+
+    private static int SkipString(string s, int i)
+    {
+        // i points at the opening quote.
+        i++;
+        while (i < s.Length)
+        {
+            if (s[i] == '"')
+            {
+                if (i + 1 < s.Length && s[i + 1] == '"') { i += 2; continue; }
+                return i + 1;
+            }
+            i++;
+        }
+        throw new FormatException("Unterminated string literal in formula.");
+    }
+
+    private static int SkipArray(string s, int i)
+    {
+        // i points at the opening brace. Excel array constants don't nest, but we
+        // balance braces defensively and skip string literals inside.
+        var depth = 0;
+        while (i < s.Length)
+        {
+            var c = s[i];
+            if (c == '"') { i = SkipString(s, i); continue; }
+            if (c == '{') { depth++; i++; continue; }
+            if (c == '}')
+            {
+                depth--;
+                i++;
+                if (depth == 0) return i;
+                continue;
+            }
+            i++;
+        }
+        throw new FormatException("Unterminated array constant in formula.");
+    }
+
+    private static int MatchErrorLiteral(string s, int i)
+    {
+        foreach (var lit in ErrorLiterals)
+        {
+            if (i + lit.Length <= s.Length &&
+                string.CompareOrdinal(s, i, lit, 0, lit.Length) == 0)
+            {
+                return lit.Length;
+            }
+        }
+        return 0;
+    }
+
+    private static int ReadNumber(string s, int i)
+    {
+        var n = s.Length;
+        while (i < n && char.IsDigit(s[i])) i++;
+        if (i < n && s[i] == '.')
+        {
+            i++;
+            while (i < n && char.IsDigit(s[i])) i++;
+        }
+        // Scientific suffix: only consume 'E' when a valid exponent follows.
+        if (i < n && (s[i] == 'E' || s[i] == 'e'))
+        {
+            var j = i + 1;
+            if (j < n && (s[j] == '+' || s[j] == '-')) j++;
+            if (j < n && char.IsDigit(s[j]))
+            {
+                i = j;
+                while (i < n && char.IsDigit(s[i])) i++;
+            }
+        }
+        return i;
+    }
+
+    /// <summary>
+    ///     Reads a maximal reference / name / function-name token: an optional
+    ///     quoted or workbook-bracket sheet qualifier, the base address or name,
+    ///     trailing structured-reference brackets, and any in-token 3-D sheet
+    ///     range (<c>Sheet1:Sheet3!A1</c>). Stops before <c>(</c> so the parser
+    ///     can recognise a function call.
+    /// </summary>
+    private static int ReadReference(string s, int i)
+    {
+        var n = s.Length;
+
+        // Leading single-quoted qualifier: 'My Sheet'! or '[Book.xlsx]Sheet'!
+        if (i < n && s[i] == '\'')
+        {
+            i = SkipSingleQuoted(s, i);
+            if (i < n && s[i] == '!') i++;
+        }
+
+        while (i < n)
+        {
+            var c = s[i];
+
+            if (c == '[')
+            {
+                i = SkipBrackets(s, i);
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                // A further quoted segment (e.g. after a 3-D ':' joiner).
+                i = SkipSingleQuoted(s, i);
+                continue;
+            }
+
+            if (c == '!')
+            {
+                i++;
+                continue;
+            }
+
+            if (c == ':')
+            {
+                // ':' is part of this reference only for a 3-D sheet range —
+                // i.e. when a sheet-name-then-'!' follows. Otherwise it is the
+                // range operator and belongs to the parser, so stop here.
+                if (IsThreeDColon(s, i)) { i++; continue; }
+                break;
+            }
+
+            if (IsNameChar(c))
+            {
+                i++;
+                continue;
+            }
+
+            break;
+        }
+
+        return i;
+    }
+
+    private static int SkipSingleQuoted(string s, int i)
+    {
+        // i points at the opening single quote. '' is an escaped literal quote.
+        i++;
+        while (i < s.Length)
+        {
+            if (s[i] == '\'')
+            {
+                if (i + 1 < s.Length && s[i + 1] == '\'') { i += 2; continue; }
+                return i + 1;
+            }
+            i++;
+        }
+        throw new FormatException("Unterminated quoted sheet/workbook name in formula.");
+    }
+
+    private static int SkipBrackets(string s, int i)
+    {
+        // i points at the opening '['. Brackets may nest (t[[A]:[B]]); inside,
+        // a leading single quote escapes the next character ('[ '] '# '@ '').
+        var depth = 0;
+        while (i < s.Length)
+        {
+            var c = s[i];
+            if (c == '\'') { i += 2; continue; }
+            if (c == '[') { depth++; i++; continue; }
+            if (c == ']')
+            {
+                depth--;
+                i++;
+                if (depth == 0) return i;
+                continue;
+            }
+            i++;
+        }
+        throw new FormatException("Unterminated structured-reference bracket in formula.");
+    }
+
+    /// <summary>
+    ///     Looks ahead from a <c>:</c> to decide whether it joins a 3-D sheet
+    ///     range (next comes an optionally-quoted sheet name then <c>!</c>) rather
+    ///     than acting as the binary range operator.
+    /// </summary>
+    private static bool IsThreeDColon(string s, int colonIndex)
+    {
+        var n = s.Length;
+        var j = colonIndex + 1;
+        if (j < n && s[j] == '\'')
+        {
+            try { j = SkipSingleQuoted(s, j); }
+            catch (FormatException) { return false; }
+            return j < n && s[j] == '!';
+        }
+        while (j < n && (char.IsLetterOrDigit(s[j]) || s[j] == '_' || s[j] == '.' || s[j] == ' '))
+            j++;
+        return j < n && s[j] == '!';
+    }
+
+    // --------------------------------------------------------------- Parser
+
+    private sealed class Parser
+    {
+        private readonly string _source;
+        private readonly List<FormulaToken> _tokens;
+        private int _pos;
+
+        public Parser(string source, List<FormulaToken> tokens)
+        {
+            _source = source;
+            _tokens = tokens;
+        }
+
+        private FormulaToken Peek => _tokens[_pos];
+
+        private FormulaToken Advance() => _tokens[_pos++];
+
+        private bool IsOp(string symbol) =>
+            Peek.Type == FormulaTokenType.Operator && Peek.Text == symbol;
+
+        public FormulaAst ParseFormula()
+        {
+            // An optional leading '=' marks a cell formula; a bare '=' anywhere
+            // else is comparison. Only the first token counts as the marker.
+            FormulaToken? equals = null;
+            if (IsOp("=")) equals = Advance();
+
+            var root = ParseExpression();
+
+            if (Peek.Type != FormulaTokenType.Eof)
+                throw new FormatException($"Unexpected '{Peek.Text}' at position {Peek.Start} in formula.");
+
+            return new FormulaAst(_source, equals, root, Peek);
+        }
+
+        private FormulaNode ParseExpression() => ParseComparison();
+
+        private FormulaNode ParseComparison()
+        {
+            var left = ParseConcat();
+            while (Peek.Type == FormulaTokenType.Operator && IsComparisonOp(Peek.Text))
+            {
+                var op = Advance();
+                var right = ParseConcat();
+                left = new BinaryNode(left, op.Text, op, right);
+            }
+            return left;
+        }
+
+        private FormulaNode ParseConcat()
+        {
+            var left = ParseAdditive();
+            while (IsOp("&"))
+            {
+                var op = Advance();
+                var right = ParseAdditive();
+                left = new BinaryNode(left, op.Text, op, right);
+            }
+            return left;
+        }
+
+        private FormulaNode ParseAdditive()
+        {
+            var left = ParseMultiplicative();
+            while (IsOp("+") || IsOp("-"))
+            {
+                var op = Advance();
+                var right = ParseMultiplicative();
+                left = new BinaryNode(left, op.Text, op, right);
+            }
+            return left;
+        }
+
+        private FormulaNode ParseMultiplicative()
+        {
+            var left = ParseUnary();
+            while (IsOp("*") || IsOp("/"))
+            {
+                var op = Advance();
+                var right = ParseUnary();
+                left = new BinaryNode(left, op.Text, op, right);
+            }
+            return left;
+        }
+
+        private FormulaNode ParseUnary()
+        {
+            if (IsOp("+") || IsOp("-"))
+            {
+                var op = Advance();
+                var operand = ParseUnary();
+                return new UnaryNode(op, operand);
+            }
+            return ParseExponent();
+        }
+
+        private FormulaNode ParseExponent()
+        {
+            // Left-associative in Excel: 2^3^2 == (2^3)^2.
+            var left = ParsePercent();
+            while (IsOp("^"))
+            {
+                var op = Advance();
+                var right = ParsePercent();
+                left = new BinaryNode(left, op.Text, op, right);
+            }
+            return left;
+        }
+
+        private FormulaNode ParsePercent()
+        {
+            var operand = ParseAt();
+            while (IsOp("%"))
+            {
+                var op = Advance();
+                operand = new PostfixNode(operand, op);
+            }
+            return operand;
+        }
+
+        private FormulaNode ParseAt()
+        {
+            if (IsOp("@"))
+            {
+                var op = Advance();
+                var operand = ParseAt();
+                return new UnaryNode(op, operand);
+            }
+            return ParseIntersection();
+        }
+
+        private FormulaNode ParseIntersection()
+        {
+            var left = ParseRange();
+            // Two operands with only whitespace between them = intersection.
+            while (IsOperandStart(Peek))
+            {
+                var right = ParseRange();
+                left = new BinaryNode(left, " ", null, right);
+            }
+            return left;
+        }
+
+        private FormulaNode ParseRange()
+        {
+            var left = ParseSpill();
+            while (IsOp(":"))
+            {
+                var op = Advance();
+                var right = ParseSpill();
+                left = new BinaryNode(left, op.Text, op, right);
+            }
+            return left;
+        }
+
+        private FormulaNode ParseSpill()
+        {
+            var operand = ParsePrimary();
+            while (IsOp("#"))
+            {
+                var op = Advance();
+                operand = new PostfixNode(operand, op);
+            }
+            return operand;
+        }
+
+        private FormulaNode ParsePrimary()
+        {
+            var t = Peek;
+            switch (t.Type)
+            {
+                case FormulaTokenType.Number:
+                case FormulaTokenType.String:
+                case FormulaTokenType.Error:
+                case FormulaTokenType.Array:
+                    Advance();
+                    return new LeafNode(t);
+
+                case FormulaTokenType.Name:
+                    Advance();
+                    if (Peek.Type == FormulaTokenType.LParen)
+                        return ParseCall(t);
+                    return new LeafNode(t);
+
+                case FormulaTokenType.LParen:
+                    return ParseParen();
+
+                default:
+                    throw new FormatException(
+                        $"Unexpected '{t.Text}' at position {t.Start} in formula.");
+            }
+        }
+
+        private FunctionCallNode ParseCall(FormulaToken nameToken)
+        {
+            var (open, items, commas, close) = ParseArgList();
+            return new FunctionCallNode(nameToken, open, items, commas, close);
+        }
+
+        private ParenNode ParseParen()
+        {
+            var (open, items, commas, close) = ParseArgList();
+            return new ParenNode(open, items, commas, close);
+        }
+
+        /// <summary>
+        ///     Parses <c>( arg , arg , … )</c> starting at the open paren. Empty
+        ///     slots become <see cref="EmptyArgNode" />. Shared by function calls
+        ///     and grouping/union parens.
+        /// </summary>
+        private (FormulaToken Open, List<FormulaNode> Items, List<FormulaToken> Commas, FormulaToken Close) ParseArgList()
+        {
+            var open = Advance(); // '('
+            var items = new List<FormulaNode>();
+            var commas = new List<FormulaToken>();
+
+            if (Peek.Type == FormulaTokenType.RParen)
+            {
+                var emptyClose = Advance();
+                return (open, items, commas, emptyClose);
+            }
+
+            while (true)
+            {
+                if (Peek.Type == FormulaTokenType.Comma || Peek.Type == FormulaTokenType.RParen)
+                    items.Add(new EmptyArgNode(Peek.Start));
+                else
+                    items.Add(ParseExpression());
+
+                if (Peek.Type == FormulaTokenType.Comma)
+                {
+                    commas.Add(Advance());
+                    continue;
+                }
+
+                if (Peek.Type == FormulaTokenType.RParen)
+                {
+                    var close = Advance();
+                    return (open, items, commas, close);
+                }
+
+                throw new FormatException(
+                    $"Expected ',' or ')' but found '{Peek.Text}' at position {Peek.Start} in formula.");
+            }
+        }
+
+        private static bool IsComparisonOp(string s) =>
+            s is "=" or "<>" or "<" or "<=" or ">" or ">=";
+
+        /// <summary>
+        ///     True when <paramref name="t" /> can begin an operand — used to spot
+        ///     the space-as-intersection operator. Leading <c>+ - @</c> are
+        ///     excluded so <c>A1 -B1</c> stays subtraction, not intersection.
+        /// </summary>
+        private static bool IsOperandStart(FormulaToken t) =>
+            t.Type is FormulaTokenType.Number
+                or FormulaTokenType.String
+                or FormulaTokenType.Error
+                or FormulaTokenType.Name
+                or FormulaTokenType.Array
+                or FormulaTokenType.LParen;
+    }
+}

--- a/addin/lambda-boss/FormulaParser.cs
+++ b/addin/lambda-boss/FormulaParser.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace LambdaBoss;
 
 /// <summary>
@@ -7,14 +5,12 @@ namespace LambdaBoss;
 ///     the comma-separated, US-function-named text that <c>Range.Formula2</c>
 ///     returns. It builds an expression tree (<see cref="FormulaAst" />) for
 ///     structure-aware rewriting (spec 0009 <c>/Unnest</c>); it never evaluates.
-///
 ///     The grammar is deliberately conservative: lexing of strings, brackets, and
 ///     references is exact and opaque (a sheet-qualified / structured / 3-D
 ///     reference stays a single leaf token), while genuinely ambiguous corners
 ///     (comma-as-union, space-as-intersection) are accepted structurally without
 ///     trying to resolve their semantics. A successful parse round-trips
 ///     character-for-character via <see cref="FormulaAst.ToFormula" />.
-///
 ///     Operator precedence, tightest-binding first:
 ///     reference <c>:</c> · intersection (space) · spill <c>#</c> · <c>@</c> ·
 ///     <c>%</c> · <c>^</c> · unary <c>+ -</c> · <c>* /</c> · <c>+ -</c> ·
@@ -28,7 +24,7 @@ internal static class FormulaParser
         // Longest-first so a prefix match never shadows a longer literal.
         "#GETTING_DATA", "#DIV/0!", "#SPILL!", "#BLOCKED!", "#CONNECT!",
         "#UNKNOWN!", "#EXTERNAL!", "#FIELD!", "#VALUE!", "#NULL!", "#NAME?",
-        "#CALC!", "#BUSY!", "#REF!", "#NUM!", "#N/A",
+        "#CALC!", "#BUSY!", "#REF!", "#NUM!", "#N/A"
     };
 
     /// <summary>
@@ -100,12 +96,30 @@ internal static class FormulaParser
                     i++;
                     tokens.Add(new FormulaToken(FormulaTokenType.Operator, lead, "#", start));
                 }
+
                 continue;
             }
 
-            if (c == '(') { i++; tokens.Add(new FormulaToken(FormulaTokenType.LParen, lead, "(", start)); continue; }
-            if (c == ')') { i++; tokens.Add(new FormulaToken(FormulaTokenType.RParen, lead, ")", start)); continue; }
-            if (c == ',') { i++; tokens.Add(new FormulaToken(FormulaTokenType.Comma, lead, ",", start)); continue; }
+            if (c == '(')
+            {
+                i++;
+                tokens.Add(new FormulaToken(FormulaTokenType.LParen, lead, "(", start));
+                continue;
+            }
+
+            if (c == ')')
+            {
+                i++;
+                tokens.Add(new FormulaToken(FormulaTokenType.RParen, lead, ")", start));
+                continue;
+            }
+
+            if (c == ',')
+            {
+                i++;
+                tokens.Add(new FormulaToken(FormulaTokenType.Comma, lead, ",", start));
+                continue;
+            }
 
             // Numeric literal (incl. leading-dot and scientific).
             if (char.IsDigit(c) || (c == '.' && i + 1 < n && char.IsDigit(s[i + 1])))
@@ -127,14 +141,18 @@ internal static class FormulaParser
             // Multi-character comparison operators.
             if (c == '<')
             {
-                if (i + 1 < n && (s[i + 1] == '=' || s[i + 1] == '>')) { i += 2; }
+                if (i + 1 < n && (s[i + 1] == '=' || s[i + 1] == '>'))
+                    i += 2;
                 else i++;
                 tokens.Add(new FormulaToken(FormulaTokenType.Operator, lead, s[start..i], start));
                 continue;
             }
+
             if (c == '>')
             {
-                if (i + 1 < n && s[i + 1] == '=') { i += 2; } else i++;
+                if (i + 1 < n && s[i + 1] == '=')
+                    i += 2;
+                else i++;
                 tokens.Add(new FormulaToken(FormulaTokenType.Operator, lead, s[start..i], start));
                 continue;
             }
@@ -153,16 +171,25 @@ internal static class FormulaParser
         return tokens;
     }
 
-    private static bool IsWhitespace(char c) => c is ' ' or '\t' or '\r' or '\n';
+    private static bool IsWhitespace(char c)
+    {
+        return c is ' ' or '\t' or '\r' or '\n';
+    }
 
-    private static bool IsOperatorChar(char c) =>
-        c is '+' or '-' or '*' or '/' or '^' or '&' or '=' or '<' or '>' or ':' or '%' or '@' or ';';
+    private static bool IsOperatorChar(char c)
+    {
+        return c is '+' or '-' or '*' or '/' or '^' or '&' or '=' or '<' or '>' or ':' or '%' or '@' or ';';
+    }
 
-    private static bool IsNameStart(char c) =>
-        char.IsLetter(c) || c == '_' || c == '$' || c == '?' || c == '\\';
+    private static bool IsNameStart(char c)
+    {
+        return char.IsLetter(c) || c == '_' || c == '$' || c == '?' || c == '\\';
+    }
 
-    private static bool IsNameChar(char c) =>
-        char.IsLetterOrDigit(c) || c == '_' || c == '.' || c == '?' || c == '$' || c == '\\';
+    private static bool IsNameChar(char c)
+    {
+        return char.IsLetterOrDigit(c) || c == '_' || c == '.' || c == '?' || c == '$' || c == '\\';
+    }
 
     private static int SkipString(string s, int i)
     {
@@ -172,11 +199,18 @@ internal static class FormulaParser
         {
             if (s[i] == '"')
             {
-                if (i + 1 < s.Length && s[i + 1] == '"') { i += 2; continue; }
+                if (i + 1 < s.Length && s[i + 1] == '"')
+                {
+                    i += 2;
+                    continue;
+                }
+
                 return i + 1;
             }
+
             i++;
         }
+
         throw new FormatException("Unterminated string literal in formula.");
     }
 
@@ -188,8 +222,19 @@ internal static class FormulaParser
         while (i < s.Length)
         {
             var c = s[i];
-            if (c == '"') { i = SkipString(s, i); continue; }
-            if (c == '{') { depth++; i++; continue; }
+            if (c == '"')
+            {
+                i = SkipString(s, i);
+                continue;
+            }
+
+            if (c == '{')
+            {
+                depth++;
+                i++;
+                continue;
+            }
+
             if (c == '}')
             {
                 depth--;
@@ -197,21 +242,20 @@ internal static class FormulaParser
                 if (depth == 0) return i;
                 continue;
             }
+
             i++;
         }
+
         throw new FormatException("Unterminated array constant in formula.");
     }
 
     private static int MatchErrorLiteral(string s, int i)
     {
         foreach (var lit in ErrorLiterals)
-        {
             if (i + lit.Length <= s.Length &&
                 string.CompareOrdinal(s, i, lit, 0, lit.Length) == 0)
-            {
                 return lit.Length;
-            }
-        }
+
         return 0;
     }
 
@@ -224,6 +268,7 @@ internal static class FormulaParser
             i++;
             while (i < n && char.IsDigit(s[i])) i++;
         }
+
         // Scientific suffix: only consume 'E' when a valid exponent follows.
         if (i < n && (s[i] == 'E' || s[i] == 'e'))
         {
@@ -235,6 +280,7 @@ internal static class FormulaParser
                 while (i < n && char.IsDigit(s[i])) i++;
             }
         }
+
         return i;
     }
 
@@ -284,7 +330,12 @@ internal static class FormulaParser
                 // ':' is part of this reference only for a 3-D sheet range —
                 // i.e. when a sheet-name-then-'!' follows. Otherwise it is the
                 // range operator and belongs to the parser, so stop here.
-                if (IsThreeDColon(s, i)) { i++; continue; }
+                if (IsThreeDColon(s, i))
+                {
+                    i++;
+                    continue;
+                }
+
                 break;
             }
 
@@ -308,11 +359,18 @@ internal static class FormulaParser
         {
             if (s[i] == '\'')
             {
-                if (i + 1 < s.Length && s[i + 1] == '\'') { i += 2; continue; }
+                if (i + 1 < s.Length && s[i + 1] == '\'')
+                {
+                    i += 2;
+                    continue;
+                }
+
                 return i + 1;
             }
+
             i++;
         }
+
         throw new FormatException("Unterminated quoted sheet/workbook name in formula.");
     }
 
@@ -324,8 +382,19 @@ internal static class FormulaParser
         while (i < s.Length)
         {
             var c = s[i];
-            if (c == '\'') { i += 2; continue; }
-            if (c == '[') { depth++; i++; continue; }
+            if (c == '\'')
+            {
+                i += 2;
+                continue;
+            }
+
+            if (c == '[')
+            {
+                depth++;
+                i++;
+                continue;
+            }
+
             if (c == ']')
             {
                 depth--;
@@ -333,8 +402,10 @@ internal static class FormulaParser
                 if (depth == 0) return i;
                 continue;
             }
+
             i++;
         }
+
         throw new FormatException("Unterminated structured-reference bracket in formula.");
     }
 
@@ -349,10 +420,18 @@ internal static class FormulaParser
         var j = colonIndex + 1;
         if (j < n && s[j] == '\'')
         {
-            try { j = SkipSingleQuoted(s, j); }
-            catch (FormatException) { return false; }
+            try
+            {
+                j = SkipSingleQuoted(s, j);
+            }
+            catch (FormatException)
+            {
+                return false;
+            }
+
             return j < n && s[j] == '!';
         }
+
         while (j < n && (char.IsLetterOrDigit(s[j]) || s[j] == '_' || s[j] == '.' || s[j] == ' '))
             j++;
         return j < n && s[j] == '!';
@@ -374,10 +453,15 @@ internal static class FormulaParser
 
         private FormulaToken Peek => _tokens[_pos];
 
-        private FormulaToken Advance() => _tokens[_pos++];
+        private FormulaToken Advance()
+        {
+            return _tokens[_pos++];
+        }
 
-        private bool IsOp(string symbol) =>
-            Peek.Type == FormulaTokenType.Operator && Peek.Text == symbol;
+        private bool IsOp(string symbol)
+        {
+            return Peek.Type == FormulaTokenType.Operator && Peek.Text == symbol;
+        }
 
         public FormulaAst ParseFormula()
         {
@@ -394,7 +478,10 @@ internal static class FormulaParser
             return new FormulaAst(_source, equals, root, Peek);
         }
 
-        private FormulaNode ParseExpression() => ParseComparison();
+        private FormulaNode ParseExpression()
+        {
+            return ParseComparison();
+        }
 
         private FormulaNode ParseComparison()
         {
@@ -405,6 +492,7 @@ internal static class FormulaParser
                 var right = ParseConcat();
                 left = new BinaryNode(left, op.Text, op, right);
             }
+
             return left;
         }
 
@@ -417,6 +505,7 @@ internal static class FormulaParser
                 var right = ParseAdditive();
                 left = new BinaryNode(left, op.Text, op, right);
             }
+
             return left;
         }
 
@@ -429,6 +518,7 @@ internal static class FormulaParser
                 var right = ParseMultiplicative();
                 left = new BinaryNode(left, op.Text, op, right);
             }
+
             return left;
         }
 
@@ -441,6 +531,7 @@ internal static class FormulaParser
                 var right = ParseUnary();
                 left = new BinaryNode(left, op.Text, op, right);
             }
+
             return left;
         }
 
@@ -452,6 +543,7 @@ internal static class FormulaParser
                 var operand = ParseUnary();
                 return new UnaryNode(op, operand);
             }
+
             return ParseExponent();
         }
 
@@ -465,6 +557,7 @@ internal static class FormulaParser
                 var right = ParsePercent();
                 left = new BinaryNode(left, op.Text, op, right);
             }
+
             return left;
         }
 
@@ -476,6 +569,7 @@ internal static class FormulaParser
                 var op = Advance();
                 operand = new PostfixNode(operand, op);
             }
+
             return operand;
         }
 
@@ -487,6 +581,7 @@ internal static class FormulaParser
                 var operand = ParseAt();
                 return new UnaryNode(op, operand);
             }
+
             return ParseIntersection();
         }
 
@@ -499,6 +594,7 @@ internal static class FormulaParser
                 var right = ParseRange();
                 left = new BinaryNode(left, " ", null, right);
             }
+
             return left;
         }
 
@@ -511,6 +607,7 @@ internal static class FormulaParser
                 var right = ParseSpill();
                 left = new BinaryNode(left, op.Text, op, right);
             }
+
             return left;
         }
 
@@ -522,6 +619,7 @@ internal static class FormulaParser
                 var op = Advance();
                 operand = new PostfixNode(operand, op);
             }
+
             return operand;
         }
 
@@ -569,7 +667,8 @@ internal static class FormulaParser
         ///     slots become <see cref="EmptyArgNode" />. Shared by function calls
         ///     and grouping/union parens.
         /// </summary>
-        private (FormulaToken Open, List<FormulaNode> Items, List<FormulaToken> Commas, FormulaToken Close) ParseArgList()
+        private (FormulaToken Open, List<FormulaNode> Items, List<FormulaToken> Commas, FormulaToken Close)
+            ParseArgList()
         {
             var open = Advance(); // '('
             var items = new List<FormulaNode>();
@@ -605,20 +704,24 @@ internal static class FormulaParser
             }
         }
 
-        private static bool IsComparisonOp(string s) =>
-            s is "=" or "<>" or "<" or "<=" or ">" or ">=";
+        private static bool IsComparisonOp(string s)
+        {
+            return s is "=" or "<>" or "<" or "<=" or ">" or ">=";
+        }
 
         /// <summary>
         ///     True when <paramref name="t" /> can begin an operand — used to spot
         ///     the space-as-intersection operator. Leading <c>+ - @</c> are
         ///     excluded so <c>A1 -B1</c> stays subtraction, not intersection.
         /// </summary>
-        private static bool IsOperandStart(FormulaToken t) =>
-            t.Type is FormulaTokenType.Number
+        private static bool IsOperandStart(FormulaToken t)
+        {
+            return t.Type is FormulaTokenType.Number
                 or FormulaTokenType.String
                 or FormulaTokenType.Error
                 or FormulaTokenType.Name
                 or FormulaTokenType.Array
                 or FormulaTokenType.LParen;
+        }
     }
 }


### PR DESCRIPTION
Closes #270. Part of #269 (spec 0009 — Unnest to LET).

## What this is

The repo's **first recursive-descent Excel-formula parser**, producing an expression tree (AST). Pure engine, no UI — the foundation `/Unnest` (#271–#273) builds on. It parses the canonical US form `Range.Formula2` returns (comma separators, US function names) and **never evaluates**: structure is good enough to identify call/operator nodes and keep leaves opaque.

## Design

- **`FormulaAst.cs`** — token + node types: `LeafNode`, `FunctionCallNode`, `BinaryNode`, `UnaryNode`, `PostfixNode`, `ParenNode` (single group / multi-item union), `EmptyArgNode`. Every token carries its **leading whitespace trivia**, so a parse → serialise round-trip is character-for-character identical (cosmetic spaces, newlines, and the space-as-intersection operator all survive). Nodes expose `Start`/`End` spans for downstream text splicing.
- **`FormulaParser.cs`** — a trivia-preserving lexer + recursive-descent parser. Precedence (tightest first): reference `:` · intersection (space) · spill `#` · `@` · `%` · `^` · unary `+ -` · `* /` · `+ -` · `&` · comparisons. `^` is left-associative (`2^3^2 == (2^3)^2`); unary minus is looser than `^` (`-A1^2 == -(A1^2)`).

### Lexing decisions (the "rock-solid brackets/strings/refs" requirement)
- References lex as **single opaque leaf tokens**: sheet-qualified (`'My Sheet'!A1`), structured (`t[[X]:[Y]]`, `[@Col]`, `t[[#Headers],[City]]`), 3-D (`Sheet1:Sheet3!A1`, via `:`-lookahead for a `!`-terminated sheet name), external (`[Book.xlsx]Sheet1!A1`). Structured-bracket `'`-escapes (`'[ '] '# '@`) handled.
- Strings (`""` escapes) and array constants (`{1,2;3,4}`) consumed whole and kept opaque.
- Spill `A1#` is a `PostfixNode`; ranges `A1:B5` are `:` `BinaryNode`s — both **non-steps** per spec, so atomic leaves are never descended into for step purposes.

## Tests

`FormulaParserTests.cs` — **204 tests**:
- Round-trip + structural assertions across the full edge-case checklist: precedence/associativity chains, nested calls, empty args (`SUM(A1,,A3)`), zero-arg calls, `_xlfn.` prefixes, every cell-ref form, structured refs, array constants with mixed types, all error literals, scientific/leading-dot numbers, string escapes, union/intersection, `@` prefix, `%`/`#` postfix, whitespace/newline fidelity, and the spec's worked example.
- Malformed-input cases assert `FormatException`.
- **Golden round-trip corpus**: parses every formula in the lambda library (82 `.lambda` files, via `LambdaParser`) and asserts identical re-serialisation — the strongest guard against real-world surprises.

Full unit suite green (1408 passed, 0 failed). Parser/AST types are `internal` (kept out of Excel's UDF registry; tests reach them via `InternalsVisibleTo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)