### PR TITLE
Add /Unnest dialog + command — #272

### DIFF
--- a/addin/lambda-boss.AddinTests/UnnestRoundTripTests.cs
+++ b/addin/lambda-boss.AddinTests/UnnestRoundTripTests.cs
@@ -1,0 +1,215 @@
+using System.Runtime.InteropServices;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LambdaBoss.AddinTests;
+
+/// <summary>
+///     Spec 0009 / issue #272 — real-Excel coverage for the <c>/Unnest</c>
+///     command's output. The dialog itself is interactive (modal WPF window)
+///     and can't be driven headless, so these tests exercise the same engine
+///     the command runs (<see cref="UnnestEngine" />) and prove its synthesised
+///     LET is accepted by Excel, round-trips through <see cref="LetParser" />,
+///     preserves the original value, and composes through
+///     <c>/Refactor → /LET to LAMBDA</c> into a working LAMBDA. The dialog's
+///     own activation guard (empty/literal cell → silent no-op) is verified via
+///     the <c>HasFormula</c> precondition the command keys on.
+/// </summary>
+[Collection("Excel Addin")]
+public class UnnestRoundTripTests
+{
+    // Structurally mirrors the spec's worked example (ROUND / SQRT / SUMSQ over
+    // an operator subtree) without the table dependency, so the test is
+    // self-contained: each leaf is a real cell.
+    private const string NestedFormula = "=ROUND(SQRT(SUMSQ(A1 - B1)) * 100, 0)";
+
+    private readonly ExcelAddinFixture _excel;
+    private readonly ITestOutputHelper _output;
+
+    public UnnestRoundTripTests(ExcelAddinFixture excel, ITestOutputHelper output)
+    {
+        _excel = excel;
+        _output = output;
+    }
+
+    [Fact]
+    public void Unnest_WorkedExample_WritesLetThatParsesAndPreservesValue()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            SeedLeaves(ws);
+
+            // Baseline: the original nested formula's computed value.
+            var original = ws.Range["D1"];
+            var unnested = ws.Range["D2"];
+            try
+            {
+                original.Formula2 = NestedFormula;
+                _excel.Application.Calculate();
+                var expected = Convert.ToDouble(original.Value);
+
+                var result = UnnestEngine.Unnest(NestedFormula);
+                _output.WriteLine($"Synthesised LET:\n{result.SynthesisedLet}");
+
+                // The synthesised LET must round-trip through LetParser (the
+                // canonical shape /LET to LAMBDA expects).
+                Assert.True(LetParser.IsLetFormula(result.SynthesisedLet));
+                var parsed = LetParser.Parse(result.SynthesisedLet);
+                Assert.NotEmpty(parsed.Bindings);
+
+                // Excel must accept the synthesised formula and compute the
+                // same value as the original.
+                unnested.Formula2 = result.SynthesisedLet;
+                _excel.Application.Calculate();
+                var actual = Convert.ToDouble(unnested.Value);
+
+                _output.WriteLine($"Original = {expected}, unnested = {actual}");
+                Assert.Equal(expected, actual);
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(original);
+                Marshal.ReleaseComObject(unnested);
+            }
+        }
+        finally
+        {
+            CleanupSheet(ws);
+        }
+    }
+
+    [Fact]
+    public void Unnest_ThenRefactor_ThenLetToLambda_ProducesWorkingLambda()
+    {
+        var ws = _excel.AddWorksheet();
+        var sheetName = (string)ws.Name;
+        try
+        {
+            SeedLeaves(ws);
+
+            var original = ws.Range["D1"];
+            var viaLambda = ws.Range["D2"];
+            try
+            {
+                original.Formula2 = NestedFormula;
+                _excel.Application.Calculate();
+                var expected = Convert.ToDouble(original.Value);
+
+                // /Unnest — explode nested calls/operators into LET steps.
+                var unnested = UnnestEngine.Unnest(NestedFormula).SynthesisedLet;
+
+                // /Refactor — hoist the leaves (A1, B1) into input bindings.
+                var refactored = RefactorEngine.Refactor(unnested, sheetName).SynthesisedLet;
+                _output.WriteLine($"Refactored LET:\n{refactored}");
+
+                // /LET to LAMBDA — keep every value binding as a parameter.
+                var parsed = LetParser.Parse(refactored);
+                var inputs = parsed.Bindings
+                    .Where(b => !b.IsCalculation)
+                    .Select(b => new InputChoice(b.Name, b.Name, Keep: true))
+                    .ToList();
+                Assert.NotEmpty(inputs); // Refactor must have hoisted A1/B1.
+
+                var lambdaText = LetToLambdaBuilder.Build(
+                    new LambdaGenerationRequest("UNNEST_CHAIN_TEST", parsed, inputs));
+                _output.WriteLine($"LAMBDA:\n{lambdaText}");
+
+                _excel.Workbook.Names.Add("UNNEST_CHAIN_TEST", lambdaText);
+
+                // Invoke the registered LAMBDA, passing the same leaves in
+                // first-seen order (A1, then B1).
+                viaLambda.Formula2 = "=UNNEST_CHAIN_TEST(A1, B1)";
+                _excel.Application.Calculate();
+                var actual = Convert.ToDouble(viaLambda.Value);
+
+                _output.WriteLine($"Original = {expected}, via LAMBDA = {actual}");
+                Assert.Equal(expected, actual);
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(original);
+                Marshal.ReleaseComObject(viaLambda);
+                TryDeleteName("UNNEST_CHAIN_TEST");
+            }
+        }
+        finally
+        {
+            CleanupSheet(ws);
+        }
+    }
+
+    [Fact]
+    public void EmptyOrLiteralCell_HasNoFormula_SoCommandNoOps()
+    {
+        var ws = _excel.AddWorksheet();
+        try
+        {
+            var empty = ws.Range["A1"];
+            var literal = ws.Range["A2"];
+            try
+            {
+                // The /Unnest command opens the dialog only when the active
+                // cell HasFormula; an empty or literal cell makes it return
+                // silently (no dialog, no error).
+                Assert.False((bool)empty.HasFormula);
+
+                literal.Value = 42;
+                Assert.False((bool)literal.HasFormula);
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(empty);
+                Marshal.ReleaseComObject(literal);
+            }
+        }
+        finally
+        {
+            CleanupSheet(ws);
+        }
+    }
+
+    private static void SeedLeaves(dynamic ws)
+    {
+        var a1 = ws.Range["A1"];
+        var b1 = ws.Range["B1"];
+        try
+        {
+            a1.Value = 3;
+            b1.Value = 0;
+        }
+        finally
+        {
+            Marshal.ReleaseComObject(a1);
+            Marshal.ReleaseComObject(b1);
+        }
+    }
+
+    private void TryDeleteName(string name)
+    {
+        try
+        {
+            var n = _excel.Workbook.Names.Item(name);
+            n.Delete();
+            Marshal.ReleaseComObject(n);
+        }
+        catch
+        {
+            // Name was never added or already gone — ignore.
+        }
+    }
+
+    private static void CleanupSheet(dynamic ws)
+    {
+        try
+        {
+            ws.Delete();
+            Marshal.ReleaseComObject(ws);
+        }
+        catch
+        {
+            // Ignore cleanup errors.
+        }
+    }
+}

