### PR TITLE
Add ALPHABET letter-constants lambda — #262

### DIFF
--- a/lambdas/string/ALPHABET.lambda
+++ b/lambdas/string/ALPHABET.lambda
@@ -1,0 +1,38 @@
+/*  FUNCTION NAME:      ALPHABET
+    DESCRIPTION:*//**Returns a spilled array of letters: all 26, just vowels, or just consonants, in upper or lower case.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-06-28  Claude      Initial version
+*/
+ALPHABET = LAMBDA(
+//  Parameter Declarations
+    [Case],
+    [Subset],
+    [ShowHelp],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →ALPHABET(Case, Subset, ShowHelp)¶" &
+                "DESCRIPTION:   →Returns a spilled array of letters: all 26, just vowels, or just consonants, in upper or lower case.¶" &
+                "VERSION:       →Jun 28 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   Case           →(Optional) 0 = uppercase [default], 1 = lowercase.¶" &
+                "   Subset         →(Optional) 0 = all 26 letters [default], 1 = vowels (5), 2 = consonants (21).¶" &
+                "   ShowHelp       →(Optional) Pass TRUE to show this help text instead of the letters.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=ALPHABET(1, 1)¶" &
+                "Result         →{a;e;i;o;u}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(ShowHelp),
+        _case, IF(ISOMITTED(Case), 0, Case),
+        _subset, IF(ISOMITTED(Subset), 0, Subset),
+    //  Procedure
+        full, CHAR(SEQUENCE(26, , IF(_case = 1, 97, 65))),
+        vowelMask, ISNUMBER(XMATCH(full, {"A";"E";"I";"O";"U"})),
+        result, SWITCH(_subset,
+                    1, FILTER(full, vowelMask),
+                    2, FILTER(full, NOT(vowelMask)),
+                    full),
+        IF(Help?, result, Help)
+)
+);

--- a/lambdas/string/ALPHABET.tests.yaml
+++ b/lambdas/string/ALPHABET.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: default returns the uppercase alphabet
+    args: []
+    expected: [["A"], ["B"], ["C"], ["D"], ["E"], ["F"], ["G"], ["H"], ["I"], ["J"], ["K"], ["L"], ["M"], ["N"], ["O"], ["P"], ["Q"], ["R"], ["S"], ["T"], ["U"], ["V"], ["W"], ["X"], ["Y"], ["Z"]]
+
+  - name: vowels uppercase
+    args: ['=0', '=1']
+    expected: [["A"], ["E"], ["I"], ["O"], ["U"]]
+
+  - name: vowels lowercase
+    args: ['=1', '=1']
+    expected: [["a"], ["e"], ["i"], ["o"], ["u"]]
+
+  - name: consonants uppercase
+    args: ['=0', '=2']
+    expected: [["B"], ["C"], ["D"], ["F"], ["G"], ["H"], ["J"], ["K"], ["L"], ["M"], ["N"], ["P"], ["Q"], ["R"], ["S"], ["T"], ["V"], ["W"], ["X"], ["Y"], ["Z"]]
+
+  - name: lowercase all letters first and last
+    args: ['=1', '=0']
+    expected_type: array
+
+  - name: help text
+    args: ['=0', '=0', '=TRUE']
+    expected_type: array


### PR DESCRIPTION
## Summary

Adds `ALPHABET`, a single discoverable letter-constants getter, replacing the need for six bare constants (`_alphabet_l/u`, `_vowels_l/u`, `_consonants_l/u`).

```
=ALPHABET([Case], [Subset], [ShowHelp])
```

- **Case** — `0` uppercase (default) / `1` lowercase
- **Subset** — `0` all 26 (default) / `1` vowels (5) / `2` consonants (21)
- **ShowHelp** — pass `TRUE` for the help table; bare `=ALPHABET()` returns the letters

Returns a spilled vertical array. Pairs with `EXPLODE` / `CHARQ` for letter-indexing work, e.g. `=XMATCH("M", ALPHABET())` → 13.

## Design notes

- **Numeric enums, not text tokens.** The issue proposed text (`"L"`, `"VOWELS"`), but per the library's standing convention (closed-choice args are numeric) I used integer enums to avoid case/spelling fragility under a 30-minute puzzle clock — Tim confirmed this choice. Spelling `"CONSONANTS"` correctly under time pressure is exactly the failure mode the convention guards against.
- **No array-lift dispatcher** — output is inherently an array (the table says don't lift), and the scalar selectors don't lift.
- Consonants are derived as alphabet-minus-vowels via `FILTER` + a case-insensitive `XMATCH` vowel mask, so there's a single source of truth.
- Data-getter help inversion (`IF(Help?, result, Help)`) keeps bare `=ALPHABET()` returning data.

## Testing

- Format tests: 664 passed
- Functional harness (ALPHABET): 6/6 — default A–Z, vowels upper/lower (exact), consonants upper (exact, all 21), lowercase all, help text
- Full harness suite: 720 passed, 0 failed

Closes #262