### PR TITLE
Add existing-LET handling to Unnest — #273

### DIFF
--- a/addin/lambda-boss.Tests/UnnestEngineTests.cs
+++ b/addin/lambda-boss.Tests/UnnestEngineTests.cs
@@ -3,11 +3,16 @@ using Xunit;
 namespace LambdaBoss.Tests;
 
 /// <summary>
-///     Spec 0009 / issue #271 — <see cref="UnnestEngine" /> tests for the non-LET
-///     decomposition path. Covers the worked example, function-only and
+///     Spec 0009 / issues #271, #273 — <see cref="UnnestEngine" /> tests. The
+///     non-LET path (#271) covers the worked example, function-only and
 ///     operator-only formulas, the single-root no-op, function-derived + calcN
 ///     naming with collision suffixing, Include-toggle inlining + re-parenting,
-///     and round-trip safety through <see cref="LetParser" />.
+///     and round-trip safety through <see cref="LetParser" />. The existing-LET
+///     path (#273) covers calc-binding + body explosion with value bindings and
+///     binding order preserved, new-step insertion before each owning binding,
+///     auto-naming around existing binding names, the already-decomposed no-op,
+///     inner-lambda opacity, Include-toggle inlining, round-trip, and the
+///     malformed-LET refusal.
 /// </summary>
 public class UnnestEngineTests
 {
@@ -372,18 +377,166 @@ public class UnnestEngineTests
         Assert.NotEmpty(parsed.Bindings);
     }
 
-    // ---------------- guards ----------------
+    // ---------------- existing-LET explosion (#273) ----------------
 
     [Fact]