--- a/addin/lambda-boss.Tests/UnnestEngineTests.cs
+++ b/addin/lambda-boss.Tests/UnnestEngineTests.cs
@@ -56,10 +56,27 @@ public class UnnestEngineTests
     {
         var result = UnnestEngine.Unnest("=ROUND(SQRT(SUM(A1:A10)), 2)");
 
+        // SUM is a 1–3 letter base, so the plain "sum1" looks like a cell
+        // reference (Excel rejects it as a name); the namer separates it as
+        // "sum_1". SQRT is longer, so "sqrt1" stands.
         Assert.Collection(result.Steps,
-            s => AssertStep(s, "sum1", "SUM(A1:A10)", UnnestStepOrigin.Function),
-            s => AssertStep(s, "sqrt1", "SQRT(sum1)", UnnestStepOrigin.Function));
+            s => AssertStep(s, "sum_1", "SUM(A1:A10)", UnnestStepOrigin.Function),
+            s => AssertStep(s, "sqrt1", "SQRT(sum_1)", UnnestStepOrigin.Function));
         Assert.Contains("ROUND(sqrt1, 2)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_ShortFunctionNames_ProduceValidExcelNames()
+    {
+        // Every 1–3 letter function base + digits collides with the cell-ref
+        // pattern; the namer must separate each so the dialog never flags an
+        // auto-name as invalid.
+        var result = UnnestEngine.Unnest("=ABS(MAX(LOG(A1), MIN(B1, C1)))");
+
+        foreach (var step in result.Steps)
+            Assert.True(
+                ExcelNameValidator.Validate(step.Name).IsValid,
+                $"Auto-name '{step.Name}' is not a valid Excel defined name.");
     }
 
     [Fact]

--- a/addin/lambda-boss/Commands/UnnestCommand.cs
+++ b/addin/lambda-boss/Commands/UnnestCommand.cs
@@ -1,0 +1,195 @@
+using ExcelDna.Integration;
+using LambdaBoss.Common;
+using LambdaBoss.UI;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace LambdaBoss.Commands;
+
+/// <summary>
+///     Spec 0009 / issue #272 — slash-command handler for <c>/Unnest</c>.
+///     Reads the active cell's formula, runs <see cref="UnnestEngine" /> to
+///     explode each nested function-call / operator node into a named LET
+///     step, opens <see cref="UnnestToLetWindow" /> on the popup's UI thread,
+///     and on Save writes the synthesised LET back via
+///     <c>activeCell.Formula2</c>. Engine diagnostics (a malformed formula or
+///     an already-LET cell — existing-LET explosion is issue #273) surface via
+///     <see cref="MessageBox" />; empty/literal active cells close the popup
+///     silently (mirrors <c>/Refactor</c>'s pattern).
+/// </summary>
+internal static class UnnestCommand
+{
+    public static void Run()
+    {
+        try
+        {
+            dynamic app = ExcelDnaUtil.Application;
+            var workbook = app.ActiveWorkbook;
+            if (workbook == null)
+                return;
+
+            var activeCell = app.ActiveCell;
+            if (activeCell == null)
+                return;
+
+            var hasFormula = (bool)activeCell.HasFormula;
+            if (!hasFormula)
+                return;
+
+            // Formula2 is the dynamic-array-aware reader — the legacy
+            // Formula property returns `@`-prefixed text for spill-shaped
+            // cells, which would corrupt the decomposition.
+            var formula = (string)activeCell.Formula2;
+
+            // Snapshot the workbook + active-sheet defined-name catalogue once
+            // when the dialog opens so the auto-namer avoids colliding with
+            // workbook names. The engine consults this on every Recompute (no
+            // further COM round-trips).
+            var worksheet = activeCell.Worksheet;
+            var definedNames = SnapshotDefinedNames(workbook, worksheet);
+
+            UnnestResult result;
+            try
+            {
+                result = UnnestEngine.Unnest(formula, definedNames);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Unnest/Engine", ex);
+                ShowError($"Failed to unnest: {ex.Message}");
+                return;
+            }
+
+            if (result.Diagnostic != null)
+            {
+                Logger.Info($"Unnest: refused — {result.Diagnostic.Kind}");
+                ShowError(result.Diagnostic.Message);
+                return;
+            }
+
+            var excelHwnd = new IntPtr(app.Hwnd);
+
+            ShowLambdaPopupCommand.InvokeOnWindowThread(dispatcher =>
+            {
+                string? saved = null;
+
+                dispatcher.Invoke(() =>
+                {
+                    UnnestResult Recompute(IReadOnlyList<UnnestRowState> rows)
+                    {
+                        try
+                        {
+                            return UnnestEngine.Recompute(formula, rows, definedNames);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error("Unnest/Recompute", ex);
+                            // Return the original result so the dialog can keep
+                            // its last-known-good preview rather than tearing
+                            // itself down on a transient error.
+                            return result;
+                        }
+                    }
+
+                    var window = new UnnestToLetWindow(result, Recompute);
+                    var wpfHwnd = new WindowInteropHelper(window).EnsureHandle();
+                    WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
+
+                    if (window.ShowDialog() == true)
+                        saved = window.SavedFormula;
+                });
+
+                if (saved == null) return;
+
+                try
+                {
+                    activeCell.Formula2 = saved;
+                    Logger.Info("Unnest: Wrote LET into active cell");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("Unnest/SetFormula", ex);
+                    ShowError($"Failed to update cell: {ex.Message}");
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Unnest", ex);
+            ShowError($"Unexpected error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    ///     Harvests the workbook-scoped and active-sheet worksheet-scoped
+    ///     defined names so the auto-namer never allocates a step name that
+    ///     shadows an existing defined name. Sheet qualifiers are stripped so
+    ///     the bare identifier (as it would appear in a formula) is compared.
+    ///     Failures are swallowed defensively — a missing catalogue just means
+    ///     the auto-namer has fewer names to avoid.
+    /// </summary>
+    private static HashSet<string> SnapshotDefinedNames(dynamic workbook, dynamic worksheet)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        HarvestNames(names, SafeNames(() => workbook.Names), "workbook");
+        HarvestNames(names, SafeNames(() => worksheet.Names), "worksheet");
+
+        return names;
+    }
+
+    private static dynamic? SafeNames(Func<dynamic?> get)
+    {
+        try
+        {
+            return get();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("Unnest/Snapshot/Names", ex);
+            return null;
+        }
+    }
+
+    private static void HarvestNames(HashSet<string> sink, dynamic? names, string scope)
+    {
+        if (names is null) return;
+        try
+        {
+            var count = (int)names.Count;
+            for (var i = 1; i <= count; i++)
+            {
+                try
+                {
+                    var item = names[i];
+                    if (item.Name is not string key || string.IsNullOrEmpty(key))
+                        continue;
+                    var bang = key.LastIndexOf('!');
+                    if (bang >= 0 && bang + 1 < key.Length)
+                        key = key[(bang + 1)..];
+                    sink.Add(key);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Unnest/Snapshot/{scope}#{i}", ex);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"Unnest/Snapshot/{scope}", ex);
+        }
+    }
+
+    private static void ShowError(string message)
+    {
+        try
+        {
+            MessageBox.Show(message, "Lambda Boss", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch
+        {
+            Logger.Info($"ShowError: {message}");
+        }
+    }
+}

--- a/addin/lambda-boss/UI/LambdaPopup.xaml.cs
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml.cs
@@ -444,6 +444,14 @@ public partial class LambdaPopup
                 ExcelAsyncUtil.QueueAsMacro(() => RefactorCommand.Run());
             }),
         new SlashCommand(
+            "Unnest",
+            "Explode the active cell's nested formula into a =LET(...) with one named step per call",
+            () =>
+            {
+                Hide();
+                ExcelAsyncUtil.QueueAsMacro(() => UnnestCommand.Run());
+            }),
+        new SlashCommand(
             "Load Library",
             "Switch to Library mode to pick a library",
             () =>

--- a/addin/lambda-boss/UI/UnnestToLetWindow.xaml
+++ b/addin/lambda-boss/UI/UnnestToLetWindow.xaml
@@ -1,0 +1,175 @@
+<Window x:Class="LambdaBoss.UI.UnnestToLetWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Lambda Boss — Unnest to LET"
+        Width="640" Height="640"
+        WindowStyle="ToolWindow"
+        ShowInTaskbar="True"
+        Topmost="True"
+        ResizeMode="CanResizeWithGrip"
+        Background="#1e1e1e"
+        PreviewKeyDown="Window_PreviewKeyDown">
+
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="Original formula"
+                   FontSize="13"
+                   FontWeight="Bold"
+                   Foreground="#dcdcaa"
+                   Margin="0,0,0,4" />
+
+        <TextBox x:Name="OriginalFormulaText"
+                 Grid.Row="1"
+                 IsReadOnly="True"
+                 IsReadOnlyCaretVisible="False"
+                 Padding="6,4"
+                 FontSize="12"
+                 FontFamily="Consolas"
+                 Background="#2d2d2d"
+                 Foreground="#cccccc"
+                 BorderBrush="#3e3e3e"
+                 BorderThickness="1"
+                 TextWrapping="Wrap"
+                 AcceptsReturn="True"
+                 VerticalScrollBarVisibility="Auto"
+                 MaxHeight="80" />
+
+        <TextBlock Grid.Row="2"
+                   Text="Steps"
+                   FontSize="13"
+                   FontWeight="Bold"
+                   Foreground="#dcdcaa"
+                   Margin="0,12,0,4" />
+
+        <Border Grid.Row="3"
+                Background="#252526"
+                BorderBrush="#3e3e3e"
+                BorderThickness="1"
+                MaxHeight="260">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <ItemsControl x:Name="StepsList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <DockPanel Margin="4,3">
+                                    <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                                    <CheckBox DockPanel.Dock="Left"
+                                              IsChecked="{Binding Include, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                              VerticalAlignment="Center"
+                                              Margin="0,0,8,0"
+                                              Cursor="Hand"
+                                              ToolTip="Uncheck to inline this step back into its parent" />
+                                    <TextBox DockPanel.Dock="Left"
+                                             Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             IsEnabled="{Binding Include}"
+                                             Width="140"
+                                             Padding="4,2"
+                                             FontFamily="Consolas"
+                                             FontSize="13"
+                                             Background="#1e1e1e"
+                                             Foreground="{Binding NameBrush}"
+                                             CaretBrush="#cccccc"
+                                             BorderBrush="{Binding NameBorderBrush}"
+                                             BorderThickness="1"
+                                             GotFocus="NameTextBox_GotFocus"
+                                             PreviewMouseLeftButtonDown="NameTextBox_PreviewMouseLeftButtonDown" />
+                                    <TextBlock DockPanel.Dock="Right"
+                                               Text="{Binding BadgeText}"
+                                               Foreground="#9cdcfe"
+                                               FontFamily="Consolas"
+                                               FontSize="11"
+                                               FontStyle="Italic"
+                                               VerticalAlignment="Center"
+                                               Margin="8,0,0,0"
+                                               ToolTip="The AST node this step was extracted from" />
+                                    <TextBlock Text="{Binding Rhs}"
+                                               Foreground="{Binding RhsBrush}"
+                                               FontFamily="Consolas"
+                                               FontSize="12"
+                                               VerticalAlignment="Center"
+                                               Margin="8,0,0,0"
+                                               TextTrimming="CharacterEllipsis"
+                                               ToolTip="{Binding Rhs}" />
+                                    <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
+                                </DockPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <TextBlock x:Name="NoStepsText"
+                               Text="Nothing to unnest — this formula has no nested function calls or operator expressions."
+                               Foreground="#808080"
+                               FontSize="12"
+                               FontStyle="Italic"
+                               TextWrapping="Wrap"
+                               Margin="6,8"
+                               Visibility="Collapsed" />
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+
+        <Grid Grid.Row="4" Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0"
+                       Text="Preview"
+                       FontSize="13"
+                       FontWeight="Bold"
+                       Foreground="#dcdcaa"
+                       Margin="0,0,0,4" />
+            <TextBox x:Name="PreviewText"
+                     Grid.Row="1"
+                     IsReadOnly="True"
+                     IsReadOnlyCaretVisible="False"
+                     Padding="6,4"
+                     FontSize="12"
+                     FontFamily="Consolas"
+                     Background="#252526"
+                     Foreground="#cccccc"
+                     BorderBrush="#3e3e3e"
+                     BorderThickness="1"
+                     TextWrapping="NoWrap"
+                     AcceptsReturn="True"
+                     VerticalScrollBarVisibility="Auto"
+                     HorizontalScrollBarVisibility="Auto" />
+        </Grid>
+
+        <DockPanel Grid.Row="5" Margin="0,12,0,0">
+            <Button x:Name="CancelButton"
+                    DockPanel.Dock="Right"
+                    Content="Cancel"
+                    Padding="16,4"
+                    Margin="6,0,0,0"
+                    Background="Transparent"
+                    Foreground="#cccccc"
+                    BorderBrush="#3e3e3e"
+                    BorderThickness="1"
+                    Cursor="Hand"
+                    Click="CancelButton_Click" />
+            <Button x:Name="SaveButton"
+                    DockPanel.Dock="Right"
+                    Content="Save"
+                    Padding="16,4"
+                    Cursor="Hand"
+                    Background="#0e639c"
+                    Foreground="#ffffff"
+                    BorderThickness="0"
+                    Click="SaveButton_Click" />
+            <TextBlock x:Name="StatusText"
+                       Foreground="#808080"
+                       FontSize="11"
+                       VerticalAlignment="Center" />
+        </DockPanel>
+    </Grid>
+</Window>

--- a/addin/lambda-boss/UI/UnnestToLetWindow.xaml.cs
+++ b/addin/lambda-boss/UI/UnnestToLetWindow.xaml.cs
@@ -1,0 +1,349 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace LambdaBoss.UI;
+
+/// <summary>
+///     Spec 0009 / issue #272 — the <c>/Unnest</c> dialog. Shows the active
+///     cell's original formula, one row per extracted step (leaf-first) with
+///     an editable live-validated name, the read-only RHS (child references
+///     already substituted to step names), an origin badge ("function: SUMSQ"
+///     / "operator: −"), and an Include checkbox (default on — un-checking
+///     inlines the step back into its parent), plus a live preview of the
+///     synthesised LET. Save returns the preview text via
+///     <see cref="SavedFormula" />; Cancel discards.
+///
+///     <para>
+///     The code-behind is intentionally thin: every row-state change (rename
+///     or Include toggle) calls back into the supplied <c>recompute</c>
+///     delegate (which wraps <see cref="UnnestEngine.Recompute" />), and the
+///     result replaces the preview + RHS text in place. Row Keys drive the
+///     identity round-trip with the engine. There are no reorder controls —
+///     step order is forced by data dependency.
+///     </para>
+/// </summary>
+public partial class UnnestToLetWindow
+{
+    private const string InvalidNameStatusText = "Fix invalid names before saving";
+
+    private readonly Func<IReadOnlyList<UnnestRowState>, UnnestResult> _recompute;
+    private readonly ObservableCollection<UnnestStepRowVm> _rows = [];
+
+    private UnnestResult _result;
+
+    // Tracks the last name-validation outcome so the status bar can choose
+    // between a validation error and the summary count.
+    private bool _namesValid = true;
+
+    // Reentrancy guard: rebuilding the row list during a Recompute fires
+    // INotifyPropertyChanged on each VM, which would re-enter the change
+    // handler. The guard short-circuits the nested calls so a single user
+    // action yields exactly one engine call.
+    private bool _suppressRecompute;
+
+    public UnnestToLetWindow(
+        UnnestResult initial,
+        Func<IReadOnlyList<UnnestRowState>, UnnestResult> recompute)
+    {
+        InitializeComponent();
+        _result = initial;
+        _recompute = recompute;
+
+        OriginalFormulaText.Text = initial.OriginalFormula;
+        PreviewText.Text = initial.SynthesisedLet;
+
+        BuildRowsFromSteps(initial.Steps);
+        StepsList.ItemsSource = _rows;
+
+        NoStepsText.Visibility = _rows.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+
+        UpdateSaveButtonEnabled(RevalidateNames());
+    }
+
+    /// <summary>Populated on Save; null when cancelled.</summary>
+    public string? SavedFormula { get; private set; }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        SavedFormula = _result.SynthesisedLet;
+        DialogResult = true;
+        Close();
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        SavedFormula = null;
+        DialogResult = false;
+        Close();
+    }
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            CancelButton_Click(this, new RoutedEventArgs());
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Enter
+            && (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control
+            && SaveButton.IsEnabled)
+        {
+            SaveButton_Click(this, new RoutedEventArgs());
+            e.Handled = true;
+        }
+    }
+
+    private void NameTextBox_GotFocus(object sender, RoutedEventArgs e)
+    {
+        if (sender is TextBox tb)
+            tb.SelectAll();
+    }
+
+    private void NameTextBox_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not TextBox tb) return;
+        if (tb.IsKeyboardFocusWithin) return;
+        tb.Focus();
+        e.Handled = true;
+    }
+
+    private void BuildRowsFromSteps(IReadOnlyList<UnnestStepRow> steps)
+    {
+        _suppressRecompute = true;
+        try
+        {
+            foreach (var v in _rows)
+                v.PropertyChanged -= Row_PropertyChanged;
+            _rows.Clear();
+
+            foreach (var step in steps)
+            {
+                var vm = new UnnestStepRowVm(step);
+                vm.PropertyChanged += Row_PropertyChanged;
+                _rows.Add(vm);
+            }
+        }
+        finally
+        {
+            _suppressRecompute = false;
+        }
+    }
+
+    private void Row_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_suppressRecompute) return;
+        if (e.PropertyName is not (nameof(UnnestStepRowVm.Name)
+            or nameof(UnnestStepRowVm.Include)))
+            return;
+
+        UpdateSaveButtonEnabled(RevalidateNames());
+        RecomputeAndRefresh();
+    }
+
+    private void RecomputeAndRefresh()
+    {
+        var rowStates = _rows
+            .Select(r => new UnnestRowState(r.Key, r.Name, r.Include))
+            .ToList();
+
+        var newResult = _recompute(rowStates);
+        if (newResult.Diagnostic != null)
+            return;
+
+        _suppressRecompute = true;
+        try
+        {
+            _result = newResult;
+            PreviewText.Text = newResult.SynthesisedLet;
+
+            // The engine re-renders each step's RHS as Include toggles change
+            // which children collapse to names; push the fresh text back into
+            // the existing VMs (matched by Key) so the row list stays stable.
+            var rhsByKey = newResult.Steps.ToDictionary(s => s.Key, s => s.Rhs, StringComparer.Ordinal);
+            foreach (var vm in _rows)
+                if (rhsByKey.TryGetValue(vm.Key, out var rhs))
+                    vm.Rhs = rhs;
+        }
+        finally
+        {
+            _suppressRecompute = false;
+        }
+
+        RefreshStatusText();
+    }
+
+    /// <summary>
+    ///     Stamps each row's <see cref="UnnestStepRowVm.IsNameValid" /> based on
+    ///     per-row canonicality (shape, via <see cref="ExcelNameValidator" />)
+    ///     and cross-row uniqueness among included rows. Un-included rows are
+    ///     never invalid (their name isn't emitted). Returns true when every
+    ///     included row is valid AND no duplicates exist.
+    /// </summary>
+    private bool RevalidateNames()
+    {
+        var included = _rows.Where(r => r.Include).ToList();
+        var dupes = included
+            .GroupBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .SelectMany(g => g)
+            .ToHashSet();
+
+        var allValid = true;
+        foreach (var vm in _rows)
+        {
+            bool valid;
+            if (!vm.Include)
+                valid = true;
+            else
+            {
+                var shapeOk = ExcelNameValidator.Validate(vm.Name).IsValid;
+                valid = shapeOk && !dupes.Contains(vm);
+                if (!valid) allValid = false;
+            }
+
+            vm.IsNameValid = valid;
+        }
+
+        return allValid;
+    }
+
+    private void UpdateSaveButtonEnabled(bool allValid)
+    {
+        _namesValid = allValid;
+        // A zero-step formula (or one with every step inlined) still produces a
+        // valid no-op rewrite, so Save stays enabled — there's simply nothing
+        // to change. Only invalid names block Save.
+        SaveButton.IsEnabled = allValid;
+        RefreshStatusText();
+    }
+
+    private void RefreshStatusText()
+    {
+        if (!_namesValid)
+        {
+            StatusText.Text = InvalidNameStatusText;
+            return;
+        }
+
+        var stepCount = _rows.Count(r => r.Include);
+        StatusText.Text = stepCount switch
+        {
+            0 => "No steps — nothing to unnest",
+            1 => "1 step",
+            _ => stepCount + " steps"
+        };
+    }
+}
+
+/// <summary>
+///     Row view-model bound to <see cref="UnnestToLetWindow" />'s steps list.
+///     Carries the step's <see cref="Key" /> identity (used to round-trip user
+///     state back to the engine via <see cref="UnnestRowState" />), the
+///     user-editable <see cref="Name" /> + <see cref="Include" />, the
+///     read-only <see cref="Rhs" /> (refreshed by the engine as Include
+///     toggles change which children collapse to names), and the origin
+///     <see cref="BadgeText" />. <see cref="IsNameValid" /> is set by the
+///     dialog on every validation pass and drives the red border on the Name
+///     TextBox.
+/// </summary>
+public class UnnestStepRowVm : INotifyPropertyChanged
+{
+    private static readonly Brush ActiveNameBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#dcdcaa"));
+
+    private static readonly Brush ActiveRhsBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#cccccc"));
+
+    private static readonly Brush MutedBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#6a6a6a"));
+
+    private static readonly Brush InvalidNameBorderBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#f48771"));
+
+    private static readonly Brush DefaultNameBorderBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#3e3e3e"));
+
+    private bool _include = true;
+    private bool _isNameValid = true;
+    private string _name;
+    private string _rhs;
+
+    public UnnestStepRowVm(UnnestStepRow step)
+    {
+        Key = step.Key;
+        _name = step.Name;
+        _rhs = step.Rhs;
+        _include = step.Include;
+        BadgeText = step.Origin == UnnestStepOrigin.Function
+            ? "function: " + step.OriginLabel
+            : "operator: " + step.OriginLabel;
+    }
+
+    public string Key { get; }
+    public string BadgeText { get; }
+
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            if (_name == value) return;
+            _name = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string Rhs
+    {
+        get => _rhs;
+        set
+        {
+            if (_rhs == value) return;
+            _rhs = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool Include
+    {
+        get => _include;
+        set
+        {
+            if (_include == value) return;
+            _include = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(NameBrush));
+            OnPropertyChanged(nameof(RhsBrush));
+        }
+    }
+
+    public bool IsNameValid
+    {
+        get => _isNameValid;
+        set
+        {
+            if (_isNameValid == value) return;
+            _isNameValid = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(NameBorderBrush));
+        }
+    }
+
+    public Brush NameBrush => Include ? ActiveNameBrush : MutedBrush;
+    public Brush RhsBrush => Include ? ActiveRhsBrush : MutedBrush;
+    public Brush NameBorderBrush => IsNameValid ? DefaultNameBorderBrush : InvalidNameBorderBrush;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? prop = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+    }
+}

--- a/addin/lambda-boss/UnnestEngine.cs
+++ b/addin/lambda-boss/UnnestEngine.cs
@@ -361,13 +361,28 @@ public static class UnnestEngine
     ///     Allocates the smallest <c>base + N</c> (N ≥ 1) not already in
     ///     <paramref name="used" />, and records it. A base used once still gets
     ///     its <c>1</c> suffix, so renumbering never shifts as the formula grows.
+    ///
+    ///     <para>
+    ///     A short base (1–3 letters) followed by digits looks like a cell
+    ///     reference — <c>SUM1</c>, <c>LOG2</c>, <c>ABS1</c> are all valid cell
+    ///     addresses (the column letters are ≤ <c>XFD</c>), so Excel refuses
+    ///     them as defined names and the dialog would flag the auto-name as
+    ///     invalid. When <c>base + N</c> fails <see cref="ExcelNameValidator" />
+    ///     for that (or any other) reason, an underscore separator is inserted
+    ///     (<c>sum_1</c>) so the auto-name is always a legal name. Longer bases
+    ///     (<c>sumsq1</c>, <c>sqrt1</c>, <c>calc1</c>) are unaffected.
+    ///     </para>
     /// </summary>
     private static string AllocateName(string baseName, HashSet<string> used)
     {
         var n = 1;
         while (true)
         {
-            var candidate = baseName + n.ToString(CultureInfo.InvariantCulture);
+            var suffix = n.ToString(CultureInfo.InvariantCulture);
+            var plain = baseName + suffix;
+            var candidate = ExcelNameValidator.Validate(plain).IsValid
+                ? plain
+                : baseName + "_" + suffix;
             if (used.Add(candidate))
                 return candidate;
             n++;


### PR DESCRIPTION
Closes #272 — part of #269, spec [0009](specs/0009-unnest-to-let.md). Builds on the parser (#270) and decomposition engine (#271); this PR is the UI and wiring layer, modelled on `RefactorToLetWindow` / `RefactorCommand`.

## What's here

**`/Unnest` slash command** (`UnnestCommand`)
- Registered in the main popup's command registry.
- Activation matches `/Refactor`: active cell holds a formula → open dialog; empty/literal cell → silent no-op (returns on `!HasFormula`).
- Reads/writes via `Range.Formula2`. Snapshots workbook + active-sheet defined names once so the auto-namer never shadows an existing name.
- Engine diagnostics (malformed formula, or a cell that's already a `=LET(...)` — existing-LET explosion is #273) surface via a message box, no dialog.

**`UnnestToLetWindow`** (WPF)
- Read-only header: original formula.
- One row per step, leaf-first: live-validated **name** editor (reuses `ExcelNameValidator` + cross-row uniqueness), read-only **RHS** (child refs already substituted to step names), **Origin** badge (`function: SUMSQ` / `operator: −`), **Include** checkbox (default on — un-checking inlines the step into its parent; the engine re-renders RHSs in place).
- Live **Preview** via `FormulaFormatter`, recomputed on every rename / Include toggle.
- **Save** writes the synthesised LET via `Formula2`; **Cancel** discards. Escape cancels, Ctrl+Enter saves. No reorder controls (order forced by dependency).
- A zero-step formula (e.g. `=A1+B1`) opens the dialog showing "nothing to unnest"; Save is a no-op rewrite (discoverable, per spec).

## Tests

- `lambda-boss.Tests` — all 1427 pass (unchanged).
- `lambda-boss.AddinTests` (real Excel) — 3 new, all green:
  - Synthesised LET is accepted by Excel, round-trips through `LetParser`, and preserves the original cell value.
  - Full `/Unnest → /Refactor → /LET to LAMBDA` chain produces a working LAMBDA computing the same value as the original.
  - Empty/literal cell has no formula → the command's activation guard no-ops silently.

The dialog itself is a modal WPF window and isn't driven headless; its behaviour is covered by the engine's unit tests (#271) plus the round-trip AddinTests, with manual UI testing to follow.