### PR TITLE
Add Unnest decomposition engine (non-LET) — #271

### DIFF
--- a/addin/lambda-boss.Tests/UnnestEngineTests.cs
+++ b/addin/lambda-boss.Tests/UnnestEngineTests.cs
@@ -1,0 +1,286 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+/// <summary>
+///     Spec 0009 / issue #271 — <see cref="UnnestEngine" /> tests for the non-LET
+///     decomposition path. Covers the worked example, function-only and
+///     operator-only formulas, the single-root no-op, function-derived + calcN
+///     naming with collision suffixing, Include-toggle inlining + re-parenting,
+///     and round-trip safety through <see cref="LetParser" />.
+/// </summary>
+public class UnnestEngineTests
+{
+    private const string WorkedExample =
+        "=ROUND(SQRT(SUMSQ(XLOOKUP(H94, t[City], t[[X-Coordinates]:[Y-Coordinates]]) - $I$92:$J$92)) * 100, 0)";
+
+    // ---------------- worked example ----------------
+
+    [Fact]
+    public void Unnest_WorkedExample_ProducesSpecLeafFirstSteps()
+    {
+        var result = UnnestEngine.Unnest(WorkedExample);
+
+        Assert.Null(result.Diagnostic);
+        Assert.Collection(result.Steps,
+            s => AssertStep(s, "xlookup1",
+                "XLOOKUP(H94, t[City], t[[X-Coordinates]:[Y-Coordinates]])", UnnestStepOrigin.Function),
+            s => AssertStep(s, "calc1", "xlookup1 - $I$92:$J$92", UnnestStepOrigin.Operator),
+            s => AssertStep(s, "sumsq1", "SUMSQ(calc1)", UnnestStepOrigin.Function),
+            s => AssertStep(s, "sqrt1", "SQRT(sumsq1)", UnnestStepOrigin.Function),
+            s => AssertStep(s, "calc2", "sqrt1 * 100", UnnestStepOrigin.Operator));
+    }
+
+    [Fact]
+    public void Unnest_WorkedExample_SynthesisesExpectedLet()
+    {
+        var result = UnnestEngine.Unnest(WorkedExample);
+
+        const string expected =
+            "=LET(\n" +
+            "    xlookup1, XLOOKUP(H94, t[City], t[[X-Coordinates]:[Y-Coordinates]]),\n" +
+            "    calc1, xlookup1 - $I$92:$J$92,\n" +
+            "    sumsq1, SUMSQ(calc1),\n" +
+            "    sqrt1, SQRT(sumsq1),\n" +
+            "    calc2, sqrt1 * 100,\n" +
+            "    ROUND(calc2, 0)\n" +
+            ")";
+
+        Assert.Equal(expected, result.SynthesisedLet);
+    }
+
+    // ---------------- function-only / operator-only ----------------
+
+    [Fact]
+    public void Unnest_FunctionOnlyFormula_NamesEachNestedCall()
+    {
+        var result = UnnestEngine.Unnest("=ROUND(SQRT(SUM(A1:A10)), 2)");
+
+        Assert.Collection(result.Steps,
+            s => AssertStep(s, "sum1", "SUM(A1:A10)", UnnestStepOrigin.Function),
+            s => AssertStep(s, "sqrt1", "SQRT(sum1)", UnnestStepOrigin.Function));
+        Assert.Contains("ROUND(sqrt1, 2)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_OperatorOnlyFormula_NamesEachOperatorCalcN()
+    {
+        var result = UnnestEngine.Unnest("=A1+B1*C1-D1");
+
+        // ((A1 + (B1*C1)) - D1): the '-' is root (body); '*' then '+' are steps.
+        Assert.Collection(result.Steps,
+            s => AssertStep(s, "calc1", "B1 * C1", UnnestStepOrigin.Operator),
+            s => AssertStep(s, "calc2", "A1 + calc1", UnnestStepOrigin.Operator));
+        Assert.Contains("calc2 - D1", result.SynthesisedLet);
+    }
+
+    // ---------------- single-leaf / single-root no-op ----------------
+
+    [Fact]
+    public void Unnest_SingleRootOperator_ZeroStepsNoOp()
+    {
+        var result = UnnestEngine.Unnest("=A1+B1");
+
+        Assert.Empty(result.Steps);
+        Assert.Equal("=A1+B1", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_SingleLeaf_ZeroStepsNoOp()
+    {
+        var result = UnnestEngine.Unnest("=A1");
+
+        Assert.Empty(result.Steps);
+        Assert.Equal("=A1", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_LoneFunctionWithLeafArgs_ZeroSteps()
+    {
+        // The function IS the root → body; its leaf args nest nothing.
+        var result = UnnestEngine.Unnest("=SUM(A1, B1)");
+
+        Assert.Empty(result.Steps);
+        Assert.Equal("=SUM(A1, B1)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_BareRange_IsLeafNotStep()
+    {
+        // ':' is a reference operator — never a step.
+        var result = UnnestEngine.Unnest("=A1:B5");
+
+        Assert.Empty(result.Steps);
+        Assert.Equal("=A1:B5", result.SynthesisedLet);
+    }
+
+    // ---------------- naming: function-derived, calcN, collision suffixing ----------------
+
+    [Fact]
+    public void Unnest_RepeatedFunction_EachGetsOwnSuffix()
+    {
+        var result = UnnestEngine.Unnest("=SQRT(A1) + SQRT(B1)");
+
+        Assert.Collection(result.Steps,
+            s => Assert.Equal("sqrt1", s.Name),
+            s => Assert.Equal("sqrt2", s.Name));
+        Assert.Contains("sqrt1 + sqrt2", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_NameCollidesWithWorkbookDefinedName_SuffixSkipsAhead()
+    {
+        var defined = new[] { "sumsq1", "calc1" };
+        var result = UnnestEngine.Unnest(WorkedExample, defined);
+
+        var sumsq = Assert.Single(result.Steps, s => s.Origin == UnnestStepOrigin.Function && s.OriginLabel == "SUMSQ");
+        Assert.Equal("sumsq2", sumsq.Name);
+
+        // Both operator steps must avoid the reserved 'calc1'.
+        var calcs = result.Steps.Where(s => s.Origin == UnnestStepOrigin.Operator).Select(s => s.Name).ToList();
+        Assert.Equal(new[] { "calc2", "calc3" }, calcs);
+    }
+
+    [Fact]
+    public void Unnest_FunctionName_StripsXlfnPrefix()
+    {
+        var result = UnnestEngine.Unnest("=SUM(_xlfn.SEQUENCE(3))");
+
+        var step = Assert.Single(result.Steps);
+        Assert.Equal("sequence1", step.Name);
+        Assert.Equal("_xlfn.SEQUENCE", step.OriginLabel);
+    }
+
+    // ---------------- include-toggle inlining + re-parenting ----------------
+
+    [Fact]
+    public void Recompute_UnIncludeOperatorStep_InlinesIntoParentAndReParentsChildren()
+    {
+        var initial = UnnestEngine.Unnest(WorkedExample);
+
+        // Flip calc1 (the '-' operator) off; keep everything else.
+        var states = initial.Steps
+            .Select(s => new UnnestRowState(s.Key, s.Name, Include: s.Name != "calc1"))
+            .ToList();
+
+        var result = UnnestEngine.Recompute(WorkedExample, states);
+
+        // calc1 row is still reported but excluded.
+        var calc1 = Assert.Single(result.Steps, s => s.Name == "calc1");
+        Assert.False(calc1.Include);
+
+        // sumsq1 now inlines calc1's RHS — xlookup1 re-parents up into it.
+        var sumsq = Assert.Single(result.Steps, s => s.Name == "sumsq1");
+        Assert.Equal("SUMSQ(xlookup1 - $I$92:$J$92)", sumsq.Rhs);
+
+        const string expected =
+            "=LET(\n" +
+            "    xlookup1, XLOOKUP(H94, t[City], t[[X-Coordinates]:[Y-Coordinates]]),\n" +
+            "    sumsq1, SUMSQ(xlookup1 - $I$92:$J$92),\n" +
+            "    sqrt1, SQRT(sumsq1),\n" +
+            "    calc2, sqrt1 * 100,\n" +
+            "    ROUND(calc2, 0)\n" +
+            ")";
+        Assert.Equal(expected, result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_UnIncludeAllSteps_NoOpRewrite()
+    {
+        var initial = UnnestEngine.Unnest(WorkedExample);
+        var states = initial.Steps
+            .Select(s => new UnnestRowState(s.Key, s.Name, Include: false))
+            .ToList();
+
+        var result = UnnestEngine.Recompute(WorkedExample, states);
+
+        Assert.Equal(WorkedExample, result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_RenameStep_UsesCustomNameAndBodyReferencesIt()
+    {
+        var initial = UnnestEngine.Unnest(WorkedExample);
+        var states = initial.Steps
+            .Select(s => new UnnestRowState(s.Key, s.Name == "calc2" ? "dist" : s.Name))
+            .ToList();
+
+        var result = UnnestEngine.Recompute(WorkedExample, states);
+
+        Assert.Single(result.Steps, s => s.Name == "dist");
+        Assert.Contains("dist, sqrt1 * 100,", result.SynthesisedLet);
+        Assert.Contains("ROUND(dist, 0)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_RenameClashesWithAutoSuffix_AutoNamesAvoidIt()
+    {
+        // Rename the first SQRT step to 'sqrt2'; the second must not also
+        // auto-name to 'sqrt2'.
+        var initial = UnnestEngine.Unnest("=SQRT(A1) + SQRT(B1)");
+        var states = new List<UnnestRowState>
+        {
+            new(initial.Steps[0].Key, "sqrt2"),
+            new(initial.Steps[1].Key, ""), // empty → re-auto-name
+        };
+
+        var result = UnnestEngine.Recompute("=SQRT(A1) + SQRT(B1)", states);
+
+        Assert.Equal("sqrt2", result.Steps[0].Name);
+        Assert.NotEqual("sqrt2", result.Steps[1].Name);
+    }
+
+    // ---------------- round-trip through LetParser ----------------
+
+    [Fact]
+    public void Unnest_WorkedExample_RoundTripsThroughLetParser()
+    {
+        var result = UnnestEngine.Unnest(WorkedExample);
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+
+        Assert.Equal(
+            new[] { "xlookup1", "calc1", "sumsq1", "sqrt1", "calc2" },
+            parsed.Bindings.Select(b => b.Name).ToArray());
+        Assert.Equal("ROUND(calc2, 0)", parsed.Body);
+        // Every binding RHS classifies as a calculation (function or operator).
+        Assert.All(parsed.Bindings, b => Assert.True(b.IsCalculation));
+    }
+
+    // ---------------- guards ----------------
+
+    [Fact]
+    public void Unnest_ExistingLet_RefusesWithDiagnostic()
+    {
+        var result = UnnestEngine.Unnest("=LET(x, A1, x+1)");
+
+        Assert.NotNull(result.Diagnostic);
+        Assert.Equal(UnnestDiagnosticKind.ExistingLet, result.Diagnostic!.Kind);
+        Assert.Empty(result.Steps);
+        Assert.Equal("=LET(x, A1, x+1)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_MalformedFormula_RefusesWithDiagnostic()
+    {
+        var result = UnnestEngine.Unnest("=SUM(A1,");
+
+        Assert.NotNull(result.Diagnostic);
+        Assert.Equal(UnnestDiagnosticKind.MalformedFormula, result.Diagnostic!.Kind);
+    }
+
+    [Fact]
+    public void Unnest_NullFormula_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => UnnestEngine.Unnest(null!));
+    }
+
+    private static void AssertStep(
+        UnnestStepRow step, string name, string rhs, UnnestStepOrigin origin)
+    {
+        Assert.Equal(name, step.Name);
+        Assert.Equal(rhs, step.Rhs);
+        Assert.Equal(origin, step.Origin);
+        Assert.True(step.Include);
+    }
+}

--- a/addin/lambda-boss/UnnestEngine.cs
+++ b/addin/lambda-boss/UnnestEngine.cs
@@ -1,0 +1,393 @@
+using System.Globalization;
+using System.Text;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     Spec 0009 — the <c>/Unnest</c> decomposition engine (non-LET path). Takes
+///     a nested formula, parses it into an expression tree via
+///     <see cref="FormulaParser" />, and explodes each function-call and binary-
+///     operator node (other than the root) into a named, leaf-first <c>=LET(...)</c>
+///     step. The root stays as the LET body with its child references rewritten
+///     to step names. Reference operators (range <c>:</c> and intersection
+///     <c>space</c>) are treated as leaves, never steps — matching the parser's
+///     "ranges are non-steps" rule. Unary expressions and postfix <c>%</c>/<c>#</c>
+///     also stay inline.
+///
+///     <para>
+///     The decomposition is maximally granular by default; the dialog's per-row
+///     Include toggle collapses a step back into its parent. Inlining and child
+///     re-parenting fall out of the recursive renderer for free: a node renders
+///     to its step name only when it is an <em>included</em> step and not the
+///     node currently being rendered as its own RHS — so un-including a step
+///     causes its parent to render through it, and that node's own included
+///     children surface as names one level up.
+///     </para>
+///
+///     <para>
+///     Re-spacing is canonical (<c>, </c> between arguments, spaces around
+///     arithmetic / concat / comparison operators, none around <c>:</c>) but no
+///     parentheses are ever synthesised: all source grouping survives as
+///     <see cref="ParenNode" />s in the tree, and substituting an atomic step
+///     name for a subtree never lowers precedence, so the rewrite is always
+///     structurally safe. A successful synthesis round-trips through
+///     <see cref="LetParser" />.
+///     </para>
+/// </summary>
+public static class UnnestEngine
+{
+    /// <summary>
+    ///     Runs the initial decomposition over <paramref name="formula" />. Every
+    ///     step is auto-named and included. <paramref name="definedNames" /> is
+    ///     the workbook's defined-name catalogue the auto-namer avoids colliding
+    ///     with (pass null when there are none to consider, e.g. unit tests).
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="formula" /> is null.</exception>
+    public static UnnestResult Unnest(
+        string formula,
+        IReadOnlyCollection<string>? definedNames = null)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+        return Decompose(formula, null, definedNames);
+    }
+
+    /// <summary>
+    ///     Re-runs the decomposition with the dialog's per-row state
+    ///     (<paramref name="rowStates" />). Each step takes its name and Include
+    ///     flag from the matching state by <see cref="UnnestRowState.Key" />;
+    ///     rows with no state default to an auto name and included. Explicit
+    ///     names are reserved before auto-naming the rest, so a user rename never
+    ///     collides with an auto-allocated suffix.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="formula" /> or <paramref name="rowStates" /> is null.</exception>
+    public static UnnestResult Recompute(
+        string formula,
+        IReadOnlyList<UnnestRowState> rowStates,
+        IReadOnlyCollection<string>? definedNames = null)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+        if (rowStates is null) throw new ArgumentNullException(nameof(rowStates));
+        return Decompose(formula, rowStates, definedNames);
+    }
+
+    private static UnnestResult Decompose(
+        string formula,
+        IReadOnlyList<UnnestRowState>? rowStates,
+        IReadOnlyCollection<string>? definedNames)
+    {
+        // Existing LETs are exploded by the existing-LET path (issue #273); the
+        // non-LET engine refuses rather than parse a LET as a function call.
+        if (LetParser.IsLetFormula(formula))
+        {
+            return new UnnestResult(
+                formula,
+                Array.Empty<UnnestStepRow>(),
+                formula,
+                new UnnestDiagnostic(
+                    UnnestDiagnosticKind.ExistingLet,
+                    "Unnest doesn't yet handle formulas that are already a LET."));
+        }
+
+        FormulaAst ast;
+        try
+        {
+            ast = FormulaParser.Parse(formula);
+        }
+        catch (FormatException ex)
+        {
+            return new UnnestResult(
+                formula,
+                Array.Empty<UnnestStepRow>(),
+                formula,
+                new UnnestDiagnostic(
+                    UnnestDiagnosticKind.MalformedFormula,
+                    $"Unnest can't parse this formula: {ex.Message}"));
+        }
+
+        // Collect the step-candidate nodes leaf-first (post-order, root excluded).
+        var candidates = new List<FormulaNode>();
+        CollectSteps(ast.Root, isRoot: true, candidates);
+
+        // Assign names + Include per row, honouring any dialog state.
+        var stateByKey = BuildStateLookup(rowStates);
+        var used = new HashSet<string>(
+            definedNames ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+
+        // Reserve every explicit user name first so auto-allocation skips them.
+        for (var i = 0; i < candidates.Count; i++)
+            if (stateByKey.TryGetValue(KeyOf(i), out var st) && !string.IsNullOrWhiteSpace(st.Name))
+                used.Add(st.Name);
+
+        var nameOf = new Dictionary<FormulaNode, string>();
+        var included = new HashSet<FormulaNode>();
+        var rows = new List<UnnestStepRow>(candidates.Count);
+
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            var node = candidates[i];
+            var key = KeyOf(i);
+            stateByKey.TryGetValue(key, out var state);
+
+            var name = state is { } s && !string.IsNullOrWhiteSpace(s.Name)
+                ? s.Name
+                : AllocateName(BaseNameOf(node), used);
+            var include = state?.Include ?? true;
+
+            nameOf[node] = name;
+            if (include) included.Add(node);
+
+            // Rhs is filled in below once every step's name is known, so a
+            // child reference resolves regardless of emission order.
+            rows.Add(new UnnestStepRow(
+                key, name, Rhs: "", OriginOf(node), OriginLabelOf(node), include));
+        }
+
+        // Now that names are assigned, render each step's RHS and the body.
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            var rhs = Render(candidates[i], nameOf, included, isRoot: true);
+            rows[i] = rows[i] with { Rhs = rhs };
+        }
+
+        var includedRows = new List<UnnestStepRow>();
+        foreach (var row in rows)
+            if (row.Include)
+                includedRows.Add(row);
+
+        var synthesised = includedRows.Count == 0
+            ? formula // No steps (or all inlined): a no-op rewrite.
+            : BuildLet(includedRows, Render(ast.Root, nameOf, included, isRoot: true));
+
+        return new UnnestResult(formula, rows, synthesised);
+    }
+
+    // ---------------- step collection ----------------
+
+    /// <summary>
+    ///     A node is a step candidate iff it is a function call or a binary
+    ///     operator that isn't a reference operator (range <c>:</c> or the
+    ///     space intersection). Unary / postfix nodes, parens, and leaves never
+    ///     qualify.
+    /// </summary>
+    private static bool IsStepCandidate(FormulaNode node)
+    {
+        return node switch
+        {
+            FunctionCallNode => true,
+            BinaryNode b => b.Operator != ":" && b.Operator != " ",
+            _ => false
+        };
+    }
+
+    /// <summary>
+    ///     Post-order walk appending step candidates leaf-first. The root is
+    ///     never a step (it becomes the LET body), so <paramref name="isRoot" />
+    ///     suppresses its own emission while still descending into its children.
+    /// </summary>
+    private static void CollectSteps(FormulaNode node, bool isRoot, List<FormulaNode> sink)
+    {
+        foreach (var child in Children(node))
+            CollectSteps(child, isRoot: false, sink);
+
+        if (!isRoot && IsStepCandidate(node))
+            sink.Add(node);
+    }
+
+    private static IEnumerable<FormulaNode> Children(FormulaNode node)
+    {
+        switch (node)
+        {
+            case FunctionCallNode fc:
+                return fc.Arguments;
+            case BinaryNode b:
+                return new[] { b.Left, b.Right };
+            case UnaryNode u:
+                return new[] { u.Operand };
+            case PostfixNode p:
+                return new[] { p.Operand };
+            case ParenNode pn:
+                return pn.Items;
+            default:
+                return Array.Empty<FormulaNode>();
+        }
+    }
+
+    // ---------------- rendering ----------------
+
+    /// <summary>
+    ///     Renders <paramref name="node" /> to expression text. A node renders to
+    ///     its step name only when it is an <em>included</em> step and it isn't
+    ///     the node being rendered as its own RHS (<paramref name="isRoot" />) —
+    ///     so a step's RHS shows its own structure while its included children
+    ///     collapse to names, and an un-included step renders through to its
+    ///     structure (re-parenting its children one level up).
+    /// </summary>
+    private static string Render(
+        FormulaNode node,
+        IReadOnlyDictionary<FormulaNode, string> nameOf,
+        ISet<FormulaNode> included,
+        bool isRoot)
+    {
+        if (!isRoot && included.Contains(node))
+            return nameOf[node];
+
+        switch (node)
+        {
+            case LeafNode leaf:
+                return leaf.Text;
+
+            case EmptyArgNode:
+                return "";
+
+            case FunctionCallNode fc:
+            {
+                var sb = new StringBuilder();
+                sb.Append(fc.Name).Append('(');
+                for (var i = 0; i < fc.Arguments.Count; i++)
+                {
+                    if (i > 0) sb.Append(", ");
+                    sb.Append(Render(fc.Arguments[i], nameOf, included, isRoot: false));
+                }
+
+                sb.Append(')');
+                return sb.ToString();
+            }
+
+            case BinaryNode b:
+            {
+                var left = Render(b.Left, nameOf, included, isRoot: false);
+                var right = Render(b.Right, nameOf, included, isRoot: false);
+                if (b.Operator == ":")
+                    return left + ":" + right;       // range — no spaces
+                if (b.Operator == " ")
+                    return left + " " + right;       // intersection — the space is the operator
+                return left + " " + b.Operator + " " + right;
+            }
+
+            case UnaryNode u:
+                return u.Operator + Render(u.Operand, nameOf, included, isRoot: false);
+
+            case PostfixNode p:
+                return Render(p.Operand, nameOf, included, isRoot: false) + p.Operator;
+
+            case ParenNode pn:
+            {
+                var sb = new StringBuilder();
+                sb.Append('(');
+                for (var i = 0; i < pn.Items.Count; i++)
+                {
+                    if (i > 0) sb.Append(", ");
+                    sb.Append(Render(pn.Items[i], nameOf, included, isRoot: false));
+                }
+
+                sb.Append(')');
+                return sb.ToString();
+            }
+
+            default:
+                // Defensive: any node type renders to its verbatim source.
+                return node.ToFormula().TrimStart();
+        }
+    }
+
+    private static string BuildLet(List<UnnestStepRow> steps, string body)
+    {
+        var bindings = new List<(string Name, string Value)>(steps.Count);
+        foreach (var s in steps)
+            bindings.Add((s.Name, s.Rhs));
+
+        var sb = new StringBuilder();
+        sb.Append('=');
+        FormulaFormatter.AppendLet(sb, 0, bindings, body);
+        return sb.ToString();
+    }
+
+    // ---------------- naming ----------------
+
+    private static UnnestStepOrigin OriginOf(FormulaNode node)
+    {
+        return node is FunctionCallNode ? UnnestStepOrigin.Function : UnnestStepOrigin.Operator;
+    }
+
+    private static string OriginLabelOf(FormulaNode node)
+    {
+        return node switch
+        {
+            FunctionCallNode fc => fc.Name,
+            BinaryNode b => b.Operator,
+            _ => ""
+        };
+    }
+
+    /// <summary>
+    ///     The base name a step auto-names from: the lowercased function name for
+    ///     a call (with any <c>_xlfn.</c>/<c>_xlws.</c> prefix and sheet qualifier
+    ///     stripped), or the generic <c>calc</c> for an operator.
+    /// </summary>
+    private static string BaseNameOf(FormulaNode node)
+    {
+        if (node is FunctionCallNode fc)
+            return FunctionBaseName(fc.Name);
+        return "calc";
+    }
+
+    private static string FunctionBaseName(string fnName)
+    {
+        var s = fnName;
+
+        // Drop a sheet / workbook qualifier on a scoped LAMBDA call.
+        var bang = s.LastIndexOf('!');
+        if (bang >= 0) s = s[(bang + 1)..];
+
+        // Strip the future-function / worksheet-function compatibility prefixes.
+        if (s.StartsWith("_xlfn._xlws.", StringComparison.OrdinalIgnoreCase))
+            s = s["_xlfn._xlws.".Length..];
+        else if (s.StartsWith("_xlfn.", StringComparison.OrdinalIgnoreCase))
+            s = s["_xlfn.".Length..];
+        else if (s.StartsWith("_xlws.", StringComparison.OrdinalIgnoreCase))
+            s = s["_xlws.".Length..];
+
+        s = s.ToLowerInvariant();
+        if (s.Length == 0)
+            return "fn";
+
+        // A valid Excel name starts with a letter or underscore.
+        if (!char.IsLetter(s[0]) && s[0] != '_')
+            s = "_" + s;
+        return s;
+    }
+
+    /// <summary>
+    ///     Allocates the smallest <c>base + N</c> (N ≥ 1) not already in
+    ///     <paramref name="used" />, and records it. A base used once still gets
+    ///     its <c>1</c> suffix, so renumbering never shifts as the formula grows.
+    /// </summary>
+    private static string AllocateName(string baseName, HashSet<string> used)
+    {
+        var n = 1;
+        while (true)
+        {
+            var candidate = baseName + n.ToString(CultureInfo.InvariantCulture);
+            if (used.Add(candidate))
+                return candidate;
+            n++;
+        }
+    }
+
+    // ---------------- keys ----------------
+
+    private static string KeyOf(int leafFirstIndex)
+    {
+        return "step" + leafFirstIndex.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static Dictionary<string, UnnestRowState> BuildStateLookup(
+        IReadOnlyList<UnnestRowState>? rowStates)
+    {
+        var map = new Dictionary<string, UnnestRowState>(StringComparer.Ordinal);
+        if (rowStates is null) return map;
+        foreach (var rs in rowStates)
+            map[rs.Key] = rs;
+        return map;
+    }
+}

--- a/addin/lambda-boss/UnnestTypes.cs
+++ b/addin/lambda-boss/UnnestTypes.cs
@@ -1,0 +1,85 @@
+namespace LambdaBoss;
+
+/// <summary>
+///     Spec 0009 — what kind of AST node a step was extracted from, used by the
+///     dialog to badge each row ("function: SUMSQ" / "operator: −").
+/// </summary>
+public enum UnnestStepOrigin
+{
+    /// <summary>A function-call node — e.g. <c>SUMSQ(...)</c>, <c>XLOOKUP(...)</c>.</summary>
+    Function,
+
+    /// <summary>A binary-operator node — e.g. <c>a - b</c>, <c>x * 100</c>, <c>p &amp; q</c>.</summary>
+    Operator
+}
+
+/// <summary>
+///     Spec 0009 — one extracted step in the decomposition. Rows are returned
+///     leaf-first (each step precedes every use of it). <see cref="Key" /> is
+///     the stable identity the dialog echoes back via <see cref="UnnestRowState" />
+///     (the leaf-first ordinal of the step candidate — invariant across
+///     <see cref="UnnestEngine.Recompute" /> because the source formula text
+///     doesn't change). <see cref="Name" /> is the current (auto- or user-)
+///     assigned binding name; <see cref="Rhs" /> is the node's expression with
+///     every included child step already substituted to its step name;
+///     <see cref="Origin" /> / <see cref="OriginLabel" /> drive the badge; and
+///     <see cref="Include" /> is the per-row toggle (default on — when off the
+///     step is inlined back into its parent and its children re-parent to the
+///     grandparent, so the row is reported but emits no binding).
+/// </summary>
+public sealed record UnnestStepRow(
+    string Key,
+    string Name,
+    string Rhs,
+    UnnestStepOrigin Origin,
+    string OriginLabel,
+    bool Include);
+
+/// <summary>
+///     User's per-row state passed back into <see cref="UnnestEngine.Recompute" />.
+///     <see cref="Key" /> matches a <see cref="UnnestStepRow.Key" />;
+///     <see cref="Name" /> is the (possibly user-edited) binding name — when
+///     empty the engine re-auto-names the row; <see cref="Include" /> toggles
+///     whether the step is emitted as a binding or inlined back into its parent.
+/// </summary>
+public sealed record UnnestRowState(
+    string Key,
+    string Name,
+    bool Include = true);
+
+/// <summary>
+///     The engine's output. <see cref="OriginalFormula" /> is the formula text
+///     passed in (handy for the dialog header). <see cref="Steps" /> is the
+///     leaf-first list of extracted steps. <see cref="SynthesisedLet" /> is the
+///     formatted <c>=LET(...)</c> ready to write back to the active cell on Save
+///     — or the original formula unchanged when there are no included steps
+///     (a no-op rewrite). <see cref="Diagnostic" /> is non-null when the engine
+///     refused; in that case <see cref="Steps" /> is empty and
+///     <see cref="SynthesisedLet" /> is the original formula unchanged.
+/// </summary>
+public sealed record UnnestResult(
+    string OriginalFormula,
+    IReadOnlyList<UnnestStepRow> Steps,
+    string SynthesisedLet,
+    UnnestDiagnostic? Diagnostic = null);
+
+/// <summary>A refusal reason — the slash command surfaces the message instead of opening the dialog.</summary>
+public sealed record UnnestDiagnostic(
+    UnnestDiagnosticKind Kind,
+    string Message);
+
+public enum UnnestDiagnosticKind
+{
+    /// <summary>
+    ///     The formula couldn't be parsed into an expression tree
+    ///     (unexpected token, unbalanced brackets, …).
+    /// </summary>
+    MalformedFormula,
+
+    /// <summary>
+    ///     The active cell holds a <c>=LET(...)</c>. Existing-LET explosion is
+    ///     handled separately (issue #273); the non-LET engine refuses rather
+    ///     than mis-parsing the LET as a function call.
+    /// </summary>
+    ExistingLet
+}


### PR DESCRIPTION
Closes #271. Part of #269 (spec [0009](specs/0009-unnest-to-let.md)).

The second build step of `/Unnest`, on top of the #270 parser: a pure decomposition engine that turns a nested formula's AST into a leaf-first `=LET(...)` of named steps. No UI — that's #272; existing-LET handling is #273.

## What it does

- **Step extraction.** Walks the AST post-order and makes every function-call node and every binary-operator node (other than the root) a step, leaf-first (each step precedes every use of it). Reference operators (range `:`, intersection space) are leaves, never steps; unary and postfix `%`/`#` stay inline. The root becomes the LET body with its child refs rewritten to step names.
- **Naming.** Function steps auto-name from the lowercased function name (`sumsq1`, `sqrt1`, `round1`, with `_xlfn.`/`_xlws.` and sheet qualifiers stripped); operator steps `calcN`. Smallest numeric suffix that avoids collision with other steps and workbook defined names; a base used once still gets `1`.
- **Include-toggle inlining.** Un-including a step inlines its RHS back into the parent and re-parents its children to the grandparent. This falls out of the recursive renderer for free — an un-included step renders through to its structure, surfacing its own included children one level up.
- **Precedence safety.** No parentheses are ever synthesised: source grouping survives as `ParenNode`s in the tree, and substituting an atomic step name for a subtree never lowers precedence — so the rewrite is always structurally safe.
- Emits via `FormulaFormatter.AppendLet`; output round-trips through `LetParser`.
- **Guards:** an existing `=LET(` (handled by #273) and a malformed formula are refused with a diagnostic rather than mis-parsed.

## Worked example

`=ROUND(SQRT(SUMSQ(XLOOKUP(H94, t[City], t[[X-Coordinates]:[Y-Coordinates]]) - $I$92:$J$92)) * 100, 0)` decomposes to steps `xlookup1`, `calc1`, `sumsq1`, `sqrt1`, `calc2` with body `ROUND(calc2, 0)` — matching the spec.

## Tests

19 new engine tests covering: the worked example (steps, synthesis, and `LetParser` round-trip), function-only / operator-only formulas, single-root / single-leaf / lone-call / bare-range no-ops, function-derived + `calcN` naming with defined-name collision suffixing, `_xlfn.` stripping, Include-toggle inlining + re-parenting, and rename collision avoidance. Full unit suite green (1427 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)