-    public void Unnest_ExistingLet_RefusesWithDiagnostic()
+    public void Unnest_ExistingLet_ExplodesCalcBindingsAndBodyPreservesValueBindings()
     {
-        var result = UnnestEngine.Unnest("=LET(x, A1, x+1)");
+        // a, A1 is a value binding (preserved verbatim). b's RHS nests SQRT
+        // (→ sqrt1 inserted before b); the body nests b * 2 (→ calc1 before body).
+        var result = UnnestEngine.Unnest("=LET(a, A1, b, ROUND(SQRT(A2), 2), a + b * 2)");
+
+        Assert.Null(result.Diagnostic);
+        Assert.Collection(result.Steps,
+            s => AssertStep(s, "sqrt1", "SQRT(A2)", UnnestStepOrigin.Function),
+            s => AssertStep(s, "calc1", "b * 2", UnnestStepOrigin.Operator));
+
+        const string expected =
+            "=LET(\n" +
+            "    a, A1,\n" +
+            "    sqrt1, SQRT(A2),\n" +
+            "    b, ROUND(sqrt1, 2),\n" +
+            "    calc1, b * 2,\n" +
+            "    a + calc1\n" +
+            ")";
+        Assert.Equal(expected, result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_ExistingLet_NewStepsInsertedBeforeEachOwningBinding()
+    {
+        // Two calc bindings each nest a SQRT; each new step lands just before
+        // its own binding and existing binding order is preserved.
+        var result = UnnestEngine.Unnest("=LET(p, SQRT(A1) + 1, q, SQRT(B1) * 2, p + q)");
+
+        Assert.Collection(result.Steps,
+            s => Assert.Equal("sqrt1", s.Name),
+            s => Assert.Equal("sqrt2", s.Name));
+
+        const string expected =
+            "=LET(\n" +
+            "    sqrt1, SQRT(A1),\n" +
+            "    p, sqrt1 + 1,\n" +
+            "    sqrt2, SQRT(B1),\n" +
+            "    q, sqrt2 * 2,\n" +
+            "    p + q\n" +
+            ")";
+        Assert.Equal(expected, result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_ExistingLet_AutoNameAvoidsExistingBindingNames()
+    {
+        // 'sqrt1' is already a (value) binding name, so the SQRT step extracted
+        // from r's RHS must skip ahead to 'sqrt2'.
+        var result = UnnestEngine.Unnest("=LET(sqrt1, X1, r, SQRT(A2) + 1, r)");
+
+        var step = Assert.Single(result.Steps);
+        Assert.Equal("sqrt2", step.Name);
+
+        const string expected =
+            "=LET(\n" +
+            "    sqrt1, X1,\n" +
+            "    sqrt2, SQRT(A2),\n" +
+            "    r, sqrt2 + 1,\n" +
+            "    r\n" +
+            ")";
+        Assert.Equal(expected, result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_ExistingLet_AlreadyDecomposed_IsNoOp()
+    {
+        // No calc binding RHS or body nests anything → nothing to extract →
+        // the original LET is returned verbatim (no cosmetic re-spacing).
+        const string formula = "=LET(a, A1, b, SUM(a), a + b)";
+        var result = UnnestEngine.Unnest(formula);
+
+        Assert.Null(result.Diagnostic);
+        Assert.Empty(result.Steps);
+        Assert.Equal(formula, result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_ExistingLet_InnerLambdaStaysOpaque()
+    {
+        // ROUND wraps a BYROW whose lambda binds 'r'; BYROW becomes its own step
+        // but the lambda interior (SUM(r) + MAX(r)) is never hoisted out.
+        var result = UnnestEngine.Unnest(
+            "=LET(a, A1, b, ROUND(BYROW(A1:B3, LAMBDA(r, SUM(r) + MAX(r))), 2), a + b)");
+
+        var step = Assert.Single(result.Steps);
+        Assert.Equal("byrow1", step.Name);
+        Assert.Equal("BYROW(A1:B3, LAMBDA(r, SUM(r) + MAX(r)))", step.Rhs);
+        Assert.DoesNotContain(result.Steps, s => s.OriginLabel is "SUM" or "MAX");
+
+        const string expected =
+            "=LET(\n" +
+            "    a, A1,\n" +
+            "    byrow1, BYROW(A1:B3, LAMBDA(r, SUM(r) + MAX(r))),\n" +
+            "    b, ROUND(byrow1, 2),\n" +
+            "    a + b\n" +
+            ")";
+        Assert.Equal(expected, result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Recompute_ExistingLet_UnIncludeNewStep_InlinesItBackIntoBody()
+    {
+        const string formula = "=LET(a, A1, b, ROUND(SQRT(A2), 2), a + b * 2)";
+        var initial = UnnestEngine.Unnest(formula);
+
+        // Drop calc1 (the body's 'b * 2'); keep sqrt1.
+        var states = initial.Steps
+            .Select(s => new UnnestRowState(s.Key, s.Name, Include: s.Name != "calc1"))
+            .ToList();
+
+        var result = UnnestEngine.Recompute(formula, states);
+
+        var calc1 = Assert.Single(result.Steps, s => s.Name == "calc1");
+        Assert.False(calc1.Include);
+
+        const string expected =
+            "=LET(\n" +
+            "    a, A1,\n" +
+            "    sqrt1, SQRT(A2),\n" +
+            "    b, ROUND(sqrt1, 2),\n" +
+            "    a + b * 2\n" +
+            ")";
+        Assert.Equal(expected, result.SynthesisedLet);
+    }
+
+    [Fact]
+    public void Unnest_ExistingLet_SynthesisedLetRoundTripsThroughLetParser()
+    {
+        var result = UnnestEngine.Unnest("=LET(a, A1, b, ROUND(SQRT(A2), 2), a + b * 2)");
+
+        var parsed = LetParser.Parse(result.SynthesisedLet);
+
+        Assert.Equal(
+            new[] { "a", "sqrt1", "b", "calc1" },
+            parsed.Bindings.Select(b => b.Name).ToArray());
+        Assert.Equal("a + calc1", parsed.Body);
+        // 'a' is the only non-calculation (value) binding; the rest are steps.
+        var a = Assert.Single(parsed.Bindings, b => b.Name == "a");
+        Assert.False(a.IsCalculation);
+    }
+
+    [Fact]
+    public void Unnest_MalformedLet_RefusesWithDiagnosticNoDialog()
+    {
+        // Even arg count → LetParser rejects it as a malformed LET.
+        const string formula = "=LET(a, A1, b, B1)";
+        var result = UnnestEngine.Unnest(formula);
 
         Assert.NotNull(result.Diagnostic);
-        Assert.Equal(UnnestDiagnosticKind.ExistingLet, result.Diagnostic!.Kind);
+        Assert.Equal(UnnestDiagnosticKind.MalformedLet, result.Diagnostic!.Kind);
+        Assert.StartsWith("Could not parse LET formula:", result.Diagnostic.Message);
         Assert.Empty(result.Steps);
-        Assert.Equal("=LET(x, A1, x+1)", result.SynthesisedLet);
+        Assert.Equal(formula, result.SynthesisedLet);
     }
+
+    // ---------------- guards ----------------
 
     [Fact]
     public void Unnest_MalformedFormula_RefusesWithDiagnostic()

--- a/addin/lambda-boss/Commands/UnnestCommand.cs
+++ b/addin/lambda-boss/Commands/UnnestCommand.cs
@@ -12,10 +12,10 @@ namespace LambdaBoss.Commands;
 ///     explode each nested function-call / operator node into a named LET
 ///     step, opens <see cref="UnnestToLetWindow" /> on the popup's UI thread,
 ///     and on Save writes the synthesised LET back via
-///     <c>activeCell.Formula2</c>. Engine diagnostics (a malformed formula or
-///     an already-LET cell — existing-LET explosion is issue #273) surface via
-///     <see cref="MessageBox" />; empty/literal active cells close the popup
-///     silently (mirrors <c>/Refactor</c>'s pattern).
+///     <c>activeCell.Formula2</c>. An already-<c>=LET(...)</c> cell is exploded
+///     binding-by-binding (issue #273). Engine diagnostics (a malformed formula
+///     or a malformed LET) surface via <see cref="MessageBox" />; empty/literal
+///     active cells close the popup silently (mirrors <c>/Refactor</c>'s pattern).
 /// </summary>
 internal static class UnnestCommand
 {

--- a/addin/lambda-boss/UI/UnnestToLetWindow.xaml.cs
+++ b/addin/lambda-boss/UI/UnnestToLetWindow.xaml.cs
@@ -17,14 +17,13 @@ namespace LambdaBoss.UI;
 ///     inlines the step back into its parent), plus a live preview of the
 ///     synthesised LET. Save returns the preview text via
 ///     <see cref="SavedFormula" />; Cancel discards.
-///
 ///     <para>
-///     The code-behind is intentionally thin: every row-state change (rename
-///     or Include toggle) calls back into the supplied <c>recompute</c>
-///     delegate (which wraps <see cref="UnnestEngine.Recompute" />), and the
-///     result replaces the preview + RHS text in place. Row Keys drive the
-///     identity round-trip with the engine. There are no reorder controls —
-///     step order is forced by data dependency.
+///         The code-behind is intentionally thin: every row-state change (rename
+///         or Include toggle) calls back into the supplied <c>recompute</c>
+///         delegate (which wraps <see cref="UnnestEngine.Recompute" />), and the
+///         result replaces the preview + RHS text in place. Row Keys drive the
+///         identity round-trip with the engine. There are no reorder controls —
+///         step order is forced by data dependency.
 ///     </para>
 /// </summary>
 public partial class UnnestToLetWindow
@@ -34,11 +33,11 @@ public partial class UnnestToLetWindow
     private readonly Func<IReadOnlyList<UnnestRowState>, UnnestResult> _recompute;
     private readonly ObservableCollection<UnnestStepRowVm> _rows = [];
 
-    private UnnestResult _result;
-
     // Tracks the last name-validation outcome so the status bar can choose
     // between a validation error and the summary count.
     private bool _namesValid = true;
+
+    private UnnestResult _result;
 
     // Reentrancy guard: rebuilding the row list during a Recompute fires
     // INotifyPropertyChanged on each VM, which would re-enter the change
@@ -270,7 +269,7 @@ public class UnnestStepRowVm : INotifyPropertyChanged
     private static readonly Brush DefaultNameBorderBrush =
         new SolidColorBrush((Color)ColorConverter.ConvertFromString("#3e3e3e"));
 
-    private bool _include = true;
+    private bool _include;
     private bool _isNameValid = true;
     private string _name;
     private string _rhs;

--- a/addin/lambda-boss/UnnestEngine.cs
+++ b/addin/lambda-boss/UnnestEngine.cs
@@ -9,7 +9,25 @@ namespace LambdaBoss;
 ///     <see cref="FormulaParser" />, and explodes each function-call and binary-
 ///     operator node (other than the root) into a named, leaf-first <c>=LET(...)</c>
 ///     step. The root stays as the LET body with its child references rewritten
-///     to step names. Reference operators (range <c>:</c> and intersection
+///     to step names.
+///
+///     <para>
+///     When the active cell's formula is <em>already</em> a <c>=LET(...)</c>
+///     (issue #273), the engine takes a second path: <see cref="LetParser" />
+///     splits the top-level bindings, then each <em>calculation</em> binding's
+///     RHS and the body are exploded the same way (their root excluded, since a
+///     calc binding's root already has the binding's name). New steps are
+///     inserted immediately before the binding (or body) they were extracted
+///     from — each new step references only nodes within that one scope, so
+///     "before first use" needs no cross-binding re-parenting. Existing
+///     <em>value</em> bindings are left untouched (they're already inputs), and
+///     existing binding names are reserved so an auto-named step never collides
+///     with one. A malformed LET (<see cref="LetParser" /> throws) is refused
+///     via <see cref="UnnestDiagnosticKind.MalformedLet" />; a calc binding or
+///     body that the expression parser can't read is kept verbatim (no steps).
+///     </para>
+///
+///     Reference operators (range <c>:</c> and intersection
 ///     <c>space</c>) are treated as leaves, never steps — matching the parser's
 ///     "ranges are non-steps" rule. Unary expressions and postfix <c>%</c>/<c>#</c>
 ///     also stay inline. A name-binding construct (a <c>LAMBDA(...)</c> or a
@@ -80,19 +98,20 @@ public static class UnnestEngine
         IReadOnlyList<UnnestRowState>? rowStates,
         IReadOnlyCollection<string>? definedNames)
     {
-        // Existing LETs are exploded by the existing-LET path (issue #273); the
-        // non-LET engine refuses rather than parse a LET as a function call.
-        if (LetParser.IsLetFormula(formula))
-        {
-            return new UnnestResult(
-                formula,
-                Array.Empty<UnnestStepRow>(),
-                formula,
-                new UnnestDiagnostic(
-                    UnnestDiagnosticKind.ExistingLet,
-                    "Unnest doesn't yet handle formulas that are already a LET."));
-        }
+        // An existing =LET(...) is exploded binding-by-binding (issue #273);
+        // everything else is a single nested expression.
+        return LetParser.IsLetFormula(formula)
+            ? DecomposeExistingLet(formula, rowStates, definedNames)
+            : DecomposeNonLet(formula, rowStates, definedNames);
+    }
 
+    // ---------------- non-LET path ----------------
+
+    private static UnnestResult DecomposeNonLet(
+        string formula,
+        IReadOnlyList<UnnestRowState>? rowStates,
+        IReadOnlyCollection<string>? definedNames)
+    {
         FormulaAst ast;
         try
         {
@@ -113,10 +132,178 @@ public static class UnnestEngine
         var candidates = new List<FormulaNode>();
         CollectSteps(ast.Root, isRoot: true, candidates);
 
-        // Assign names + Include per row, honouring any dialog state.
-        var stateByKey = BuildStateLookup(rowStates);
         var used = new HashSet<string>(
             definedNames ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        var (nameOf, included, rows) = AssignAndRender(candidates, rowStates, used);
+
+        var includedRows = rows.Where(r => r.Include).ToList();
+        var synthesised = includedRows.Count == 0
+            ? formula // No steps (or all inlined): a no-op rewrite.
+            : BuildLet(includedRows, Render(ast.Root, nameOf, included, isRoot: true));
+
+        return new UnnestResult(formula, rows, synthesised);
+    }
+
+    // ---------------- existing-LET path (issue #273) ----------------
+
+    /// <summary>
+    ///     Explodes an existing <c>=LET(...)</c>. The LET is split into top-level
+    ///     bindings by <see cref="LetParser" /> (a <see cref="FormatException" />
+    ///     there is refused via <see cref="UnnestDiagnosticKind.MalformedLet" />).
+    ///     Each calculation binding's RHS and the body are parsed and exploded
+    ///     leaf-first with their own root excluded — a calc binding's root keeps
+    ///     the binding's existing name — and the new steps are inserted directly
+    ///     before the binding (or body) they came from. Value bindings, binding
+    ///     names, and binding order are preserved. When nothing new is extracted
+    ///     (or every new step is un-included) the original formula is returned
+    ///     unchanged so a fully-decomposed LET is a true no-op rather than a
+    ///     cosmetic re-spacing.
+    /// </summary>
+    private static UnnestResult DecomposeExistingLet(
+        string formula,
+        IReadOnlyList<UnnestRowState>? rowStates,
+        IReadOnlyCollection<string>? definedNames)
+    {
+        ParsedLet parsed;
+        try
+        {
+            parsed = LetParser.Parse(formula);
+        }
+        catch (FormatException ex)
+        {
+            return new UnnestResult(
+                formula,
+                Array.Empty<UnnestStepRow>(),
+                formula,
+                new UnnestDiagnostic(
+                    UnnestDiagnosticKind.MalformedLet,
+                    $"Could not parse LET formula: {ex.Message}"));
+        }
+
+        var bindings = parsed.Bindings;
+
+        // Parse each calc binding's RHS and the body into scopes, collecting
+        // their nested step candidates leaf-first. The global candidate order
+        // (calc bindings in source order, then the body) gives each step a
+        // stable key across Recompute, since the source text never changes.
+        var calcRootByIndex = new Dictionary<int, FormulaNode>();
+        var calcCandidatesByIndex = new Dictionary<int, List<FormulaNode>>();
+        var allCandidates = new List<FormulaNode>();
+
+        for (var i = 0; i < bindings.Count; i++)
+        {
+            if (!bindings[i].IsCalculation) continue;
+            var root = TryParseScope(bindings[i].RhsText);
+            if (root is null) continue; // Unparseable RHS — kept verbatim, no steps.
+
+            var cands = new List<FormulaNode>();
+            CollectSteps(root, isRoot: true, cands);
+            calcRootByIndex[i] = root;
+            calcCandidatesByIndex[i] = cands;
+            allCandidates.AddRange(cands);
+        }
+
+        var bodyRoot = TryParseScope(parsed.Body);
+        var bodyCandidates = new List<FormulaNode>();
+        if (bodyRoot is not null)
+            CollectSteps(bodyRoot, isRoot: true, bodyCandidates);
+        allCandidates.AddRange(bodyCandidates);
+
+        // Reserve defined names AND every existing binding name so an auto-named
+        // step never shadows one.
+        var used = new HashSet<string>(
+            definedNames ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        foreach (var b in bindings)
+            used.Add(b.Name);
+
+        var (nameOf, included, rows) = AssignAndRender(allCandidates, rowStates, used);
+
+        // Nothing new (or every new step inlined) — return the LET untouched.
+        if (!rows.Any(r => r.Include))
+            return new UnnestResult(formula, rows, formula);
+
+        var rowByNode = new Dictionary<FormulaNode, UnnestStepRow>();
+        for (var i = 0; i < allCandidates.Count; i++)
+            rowByNode[allCandidates[i]] = rows[i];
+
+        // Walk the original bindings in order, emitting each calc binding's new
+        // steps just ahead of it; value bindings pass through verbatim.
+        var letBindings = new List<(string Name, string Value)>();
+        for (var i = 0; i < bindings.Count; i++)
+        {
+            var b = bindings[i];
+            if (!b.IsCalculation || !calcCandidatesByIndex.TryGetValue(i, out var cands))
+            {
+                letBindings.Add((b.Name, b.RhsText));
+                continue;
+            }
+
+            AppendIncludedSteps(letBindings, cands, rowByNode);
+            letBindings.Add((b.Name, Render(calcRootByIndex[i], nameOf, included, isRoot: true)));
+        }
+
+        AppendIncludedSteps(letBindings, bodyCandidates, rowByNode);
+        var bodyText = bodyRoot is not null
+            ? Render(bodyRoot, nameOf, included, isRoot: true)
+            : parsed.Body;
+
+        return new UnnestResult(formula, rows, BuildLetFromBindings(letBindings, bodyText));
+    }
+
+    /// <summary>
+    ///     Parses a calc-binding RHS or LET body (expression text, no leading
+    ///     <c>=</c>) into its root node, or returns null when the expression
+    ///     parser can't read it — in which case the caller keeps the text
+    ///     verbatim rather than failing the whole explosion.
+    /// </summary>
+    private static FormulaNode? TryParseScope(string text)
+    {
+        try
+        {
+            return FormulaParser.Parse(text).Root;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    ///     Appends each included step in <paramref name="candidates" /> (leaf-first
+    ///     order) as a <c>(name, rhs)</c> binding. Un-included steps are skipped —
+    ///     their RHS was already inlined into the parent's render.
+    /// </summary>
+    private static void AppendIncludedSteps(
+        List<(string Name, string Value)> letBindings,
+        List<FormulaNode> candidates,
+        Dictionary<FormulaNode, UnnestStepRow> rowByNode)
+    {
+        foreach (var node in candidates)
+        {
+            var row = rowByNode[node];
+            if (row.Include)
+                letBindings.Add((row.Name, row.Rhs));
+        }
+    }
+
+    /// <summary>
+    ///     Assigns a name and Include flag to each step candidate (honouring any
+    ///     dialog <paramref name="rowStates" />), then renders each candidate's
+    ///     RHS with its included children collapsed to names. <paramref name="used" />
+    ///     is the pre-seeded set of reserved names (defined names, plus existing
+    ///     binding names on the existing-LET path) the auto-namer avoids; explicit
+    ///     user names are reserved on top before auto-allocation so a rename never
+    ///     collides with an auto suffix. Candidate order is the engine's leaf-first
+    ///     order, so <c>step</c><i>N</i> keys stay stable across Recompute.
+    /// </summary>
+    private static (Dictionary<FormulaNode, string> NameOf,
+        HashSet<FormulaNode> Included,
+        List<UnnestStepRow> Rows) AssignAndRender(
+            IReadOnlyList<FormulaNode> candidates,
+            IReadOnlyList<UnnestRowState>? rowStates,
+            HashSet<string> used)
+    {
+        var stateByKey = BuildStateLookup(rowStates);
 
         // Reserve every explicit user name first so auto-allocation skips them.
         for (var i = 0; i < candidates.Count; i++)
@@ -147,23 +334,10 @@ public static class UnnestEngine
                 key, name, Rhs: "", OriginOf(node), OriginLabelOf(node), include));
         }
 
-        // Now that names are assigned, render each step's RHS and the body.
         for (var i = 0; i < candidates.Count; i++)
-        {
-            var rhs = Render(candidates[i], nameOf, included, isRoot: true);
-            rows[i] = rows[i] with { Rhs = rhs };
-        }
+            rows[i] = rows[i] with { Rhs = Render(candidates[i], nameOf, included, isRoot: true) };
 
-        var includedRows = new List<UnnestStepRow>();
-        foreach (var row in rows)
-            if (row.Include)
-                includedRows.Add(row);
-
-        var synthesised = includedRows.Count == 0
-            ? formula // No steps (or all inlined): a no-op rewrite.
-            : BuildLet(includedRows, Render(ast.Root, nameOf, included, isRoot: true));
-
-        return new UnnestResult(formula, rows, synthesised);
+        return (nameOf, included, rows);
     }
 
     // ---------------- step collection ----------------
@@ -324,7 +498,12 @@ public static class UnnestEngine
         var bindings = new List<(string Name, string Value)>(steps.Count);
         foreach (var s in steps)
             bindings.Add((s.Name, s.Rhs));
+        return BuildLetFromBindings(bindings, body);
+    }
 
+    private static string BuildLetFromBindings(
+        IReadOnlyList<(string Name, string Value)> bindings, string body)
+    {
         var sb = new StringBuilder();
         sb.Append('=');
         FormulaFormatter.AppendLet(sb, 0, bindings, body);

--- a/addin/lambda-boss/UnnestTypes.cs
+++ b/addin/lambda-boss/UnnestTypes.cs
@@ -77,9 +77,12 @@ public enum UnnestDiagnosticKind
     MalformedFormula,
 
     /// <summary>
-    ///     The active cell holds a <c>=LET(...)</c>. Existing-LET explosion is
-    ///     handled separately (issue #273); the non-LET engine refuses rather
-    ///     than mis-parsing the LET as a function call.
+    ///     The active cell holds a <c>=LET(...)</c> whose top-level structure
+    ///     couldn't be parsed by <see cref="LetParser" /> (wrong argument
+    ///     count, unbalanced parens, an invalid binding name, …). The engine
+    ///     refuses rather than attempt an explosion over a malformed LET — the
+    ///     command surfaces the message instead of opening the dialog, matching
+    ///     <c>ConvertLetToLambdaCommand</c>'s wording.
     /// </summary>
-    ExistingLet
+    MalformedLet
 }


### PR DESCRIPTION
Part of #269 — spec [0009](specs/0009-unnest-to-let.md). Extends `/Unnest` to handle a formula that is already a `=LET(...)`, the last piece of the Unnest engine after the non-LET core (#271) and the dialog (#272).

## What changed

`UnnestEngine.Decompose` now branches: an existing `=LET(...)` routes to a new `DecomposeExistingLet`; everything else keeps the non-LET path. The two paths share a new `AssignAndRender` helper for name allocation + RHS rendering, so behaviour stays identical where it overlaps.

### Existing-LET explosion
- `LetParser` splits the top-level bindings (shallow). Each **calculation** binding's RHS and the **body** are parsed with the recursive-descent expression parser (#270) and exploded leaf-first, with their own **root excluded** — a calc binding's root already carries the binding's name.
- New steps are inserted **immediately before the binding (or body) they came from**. Because each new step references only nodes within that one scope, "before first use" falls out for free — no cross-binding re-parenting (the fallback risk the issue flagged never materialises, so v1 ships the full body-and-calc explosion rather than body-only).
- **Value bindings, binding names, and binding order are preserved.** Existing binding names are reserved alongside workbook defined names, so an auto-named step never shadows one (`sqrt1` already taken → `sqrt2`).
- **Malformed LET** → refused via a new `MalformedLet` diagnostic reusing `ConvertLetToLambdaCommand`'s wording (`Could not parse LET formula: …`), no dialog. A calc binding / body the expression parser can't read is kept verbatim rather than failing the whole explosion.
- **Nested `LAMBDA`/`LET`** inside a calc binding stays opaque (no hoisting out of scope), same rule as the non-LET path (#278).
- A **fully-decomposed LET** (or one with every new step un-included) is a true **no-op** — the original formula is returned unchanged, no cosmetic re-spacing.

No dialog or command changes were needed: engine diagnostics and zero-step formulas already flow through `UnnestCommand` / `UnnestToLetWindow`. (The stale `ExistingLet` diagnostic kind, which used to refuse LETs, is replaced by `MalformedLet`.)

### Worked example
`=LET(a, A1, b, ROUND(SQRT(A2), 2), a + b * 2)` →
```
=LET(
    a, A1,
    sqrt1, SQRT(A2),
    b, ROUND(sqrt1, 2),
    calc1, b * 2,
    a + calc1
)
```

## Tests
Added to `UnnestEngineTests` (covers the issue's checklist):
- Tidy LET → calc-binding RHS + body exploded; value bindings preserved.
- New steps inserted before each owning binding; existing order preserved (two-calc-binding case).
- Auto-naming skips existing binding names.
- Already-decomposed LET → no-op.
- Inner-lambda stays opaque inside the LET path.
- Include-toggle inlines a new step back into the body (Recompute).
- Round-trip through `LetParser`.
- Malformed LET → `MalformedLet` refusal, no dialog.

The pre-existing `Unnest_ExistingLet_RefusesWithDiagnostic` test (which asserted the old refusal) is replaced by the explosion tests.

Full unit suite green: **1441 passed, 0 failed**.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)