### PR TITLE
Treat inner LAMBDA / nested LET as opaque in Unnest — #278

### DIFF
--- a/addin/lambda-boss.Tests/UnnestEngineTests.cs
+++ b/addin/lambda-boss.Tests/UnnestEngineTests.cs
@@ -247,6 +247,114 @@ public class UnnestEngineTests
         Assert.All(parsed.Bindings, b => Assert.True(b.IsCalculation));
     }
 
+    // ---------------- scope: opaque LAMBDA / nested LET (#278) ----------------
+
+    [Fact]
+    public void Unnest_InnerLambda_KeptIntactAndNotDecomposed()
+    {
+        // BYROW's lambda binds 'r'; SUM(r) / MAX(r) inside it must NOT be
+        // hoisted (they'd reference an unbound 'r' at the top level). The whole
+        // lambda stays inline in byrow1's RHS.
+        var result = UnnestEngine.Unnest("=ROUND(BYROW(A1:B3, LAMBDA(r, SUM(r) + MAX(r))), 2)");
+
+        var step = Assert.Single(result.Steps);
+        Assert.Equal("byrow1", step.Name);
+        Assert.Equal("BYROW(A1:B3, LAMBDA(r, SUM(r) + MAX(r)))", step.Rhs);
+        Assert.Contains("ROUND(byrow1, 2)", result.SynthesisedLet);
+
+        // Round-trips, and no binding ever references the bound param 'r'.
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.Equal(new[] { "byrow1" }, parsed.Bindings.Select(b => b.Name).ToArray());
+    }
+
+    [Fact]
+    public void Unnest_StructureAroundLambda_DecomposesButLeavesLambdaIntact()
+    {
+        // SQRT(A1:B3) (BYROW's first arg) is outside the lambda → a step;
+        // AVERAGE / BYROW outside too → steps. SUM(r) inside the lambda stays.
+        var result = UnnestEngine.Unnest(
+            "=ROUND(AVERAGE(BYROW(SQRT(A1:B3), LAMBDA(r, SUM(r)))), 2)");
+
+        Assert.Equal(
+            new[] { "sqrt1", "byrow1", "average1" },
+            result.Steps.Select(s => s.Name).ToArray());
+        Assert.Equal("BYROW(sqrt1, LAMBDA(r, SUM(r)))",
+            Assert.Single(result.Steps, s => s.Name == "byrow1").Rhs);
+
+        // SUM(r) was never extracted as its own step.
+        Assert.DoesNotContain(result.Steps, s => s.Rhs == "SUM(r)");
+    }
+
+    [Fact]
+    public void Unnest_NestedDoubleLambda_AllParamDependentNodesStayInline()
+    {
+        // Mirrors the reported case: two nested lambdas (binds r, then a/b).
+        // Everything inside either lambda must stay inline.
+        const string formula =
+            "=ROUND(BYROW(A1:B3, LAMBDA(r, SUM(PAIROP(r, LAMBDA(a, b, SQRT(SUMSQ(VSTACK(a, b)))), , 1)))), 2)";
+        var result = UnnestEngine.Unnest(formula);
+
+        var step = Assert.Single(result.Steps);
+        Assert.Equal("byrow1", step.Name);
+        // The full nested-lambda payload survives verbatim in the RHS.
+        Assert.Contains("LAMBDA(a, b, SQRT(SUMSQ(VSTACK(a, b))))", step.Rhs);
+        // None of the lambda-interior nodes leaked out as their own step
+        // (a node "leaks" only if it became a step, i.e. carries that
+        // OriginLabel — its appearance inside the kept lambda's RHS is fine).
+        Assert.DoesNotContain(result.Steps,
+            s => s.OriginLabel is "VSTACK" or "SUMSQ" or "PAIROP" or "SQRT" or "SUM");
+    }
+
+    [Fact]
+    public void Unnest_NestedLetSubExpression_IsOpaque()
+    {
+        // A nested LET binds 'x' inside itself; the engine treats it as opaque
+        // (it is never the root here, so the top-level refusal doesn't apply).
+        var result = UnnestEngine.Unnest("=ROUND(LET(x, A1, x + 1), 2)");
+
+        Assert.Null(result.Diagnostic);
+        Assert.Empty(result.Steps);
+        Assert.Equal("=ROUND(LET(x, A1, x + 1), 2)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_RootLambda_ZeroStepsNoOp()
+    {
+        var result = UnnestEngine.Unnest("=LAMBDA(x, x + 1)");
+
+        Assert.Null(result.Diagnostic);
+        Assert.Empty(result.Steps);
+        Assert.Equal("=LAMBDA(x, x + 1)", result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_ReportedFormula_DecomposesOuterNestKeepsLambdasIntact()
+    {
+        const string formula =
+            "=ROUND(MIN(BIROW(HSTACK(IFS(SEQUENCE(6), \"Vienna\"), " +
+            "PERMUTATIONS(XLOOKUP(G141:I141,t[Concat], t[City]),3)), " +
+            "LAMBDA(r, SUM(PAIROP(r, LAMBDA(a,b, SQRT(SUMSQ(PAIROP(XV(VSTACK(a,b), " +
+            "t[[City]:[Y-Coordinates]], {2,3}),,1)))*100),,1)))))+45,)";
+
+        var result = UnnestEngine.Unnest(formula);
+
+        Assert.Null(result.Diagnostic);
+
+        // Outer (non-lambda) structure decomposes — e.g. the XLOOKUP inside HSTACK
+        // becomes its own step.
+        Assert.Contains(result.Steps, s => s.OriginLabel == "XLOOKUP");
+
+        // Nothing from inside the lambdas leaks out as its own step.
+        Assert.DoesNotContain(result.Steps,
+            s => s.OriginLabel is "VSTACK" or "SUMSQ" or "XV" or "PAIROP" or "SQRT" or "SUM");
+        // The param-dependent expression stays inline within the kept lambda.
+        Assert.Contains("VSTACK(a, b)", result.SynthesisedLet);
+
+        // The whole thing still round-trips through LetParser.
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+        Assert.NotEmpty(parsed.Bindings);
+    }
+
     // ---------------- guards ----------------
 
     [Fact]

--- a/addin/lambda-boss/UnnestEngine.cs
+++ b/addin/lambda-boss/UnnestEngine.cs
@@ -12,7 +12,12 @@ namespace LambdaBoss;
 ///     to step names. Reference operators (range <c>:</c> and intersection
 ///     <c>space</c>) are treated as leaves, never steps — matching the parser's
 ///     "ranges are non-steps" rule. Unary expressions and postfix <c>%</c>/<c>#</c>
-///     also stay inline.
+///     also stay inline. A name-binding construct (a <c>LAMBDA(...)</c> or a
+///     nested <c>LET(...)</c>) is <em>opaque</em>: its body binds names that
+///     exist only inside it, so the engine never descends into it nor emits it
+///     as a step — hoisting a sub-expression out of that scope would leave the
+///     bound names unbound (issue #278). Decomposing inside a lambda via a
+///     scoped nested LET is a future enhancement (issue #279).
 ///
 ///     <para>
 ///     The decomposition is maximally granular by default; the dialog's per-row
@@ -180,12 +185,36 @@ public static class UnnestEngine
     }
 
     /// <summary>
+    ///     True when <paramref name="node" /> is a name-binding construct — a
+    ///     <c>LAMBDA(...)</c> or a (nested) <c>LET(...)</c>. Both bind names
+    ///     scoped to their own body: a <c>LAMBDA</c>'s parameters and a
+    ///     <c>LET</c>'s bindings exist only inside the construct. Hoisting any
+    ///     sub-expression out of that scope into the top-level LET would leave
+    ///     those names unbound and break the formula, so the engine treats the
+    ///     whole construct as opaque — it is never descended into and never
+    ///     emitted as a step, staying inline in its parent's RHS verbatim.
+    ///     (Top-level LET is refused earlier, so only nested LETs reach here.
+    ///     Decomposing inside a lambda via a scoped nested LET is issue #279.)
+    /// </summary>
+    private static bool IsScopeIntroducing(FormulaNode node)
+    {
+        if (node is not FunctionCallNode fc) return false;
+        var name = FunctionBaseName(fc.Name);
+        return name is "lambda" or "let";
+    }
+
+    /// <summary>
     ///     Post-order walk appending step candidates leaf-first. The root is
     ///     never a step (it becomes the LET body), so <paramref name="isRoot" />
     ///     suppresses its own emission while still descending into its children.
+    ///     A scope-introducing node (<see cref="IsScopeIntroducing" />) is opaque
+    ///     — neither descended into nor emitted — so nothing escapes its scope.
     /// </summary>
     private static void CollectSteps(FormulaNode node, bool isRoot, List<FormulaNode> sink)
     {
+        if (IsScopeIntroducing(node))
+            return;
+
         foreach (var child in Children(node))
             CollectSteps(child, isRoot: false, sink);
 


### PR DESCRIPTION
Closes #278.

## Problem

`/Unnest` parsed an inner `LAMBDA(...)` as an ordinary function call and descended into its body, hoisting nested sub-expressions into the top-level `LET`. Any step that referenced a LAMBDA parameter then escaped the scope where that parameter was bound — producing a **broken formula**. For example, on a formula containing `LAMBDA(a, b, … VSTACK(a, b) …)`, `/Unnest` lifted `VSTACK(a, b)` into its own top-level binding where `a` and `b` are unbound.

The same bug class applies to a nested `LET(...)` used as a sub-expression. `LET` and `LAMBDA` are the two name-binding constructs; both introduce scope the hoister must respect.

## Fix (opaque LAMBDA/LET — Option 1)

`UnnestEngine.CollectSteps` now treats a name-binding construct as **opaque**: it is never descended into and never emitted as a step, so it stays inline in its parent's RHS exactly as written. Everything *outside* lambdas decomposes as before. (Top-level LET is already refused upstream, so only nested LETs reach this path.)

On the reported formula, the outer nest (`ROUND / MIN / BIROW / HSTACK / IFS / SEQUENCE / PERMUTATIONS / XLOOKUP`, `+45`) decomposes into steps while both lambdas — and all their interiors — stay intact:

```
…
xlookup1,      XLOOKUP(G141:I141, t[Concat], t[City]),
permutations1, PERMUTATIONS(xlookup1, 3),
hstack1,       HSTACK(ifs1, permutations1),
birow1,        BIROW(hstack1, LAMBDA(r, SUM(PAIROP(r, LAMBDA(a, b, SQRT(SUMSQ(PAIROP(XV(VSTACK(a, b), …), , 1))) * 100), , 1)))),
min1,          MIN(birow1),
calc1,         min1 + 45,
ROUND(calc1, )
```

Step-level decomposition *inside* lambdas (via a scoped nested LET) is the follow-up enhancement #279 (needs a spec + Tim's approval).

## Tests

Six new `UnnestEngineTests`:
- inner lambda kept intact, not decomposed;
- outer structure around a lambda still decomposes (lambda's non-lambda sibling args become steps);
- nested double-lambda — every param-dependent node stays inline;
- nested `LET(...)` sub-expression is opaque;
- root `LAMBDA(...)` → zero-step no-op;
- the exact reported formula: outer nest decomposes, lambdas stay intact, round-trips through `LetParser` (also confirms the parser handles table refs, `{2,3}` array constants, empty args, and double-nested lambdas).

Full unit suite: 1433/1433 pass.

Independent of #277 (the `/Unnest` dialog) — different engine methods, no overlap; merges cleanly in either order.