### PR TITLE
Spike: /Debug Lambda — extract nested LAMBDA to a scratch sheet (#279)

### DIFF
--- a/addin/lambda-boss.Tests/DebugNestedEngineTests.cs
+++ b/addin/lambda-boss.Tests/DebugNestedEngineTests.cs
@@ -276,4 +276,28 @@ public class DebugNestedEngineTests
             DebugNestedEngine.BuildCaptureFormula(
                 "=BYROW(rng, LAMBDA(r, r + 1))", "scope0", "CHOOSEROWS(rng, 1)"));
     }
+
+    [Fact]
+    public void BuildParamProbe_CustomHost_ReplacesBodyWithParamAndIndexes()
+    {
+        // A top-level custom HOF: probe `a` by running PAIROP with the body → a,
+        // then INDEX the result. No enclosing context, so a bare =INDEX(...).
+        var probe = DebugNestedEngine.BuildParamProbe(
+            "=PAIROP(rng, LAMBDA(a, b, a + b))", "scope0", "a", 1);
+
+        Assert.Equal("=INDEX(PAIROP(rng, LAMBDA(a, b, a)), 1)", probe);
+    }
+
+    [Fact]
+    public void BuildParamProbe_NestedCustomHost_PinsEnclosingParam()
+    {
+        // Inner LAMBDA(a, b) under a custom PAIROP, itself under an outer BYROW:
+        // the probe pins the enclosing `r` to the outer iterator's slice so PAIROP
+        // can run, then captures `a`.
+        var probe = DebugNestedEngine.BuildParamProbe(Nested, "scope1", "a", 1);
+
+        Assert.Equal(
+            "=LET(r, CHOOSEROWS(data, 1), INDEX(PAIROP(r, LAMBDA(a, b, a), 1), 1))",
+            probe);
+    }
 }

--- a/addin/lambda-boss.Tests/DebugNestedEngineTests.cs
+++ b/addin/lambda-boss.Tests/DebugNestedEngineTests.cs
@@ -1,0 +1,181 @@
+using Xunit;
+
+namespace LambdaBoss.Tests;
+
+/// <summary>
+///     Spec 0010 (spike) / issue #279 — <see cref="DebugNestedEngine" /> tests.
+///     Covers lambda-scope discovery (single + nested, with host / params /
+///     enclosing-params / depth), the no-lambda and malformed refusals, default
+///     pin suggestion for recognised iterators vs. blanks for custom hosts, and
+///     <see cref="DebugNestedEngine.BuildWatch" /> assembling self-contained
+///     evaluable <c>=LET(...)</c> formulas (pins + leaf-first steps), including
+///     blank-pin omission and the no-step body.
+/// </summary>
+public class DebugNestedEngineTests
+{
+    // A doubly-dynamic formula in the shape of the #279 trip example: an outer
+    // BYROW binds `r` per row, an inner custom PAIROP binds `a`/`b` per pair.
+    private const string Nested =
+        "=MIN(BYROW(data, LAMBDA(r, SUM(PAIROP(r, LAMBDA(a, b, a + b), 1)))))";
+
+    private const string Simple =
+        "=SUM(BYROW(A1:B3, LAMBDA(r, SUM(r)*2)))";
+
+    // ---------------- discovery ----------------
+
+    [Fact]
+    public void Discover_SingleLambda_CapturesHostParamsAndBody()
+    {
+        var d = DebugNestedEngine.Discover(Simple);
+
+        Assert.Null(d.Diagnostic);
+        var scope = Assert.Single(d.Scopes);
+        Assert.Equal(0, scope.Depth);
+        Assert.Equal("BYROW", scope.HostFunction);
+        Assert.Equal(new[] { "r" }, scope.Params);
+        Assert.Empty(scope.EnclosingParams);
+        Assert.Equal("SUM(r)*2", scope.BodyText);
+        Assert.Equal("LAMBDA(r) — arg of BYROW", scope.Label);
+    }
+
+    [Fact]
+    public void Discover_NestedLambdas_OrdersOuterFirstWithEnclosingParams()
+    {
+        var d = DebugNestedEngine.Discover(Nested);
+
+        Assert.Null(d.Diagnostic);
+        Assert.Equal(2, d.Scopes.Count);
+
+        var outer = d.Scopes[0];
+        Assert.Equal(0, outer.Depth);
+        Assert.Equal("BYROW", outer.HostFunction);
+        Assert.Equal(new[] { "r" }, outer.Params);
+        Assert.Empty(outer.EnclosingParams);
+
+        var inner = d.Scopes[1];
+        Assert.Equal(1, inner.Depth);
+        Assert.Equal("PAIROP", inner.HostFunction);
+        Assert.Equal(new[] { "a", "b" }, inner.Params);
+        Assert.Equal(new[] { "r" }, inner.EnclosingParams);
+        Assert.Equal("a + b", inner.BodyText);
+    }
+
+    [Fact]
+    public void Discover_NoLambda_Refuses()
+    {
+        var d = DebugNestedEngine.Discover("=SUM(A1:A3) + 1");
+
+        Assert.Empty(d.Scopes);
+        Assert.NotNull(d.Diagnostic);
+        Assert.Equal(DebugDiagnosticKind.NoLambda, d.Diagnostic!.Kind);
+    }
+
+    [Fact]
+    public void Discover_MalformedFormula_Refuses()
+    {
+        var d = DebugNestedEngine.Discover("=SUM(");
+
+        Assert.Empty(d.Scopes);
+        Assert.NotNull(d.Diagnostic);
+        Assert.Equal(DebugDiagnosticKind.MalformedFormula, d.Diagnostic!.Kind);
+    }
+
+    // ---------------- pin suggestion ----------------
+
+    [Fact]
+    public void SuggestPins_ByRowHost_SlicesSourceWithChooseRows()
+    {
+        var pins = DebugNestedEngine.SuggestPins(Simple, "scope0");
+
+        var pin = Assert.Single(pins);
+        Assert.Equal("r", pin.Param);
+        Assert.Equal("CHOOSEROWS(A1:B3, 1)", pin.Expression);
+    }
+
+    [Fact]
+    public void SuggestPins_InnerScope_IncludesEnclosingPinsThenBlanksForCustomHost()
+    {
+        var pins = DebugNestedEngine.SuggestPins(Nested, "scope1");
+
+        Assert.Collection(pins,
+            p =>
+            {
+                Assert.Equal("r", p.Param);
+                Assert.Equal("CHOOSEROWS(data, 1)", p.Expression);
+            },
+            p =>
+            {
+                Assert.Equal("a", p.Param);
+                Assert.Equal("", p.Expression);
+            },
+            p =>
+            {
+                Assert.Equal("b", p.Param);
+                Assert.Equal("", p.Expression);
+            });
+    }
+
+    [Fact]
+    public void SuggestPins_HonoursExampleIndex()
+    {
+        var pins = DebugNestedEngine.SuggestPins(Simple, "scope0", index: 3);
+
+        Assert.Equal("CHOOSEROWS(A1:B3, 3)", pins[0].Expression);
+    }
+
+    // ---------------- watch / evaluable formulas ----------------
+
+    [Fact]
+    public void BuildWatch_OuterScope_BuildsPinnedStepAndFinalFormulas()
+    {
+        var pins = new[] { new DebugPin("r", "CHOOSEROWS(A1:B3, 1)") };
+
+        var watch = DebugNestedEngine.BuildWatch(Simple, "scope0", pins);
+
+        Assert.Null(watch.Diagnostic);
+
+        // `sum1` reads as a valid cell address, so the auto-namer underscores
+        // it to the legal `sum_1` (see UnnestEngine.AllocateName).
+        var step = Assert.Single(watch.Steps);
+        Assert.Equal("sum_1", step.Name);
+        Assert.Equal("SUM(r)", step.Rhs);
+        Assert.Equal("=LET(r, CHOOSEROWS(A1:B3, 1), sum_1, SUM(r), sum_1)", step.EvaluableFormula);
+
+        Assert.Equal(
+            "=LET(r, CHOOSEROWS(A1:B3, 1), sum_1, SUM(r), sum_1 * 2)",
+            watch.FinalEvaluableFormula);
+    }
+
+    [Fact]
+    public void BuildWatch_BlankPinOmittedAndNoStepBody()
+    {
+        // Inner scope `a + b`: a/b supplied, the unused enclosing `r` left blank.
+        var pins = new[]
+        {
+            new DebugPin("r", ""),
+            new DebugPin("a", "1"),
+            new DebugPin("b", "2")
+        };
+
+        var watch = DebugNestedEngine.BuildWatch(Nested, "scope1", pins);
+
+        Assert.Null(watch.Diagnostic);
+        Assert.Empty(watch.Steps); // `a + b` root is the body, not a step.
+        Assert.Equal("=LET(a, 1, b, 2, a + b)", watch.FinalEvaluableFormula);
+    }
+
+    [Fact]
+    public void BuildWatch_InnerLambdaKeptInlineInOuterStep()
+    {
+        var pins = new[] { new DebugPin("r", "CHOOSEROWS(data, 1)") };
+
+        var watch = DebugNestedEngine.BuildWatch(Nested, "scope0", pins);
+
+        Assert.Null(watch.Diagnostic);
+        // The outer body SUM(PAIROP(r, LAMBDA(a, b, a + b), 1)) decomposes its
+        // non-lambda structure; the inner LAMBDA stays inline in the PAIROP step.
+        var pairop = Assert.Single(watch.Steps, s => s.Name == "pairop1");
+        Assert.Contains("LAMBDA(a, b, a + b)", pairop.Rhs);
+        Assert.StartsWith("=LET(r, CHOOSEROWS(data, 1),", pairop.EvaluableFormula);
+    }
+}

--- a/addin/lambda-boss.Tests/DebugNestedEngineTests.cs
+++ b/addin/lambda-boss.Tests/DebugNestedEngineTests.cs
@@ -253,4 +253,27 @@ public class DebugNestedEngineTests
         Assert.DoesNotContain(parsed.Bindings, b => b.Name == "convert");
         Assert.Equal("IF(calc1, m, 0)", parsed.Body);
     }
+
+    [Fact]
+    public void BuildCaptureFormula_WrapsExpressionInEnclosingLetContext()
+    {
+        // A param slice and an enclosing-LET binding both evaluate correctly once
+        // wrapped in the parent LET's bindings.
+        Assert.Equal(
+            "=LET(convert, data[Amount], both, VSTACK(convert, convert), CHOOSEROWS(both, 1))",
+            DebugNestedEngine.BuildCaptureFormula(LetWrapped, "scope0", "CHOOSEROWS(both, 1)"));
+
+        Assert.Equal(
+            "=LET(convert, data[Amount], both, VSTACK(convert, convert), convert)",
+            DebugNestedEngine.BuildCaptureFormula(LetWrapped, "scope0", "convert"));
+    }
+
+    [Fact]
+    public void BuildCaptureFormula_NoEnclosingLet_JustPrefixesEquals()
+    {
+        Assert.Equal(
+            "=CHOOSEROWS(rng, 1)",
+            DebugNestedEngine.BuildCaptureFormula(
+                "=BYROW(rng, LAMBDA(r, r + 1))", "scope0", "CHOOSEROWS(rng, 1)"));
+    }
 }

--- a/addin/lambda-boss.Tests/DebugNestedEngineTests.cs
+++ b/addin/lambda-boss.Tests/DebugNestedEngineTests.cs
@@ -178,4 +178,79 @@ public class DebugNestedEngineTests
         Assert.Contains("LAMBDA(a, b, a + b)", pairop.Rhs);
         Assert.StartsWith("=LET(r, CHOOSEROWS(data, 1),", pairop.EvaluableFormula);
     }
+
+    // ---------------- scratch-sheet extraction (new approach) ----------------
+
+    // A LET-wrapped formula like Tim's: `convert` and `both` are parent-LET
+    // bindings; the inner lambda body references `r` (its param) and `convert`.
+    private const string LetWrapped =
+        "=LET(convert, data[Amount], both, VSTACK(convert, convert), " +
+        "BYROW(both, LAMBDA(r, LET(m, MAX(r), IF(m > AVERAGE(convert), m, 0)))))";
+
+    [Fact]
+    public void AnalyzeInputs_ClassifiesParamAndEnclosingLetBinding()
+    {
+        var inputs = DebugNestedEngine.AnalyzeInputs(LetWrapped, "scope0");
+
+        // `r` is the lambda param; `convert` is an enclosing-LET binding whose
+        // definition we can rebuild. `both` (unreferenced by the body) and `m`
+        // (bound inside the body's own LET) are correctly excluded.
+        Assert.Collection(inputs,
+            i =>
+            {
+                Assert.Equal("r", i.Name);
+                Assert.Equal(DebugInputKind.Param, i.Kind);
+                Assert.Null(i.Definition);
+            },
+            i =>
+            {
+                Assert.Equal("convert", i.Name);
+                Assert.Equal(DebugInputKind.LetBinding, i.Kind);
+                Assert.Equal("data[Amount]", i.Definition);
+            });
+    }
+
+    [Fact]
+    public void AnalyzeInputs_UnknownName_ClassifiesAsExternal()
+    {
+        var inputs = DebugNestedEngine.AnalyzeInputs(
+            "=BYROW(rng, LAMBDA(r, r + factor))", "scope0");
+
+        Assert.Collection(inputs,
+            i => Assert.Equal(DebugInputKind.Param, i.Kind),
+            i =>
+            {
+                Assert.Equal("factor", i.Name);
+                Assert.Equal(DebugInputKind.External, i.Kind);
+            });
+    }
+
+    [Fact]
+    public void AnalyzeInputs_InnerScope_ParamAndEnclosingParam()
+    {
+        var inputs = DebugNestedEngine.AnalyzeInputs(Nested, "scope1");
+
+        // Inner LAMBDA(a, b) body `a + b`: both are its own params.
+        Assert.All(inputs, i => Assert.Equal(DebugInputKind.Param, i.Kind));
+        Assert.Equal(new[] { "a", "b" }, inputs.Select(i => i.Name));
+    }
+
+    [Fact]
+    public void BuildDebugLet_SeedsParamFirstThenUnnestedBody()
+    {
+        var seeds = new[] { new DebugPin("r", "CHOOSEROWS(both, 1)") };
+
+        var let = DebugNestedEngine.BuildDebugLet(LetWrapped, "scope0", seeds);
+
+        Assert.StartsWith("=LET(", let);
+
+        // Round-trips through LetParser, param seeded first, enclosing-LET name
+        // `convert` left free (rebuilt on the sheet, not a binding), body intact.
+        var parsed = LetParser.Parse(let);
+        Assert.Equal("r", parsed.Bindings[0].Name);
+        Assert.Equal("CHOOSEROWS(both, 1)", parsed.Bindings[0].RhsText);
+        Assert.Contains(parsed.Bindings, b => b.RhsText == "AVERAGE(convert)");
+        Assert.DoesNotContain(parsed.Bindings, b => b.Name == "convert");
+        Assert.Equal("IF(calc1, m, 0)", parsed.Body);
+    }
 }

--- a/addin/lambda-boss/Commands/DebugLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/DebugLambdaCommand.cs
@@ -117,27 +117,35 @@ internal static class DebugLambdaCommand
             foreach (var inp in inputs)
             {
                 string defName;
-                string captureExpr;
+                string? finalFormula;
                 switch (inp.Kind)
                 {
                     case DebugInputKind.Param:
                         defName = inp.Name + "_in";
                         ownParamSeeds.Add(new DebugPin(inp.Name, defName));
-                        seedByName.TryGetValue(inp.Name, out captureExpr!);
+                        var expr = Seed(seedByName, inp.Name);
+                        // A recognised iterator gives a slice; a custom-HOF param
+                        // has no slice, so probe the host for its bound value.
+                        finalFormula = !string.IsNullOrWhiteSpace(expr)
+                            ? DebugNestedEngine.BuildCaptureFormula(formula, scopeKey, expr)
+                            : DebugNestedEngine.BuildParamProbe(formula, scopeKey, inp.Name, index);
                         break;
                     case DebugInputKind.EnclosingParam:
                         defName = inp.Name;
-                        seedByName.TryGetValue(inp.Name, out captureExpr!);
+                        var enclExpr = Seed(seedByName, inp.Name);
+                        finalFormula = string.IsNullOrWhiteSpace(enclExpr)
+                            ? null
+                            : DebugNestedEngine.BuildCaptureFormula(formula, scopeKey, enclExpr);
                         break;
                     case DebugInputKind.LetBinding:
                         defName = inp.Name;
-                        captureExpr = inp.Name; // capture the binding's value in context
+                        finalFormula = DebugNestedEngine.BuildCaptureFormula(formula, scopeKey, inp.Name);
                         break;
                     default:
                         continue; // External — resolves on its own
                 }
 
-                captures.Add(Capture(sourceSheet, scratch, formula, scopeKey, defName, inp.Name, captureExpr));
+                captures.Add(Evaluate(sourceSheet, scratch, finalFormula, defName, inp.Name));
             }
 
             var letText = DebugNestedEngine.BuildDebugLet(formula, scopeKey, ownParamSeeds);
@@ -163,21 +171,27 @@ internal static class DebugLambdaCommand
         }
     }
 
-    private static CapturedInput Capture(
-        dynamic sourceSheet, ScratchCell scratch,
-        string formula, string scopeKey, string defName, string label, string captureExpr)
+    private static string Seed(IReadOnlyDictionary<string, string> seeds, string name)
     {
-        if (string.IsNullOrWhiteSpace(captureExpr))
-            return CapturedInput.Manual(defName, label);
+        return seeds.TryGetValue(name, out var expr) ? expr : "";
+    }
 
-        var capFormula = DebugNestedEngine.BuildCaptureFormula(formula, scopeKey, captureExpr);
-        if (capFormula is null)
+    /// <summary>
+    ///     Evaluates <paramref name="finalFormula" /> in a scratch cell on the
+    ///     source sheet and returns its value snapshot (scalar or spilled block). A
+    ///     null formula, an exception, or an Excel-error result all become a manual
+    ///     "fill in" placeholder.
+    /// </summary>
+    private static CapturedInput Evaluate(
+        dynamic sourceSheet, ScratchCell scratch, string? finalFormula, string defName, string label)
+    {
+        if (finalFormula is null)
             return CapturedInput.Manual(defName, label);
 
         dynamic cell = sourceSheet.Cells[scratch.Row, scratch.Col];
         try
         {
-            cell.Formula2 = capFormula;
+            cell.Formula2 = finalFormula;
 
             var spill = false;
             try { spill = (bool)cell.HasSpill; }
@@ -192,11 +206,16 @@ internal static class DebugLambdaCommand
                 return CapturedInput.FromBlock(defName, label, block, rows, cols);
             }
 
+            // A scalar Excel error (e.g. an un-pinnable probe) → leave it to fill in.
+            var text = (string)cell.Text;
+            if (!string.IsNullOrEmpty(text) && text[0] == '#')
+                return CapturedInput.Manual(defName, label);
+
             return CapturedInput.FromScalar(defName, label, cell.Value2);
         }
         catch (Exception ex)
         {
-            Logger.Error($"DebugLambda/Capture({label})", ex);
+            Logger.Error($"DebugLambda/Evaluate({label})", ex);
             return CapturedInput.Manual(defName, label);
         }
         finally
@@ -311,6 +330,9 @@ internal static class DebugLambdaCommand
             dynamic cell = sheet.Cells[row, col];
             cell.NumberFormat = "@";
             cell.Value2 = text;
+            // Keep it to one row by default (an embedded-newline source formula
+            // would otherwise wrap tall); the user can turn wrap on to inspect.
+            cell.WrapText = false;
         }
         catch (Exception ex) { Logger.Error($"DebugLambda/SetFormulaText({row},{col})", ex); }
     }

--- a/addin/lambda-boss/Commands/DebugLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/DebugLambdaCommand.cs
@@ -1,0 +1,380 @@
+using System.Globalization;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Interop;
+
+using ExcelDna.Integration;
+
+using LambdaBoss.Common;
+using LambdaBoss.UI;
+
+namespace LambdaBoss.Commands;
+
+/// <summary>
+///     Spec 0010 (spike) / issue #279 — <c>/Debug Lambda</c>. Extracts a nested
+///     <c>LAMBDA(...)</c> from the active cell onto a fresh scratch worksheet as
+///     an editable multiline <c>=LET(...)</c> wired to sample inputs, so the user
+///     can debug it in real cells and then convert it back with <c>/LET to LAMBDA</c>.
+///
+///     <para>
+///     A modal picker chooses the scope + example index (no Excel work while
+///     open). Then, on the macro thread: each input the body needs is
+///     <em>captured</em> by evaluating it in the lambda's enclosing context on the
+///     <em>source</em> sheet (so sheet-local refs and tables resolve) and the
+///     resulting value snapshot is written to the scratch sheet under a
+///     sheet-scoped name — the lambda's own params as <c>name_in</c> (seeded into
+///     the LET so <c>/LET to LAMBDA</c> lifts exactly them), enclosing-LET bindings
+///     and enclosing-lambda params under their own name (referenced freely by the
+///     body). A recognised iterator's param is sliced (<c>CHOOSEROWS</c>); a param
+///     under a custom higher-order function is left as a blank cell to fill in
+///     (probe-capture is a follow-up). Deleting the sheet removes its scoped names.
+///     </para>
+/// </summary>
+internal static class DebugLambdaCommand
+{
+    public static void Run()
+    {
+        try
+        {
+            dynamic app = ExcelDnaUtil.Application;
+            var workbook = app.ActiveWorkbook;
+            if (workbook == null)
+                return;
+
+            var activeCell = app.ActiveCell;
+            if (activeCell == null)
+                return;
+
+            if (!(bool)activeCell.HasFormula)
+                return;
+
+            var formula = (string)activeCell.Formula2;
+            var sourceSheet = activeCell.Worksheet;
+
+            var discovery = DebugNestedEngine.Discover(formula);
+            if (discovery.Diagnostic != null)
+            {
+                Logger.Info($"DebugLambda: refused — {discovery.Diagnostic.Kind}");
+                ShowError(discovery.Diagnostic.Message);
+                return;
+            }
+
+            // Modal picker — pure UI, no Excel. Blocks the macro thread until closed.
+            var excelHwnd = new IntPtr(app.Hwnd);
+            string? scopeKey = null;
+            var index = 1;
+
+            ShowLambdaPopupCommand.InvokeOnWindowThread(dispatcher =>
+            {
+                dispatcher.Invoke(() =>
+                {
+                    var picker = new DebugScopePickerWindow(formula, discovery);
+                    var hwnd = new WindowInteropHelper(picker).EnsureHandle();
+                    WindowPositioner.CenterOnExcel(excelHwnd, hwnd);
+                    if (picker.ShowDialog() == true)
+                    {
+                        scopeKey = picker.SelectedScopeKey;
+                        index = picker.ExampleIndex;
+                    }
+                });
+            });
+
+            if (scopeKey is null)
+                return;
+
+            var scope = discovery.Scopes.FirstOrDefault(s => s.Key == scopeKey);
+            GenerateSheet(app, workbook, sourceSheet, formula, scopeKey, scope?.Label ?? "", index);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("DebugLambda", ex);
+            ShowError($"Unexpected error: {ex.Message}");
+        }
+    }
+
+    private static void GenerateSheet(
+        dynamic app, dynamic workbook, dynamic sourceSheet,
+        string formula, string scopeKey, string scopeLabel, int index)
+    {
+        var inputs = DebugNestedEngine.AnalyzeInputs(formula, scopeKey);
+        var seeds = DebugNestedEngine.SuggestPins(formula, scopeKey, index);
+        var seedByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in seeds)
+            seedByName[p.Param] = p.Expression;
+
+        // Capture every input the body needs (on the source sheet, before we add
+        // the new sheet) and collect the own-param seeds for the LET.
+        var scratch = ScratchCell.Locate(sourceSheet);
+        var captures = new List<CapturedInput>();
+        var ownParamSeeds = new List<DebugPin>();
+
+        object? priorScreenUpdating = null;
+        try
+        {
+            try { priorScreenUpdating = app.ScreenUpdating; app.ScreenUpdating = false; }
+            catch { /* cosmetic only */ }
+
+            foreach (var inp in inputs)
+            {
+                string defName;
+                string captureExpr;
+                switch (inp.Kind)
+                {
+                    case DebugInputKind.Param:
+                        defName = inp.Name + "_in";
+                        ownParamSeeds.Add(new DebugPin(inp.Name, defName));
+                        seedByName.TryGetValue(inp.Name, out captureExpr!);
+                        break;
+                    case DebugInputKind.EnclosingParam:
+                        defName = inp.Name;
+                        seedByName.TryGetValue(inp.Name, out captureExpr!);
+                        break;
+                    case DebugInputKind.LetBinding:
+                        defName = inp.Name;
+                        captureExpr = inp.Name; // capture the binding's value in context
+                        break;
+                    default:
+                        continue; // External — resolves on its own
+                }
+
+                captures.Add(Capture(sourceSheet, scratch, formula, scopeKey, defName, inp.Name, captureExpr));
+            }
+
+            var letText = DebugNestedEngine.BuildDebugLet(formula, scopeKey, ownParamSeeds);
+            if (string.IsNullOrEmpty(letText))
+            {
+                ShowError("Couldn't build a debuggable LET for this lambda.");
+                return;
+            }
+
+            var sheet = CreateFreshSheet(workbook);
+            WriteSheet(sheet, formula, scopeLabel, captures, letText);
+
+            try { sheet.Activate(); } catch (Exception ex) { Logger.Error("DebugLambda/Activate", ex); }
+            Logger.Info($"DebugLambda: wrote debug sheet for {scopeKey}");
+        }
+        finally
+        {
+            try
+            {
+                if (priorScreenUpdating is bool b) app.ScreenUpdating = b;
+            }
+            catch { /* leave as-is */ }
+        }
+    }
+
+    private static CapturedInput Capture(
+        dynamic sourceSheet, ScratchCell scratch,
+        string formula, string scopeKey, string defName, string label, string captureExpr)
+    {
+        if (string.IsNullOrWhiteSpace(captureExpr))
+            return CapturedInput.Manual(defName, label);
+
+        var capFormula = DebugNestedEngine.BuildCaptureFormula(formula, scopeKey, captureExpr);
+        if (capFormula is null)
+            return CapturedInput.Manual(defName, label);
+
+        dynamic cell = sourceSheet.Cells[scratch.Row, scratch.Col];
+        try
+        {
+            cell.Formula2 = capFormula;
+
+            var spill = false;
+            try { spill = (bool)cell.HasSpill; }
+            catch { /* HasSpill is 365-only */ }
+
+            if (spill)
+            {
+                dynamic range = cell.SpillingToRange;
+                var rows = (int)range.Rows.Count;
+                var cols = (int)range.Columns.Count;
+                var block = (object[,])range.Value2;
+                return CapturedInput.FromBlock(defName, label, block, rows, cols);
+            }
+
+            return CapturedInput.FromScalar(defName, label, cell.Value2);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"DebugLambda/Capture({label})", ex);
+            return CapturedInput.Manual(defName, label);
+        }
+        finally
+        {
+            try { cell.ClearContents(); }
+            catch (Exception ex) { Logger.Error("DebugLambda/ClearScratch", ex); }
+        }
+    }
+
+    private static dynamic CreateFreshSheet(dynamic workbook)
+    {
+        dynamic sheets = workbook.Worksheets;
+        var count = (int)sheets.Count;
+
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 1; i <= count; i++)
+            existing.Add((string)sheets[i].Name);
+
+        var n = 1;
+        string name;
+        do
+        {
+            name = "LB Debug " + n.ToString(CultureInfo.InvariantCulture);
+            n++;
+        } while (existing.Contains(name));
+
+        dynamic last = sheets[count];
+        dynamic sheet = sheets.Add(Missing.Value, last); // Add(Before, After) — after the last sheet
+        sheet.Name = name;
+        return sheet;
+    }
+
+    private static void WriteSheet(
+        dynamic sheet, string formula, string scopeLabel,
+        IReadOnlyList<CapturedInput> captures, string letText)
+    {
+        var sheetName = (string)sheet.Name;
+
+        SetCell(sheet, 1, 1, "Debug Lambda");
+        SetCell(sheet, 2, 1, "Source");
+        SetCell(sheet, 2, 2, formula);
+        SetCell(sheet, 3, 1, "Lambda");
+        SetCell(sheet, 3, 2, scopeLabel);
+
+        var row = 5;
+        SetCell(sheet, row, 1, "Inputs (edit freely — these are samples):");
+        row++;
+
+        foreach (var cap in captures)
+        {
+            SetCell(sheet, row, 1, cap.Label);
+            var anchorCol = 2;
+
+            if (cap.IsManual)
+            {
+                SetCell(sheet, row, anchorCol, cap.Note);
+                DefineName(sheet, sheetName, cap.DefName, row, anchorCol, row, anchorCol);
+                row += 2;
+                continue;
+            }
+
+            if (cap.Block is not null)
+            {
+                var endRow = row + cap.Rows - 1;
+                var endCol = anchorCol + cap.Cols - 1;
+                dynamic top = sheet.Cells[row, anchorCol];
+                dynamic bottom = sheet.Cells[endRow, endCol];
+                dynamic range = sheet.Range[top, bottom];
+                try { range.Value2 = cap.Block; }
+                catch (Exception ex) { Logger.Error($"DebugLambda/WriteBlock({cap.Label})", ex); }
+                DefineName(sheet, sheetName, cap.DefName, row, anchorCol, endRow, endCol);
+                row = endRow + 2;
+            }
+            else
+            {
+                try { sheet.Cells[row, anchorCol].Value2 = cap.Scalar; }
+                catch (Exception ex) { Logger.Error($"DebugLambda/WriteScalar({cap.Label})", ex); }
+                DefineName(sheet, sheetName, cap.DefName, row, anchorCol, row, anchorCol);
+                row += 2;
+            }
+        }
+
+        row++;
+        SetCell(sheet, row, 1, "Debug LET (play here, then /LET to LAMBDA):");
+        row++;
+        try { sheet.Cells[row, 2].Formula2 = letText; }
+        catch (Exception ex) { Logger.Error("DebugLambda/WriteLet", ex); }
+
+        try { sheet.Columns[1].ColumnWidth = 16; }
+        catch { /* cosmetic */ }
+    }
+
+    private static void SetCell(dynamic sheet, int row, int col, string text)
+    {
+        try { sheet.Cells[row, col].Value2 = text; }
+        catch (Exception ex) { Logger.Error($"DebugLambda/SetCell({row},{col})", ex); }
+    }
+
+    private static void DefineName(
+        dynamic sheet, string sheetName, string name, int r0, int c0, int r1, int c1)
+    {
+        try
+        {
+            dynamic top = sheet.Cells[r0, c0];
+            dynamic bottom = sheet.Cells[r1, c1];
+            dynamic range = sheet.Range[top, bottom];
+            var address = (string)range.Address(true, true); // $A$1 absolute
+            var refersTo = "='" + sheetName.Replace("'", "''") + "'!" + address;
+            sheet.Names.Add(name, refersTo); // sheet-scoped (worksheet.Names)
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"DebugLambda/DefineName({name})", ex);
+        }
+    }
+
+    private static void ShowError(string message)
+    {
+        try
+        {
+            MessageBox.Show(message, "Lambda Boss", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch
+        {
+            Logger.Info($"ShowError: {message}");
+        }
+    }
+
+    /// <summary>A scratch cell on the source sheet, parked beyond the used range.</summary>
+    private readonly struct ScratchCell
+    {
+        public int Row { get; }
+        public int Col { get; }
+
+        private ScratchCell(int row, int col)
+        {
+            Row = row;
+            Col = col;
+        }
+
+        public static ScratchCell Locate(dynamic sheet)
+        {
+            var row = 1;
+            var col = 1;
+            try
+            {
+                dynamic used = sheet.UsedRange;
+                row = (int)used.Row + (int)used.Rows.Count + 2;
+                col = (int)used.Column + (int)used.Columns.Count + 2;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("DebugLambda/ScratchCell", ex);
+            }
+
+            return new ScratchCell(row, col);
+        }
+    }
+
+    /// <summary>A captured input's value snapshot (scalar, 2-D block, or a manual placeholder).</summary>
+    private sealed class CapturedInput
+    {
+        public string DefName { get; private init; } = "";
+        public string Label { get; private init; } = "";
+        public object? Scalar { get; private init; }
+        public object[,]? Block { get; private init; }
+        public int Rows { get; private init; }
+        public int Cols { get; private init; }
+        public bool IsManual { get; private init; }
+        public string Note { get; private init; } = "";
+
+        public static CapturedInput FromScalar(string def, string label, object? value) =>
+            new() { DefName = def, Label = label, Scalar = value };
+
+        public static CapturedInput FromBlock(string def, string label, object[,] block, int rows, int cols) =>
+            new() { DefName = def, Label = label, Block = block, Rows = rows, Cols = cols };
+
+        public static CapturedInput Manual(string def, string label) =>
+            new() { DefName = def, Label = label, IsManual = true, Note = "(fill in an example value)" };
+    }
+}

--- a/addin/lambda-boss/Commands/DebugLambdaCommand.cs
+++ b/addin/lambda-boss/Commands/DebugLambdaCommand.cs
@@ -237,7 +237,11 @@ internal static class DebugLambdaCommand
 
         SetCell(sheet, 1, 1, "Debug Lambda");
         SetCell(sheet, 2, 1, "Source");
-        SetCell(sheet, 2, 2, formula);
+        // The source is an informational echo, not a live formula — write it as
+        // text so Excel doesn't enter it (the Value2 setter would route a leading
+        // '=' through the legacy formula path, scalarising dynamic-array refs with
+        // '@' and resolving any sheet-local refs against this sheet).
+        SetFormulaText(sheet, 2, 2, formula);
         SetCell(sheet, 3, 1, "Lambda");
         SetCell(sheet, 3, 2, scopeLabel);
 
@@ -293,6 +297,22 @@ internal static class DebugLambdaCommand
     {
         try { sheet.Cells[row, col].Value2 = text; }
         catch (Exception ex) { Logger.Error($"DebugLambda/SetCell({row},{col})", ex); }
+    }
+
+    /// <summary>
+    ///     Writes <paramref name="text" /> that may start with <c>=</c> as literal
+    ///     text (forcing the cell to text format first) so Excel displays it
+    ///     verbatim instead of entering it as a formula.
+    /// </summary>
+    private static void SetFormulaText(dynamic sheet, int row, int col, string text)
+    {
+        try
+        {
+            dynamic cell = sheet.Cells[row, col];
+            cell.NumberFormat = "@";
+            cell.Value2 = text;
+        }
+        catch (Exception ex) { Logger.Error($"DebugLambda/SetFormulaText({row},{col})", ex); }
     }
 
     private static void DefineName(

--- a/addin/lambda-boss/Commands/DebugNestedCommand.cs
+++ b/addin/lambda-boss/Commands/DebugNestedCommand.cs
@@ -1,0 +1,305 @@
+using System.Globalization;
+using System.Text;
+using System.Windows;
+using System.Windows.Interop;
+
+using ExcelDna.Integration;
+
+using LambdaBoss.Common;
+using LambdaBoss.UI;
+
+namespace LambdaBoss.Commands;
+
+/// <summary>
+///     Spec 0010 (spike) / issue #279 — slash-command handler for
+///     <c>/Debug Nested</c>. Reads the active cell's formula, finds its
+///     <c>LAMBDA(...)</c> scopes (<see cref="DebugNestedEngine" />), and opens
+///     <see cref="DebugNestedWindow" /> so the user can pin one concrete example
+///     and watch each step of a chosen lambda body compute a live value.
+///
+///     <para>
+///     Unlike <c>/Unnest</c>'s modal dialog (which blocks Excel's main thread
+///     while open), this window is <em>modeless</em>: the debugger must evaluate
+///     probe formulas against the live grid while it's open, which requires
+///     Excel to stay responsive. Each evaluation is marshalled back onto the
+///     Excel macro thread via <see cref="ExcelAsyncUtil.QueueAsMacro" /> — the
+///     window calls the supplied delegate from a background task and blocks only
+///     its own UI thread until the macro completes. The probe is written to a
+///     scratch cell beyond the sheet's used range, read back, and cleared
+///     (mechanism C). Nothing is written to the active cell — this is a read-only
+///     debugging view, not a refactor.
+///     </para>
+/// </summary>
+internal static class DebugNestedCommand
+{
+    public static void Run()
+    {
+        try
+        {
+            dynamic app = ExcelDnaUtil.Application;
+            var workbook = app.ActiveWorkbook;
+            if (workbook == null)
+                return;
+
+            var activeCell = app.ActiveCell;
+            if (activeCell == null)
+                return;
+
+            if (!(bool)activeCell.HasFormula)
+                return;
+
+            var formula = (string)activeCell.Formula2;
+
+            var discovery = DebugNestedEngine.Discover(formula);
+            if (discovery.Diagnostic != null)
+            {
+                Logger.Info($"DebugNested: refused — {discovery.Diagnostic.Kind}");
+                ShowError(discovery.Diagnostic.Message);
+                return;
+            }
+
+            var worksheet = activeCell.Worksheet;
+            var evaluator = ScratchEvaluator.Create(app, worksheet);
+
+            // A blocking evaluate delegate that is safe to call from the WPF
+            // window thread: it hops onto the Excel macro thread (free, because
+            // the window is modeless) and blocks the caller until the batch is
+            // computed against the live grid.
+            IReadOnlyList<DebugValue> Evaluate(IReadOnlyList<string> formulas)
+            {
+                IReadOnlyList<DebugValue> result =
+                    formulas.Select(_ => new DebugValue("(not computed)", true)).ToArray();
+                var done = new ManualResetEventSlim(false);
+
+                ExcelAsyncUtil.QueueAsMacro(() =>
+                {
+                    try
+                    {
+                        result = evaluator.EvaluateBatch(formulas);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error("DebugNested/Evaluate", ex);
+                    }
+                    finally
+                    {
+                        done.Set();
+                    }
+                });
+
+                done.Wait();
+                return result;
+            }
+
+            var excelHwnd = new IntPtr(app.Hwnd);
+
+            ShowLambdaPopupCommand.InvokeOnWindowThread(dispatcher =>
+            {
+                dispatcher.Invoke(() =>
+                {
+                    var window = new DebugNestedWindow(formula, discovery, Evaluate);
+                    var wpfHwnd = new WindowInteropHelper(window).EnsureHandle();
+                    WindowPositioner.CenterOnExcel(excelHwnd, wpfHwnd);
+                    window.Show();
+                });
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.Error("DebugNested", ex);
+            ShowError($"Unexpected error: {ex.Message}");
+        }
+    }
+
+    private static void ShowError(string message)
+    {
+        try
+        {
+            MessageBox.Show(message, "Lambda Boss", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch
+        {
+            Logger.Info($"ShowError: {message}");
+        }
+    }
+
+    /// <summary>
+    ///     Evaluates probe formulas (mechanism C) by writing each to a scratch
+    ///     cell beyond the active sheet's used range, reading the result back,
+    ///     and clearing the cell. The scratch cell is on the <em>same sheet</em>
+    ///     as the active cell so that sheet-local A1 references in the original
+    ///     formula resolve to the same targets. All members must run on the Excel
+    ///     main thread (the command only ever calls them inside QueueAsMacro).
+    /// </summary>
+    private sealed class ScratchEvaluator
+    {
+        private const int MaxPreviewCells = 12;
+
+        private readonly dynamic _app;
+        private readonly dynamic _sheet;
+        private readonly int _row;
+        private readonly int _col;
+
+        private ScratchEvaluator(dynamic app, dynamic sheet, int row, int col)
+        {
+            _app = app;
+            _sheet = sheet;
+            _row = row;
+            _col = col;
+        }
+
+        public static ScratchEvaluator Create(dynamic app, dynamic sheet)
+        {
+            // Park the scratch cell a few rows/cols beyond the used range so a
+            // spilled probe has room and never clobbers real data.
+            var row = 1;
+            var col = 1;
+            try
+            {
+                dynamic used = sheet.UsedRange;
+                row = (int)used.Row + (int)used.Rows.Count + 2;
+                col = (int)used.Column + (int)used.Columns.Count + 2;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("DebugNested/Scratch/UsedRange", ex);
+            }
+
+            return new ScratchEvaluator(app, sheet, row, col);
+        }
+
+        public IReadOnlyList<DebugValue> EvaluateBatch(IReadOnlyList<string> formulas)
+        {
+            object? priorScreenUpdating = null;
+            try
+            {
+                priorScreenUpdating = _app.ScreenUpdating;
+                _app.ScreenUpdating = false;
+            }
+            catch
+            {
+                // Non-fatal cosmetics — proceed without toggling.
+            }
+
+            try
+            {
+                return formulas.Select(EvaluateOne).ToArray();
+            }
+            finally
+            {
+                try
+                {
+                    if (priorScreenUpdating is bool b)
+                        _app.ScreenUpdating = b;
+                }
+                catch
+                {
+                    // Ignore — leave ScreenUpdating in whatever state we managed.
+                }
+            }
+        }
+
+        private DebugValue EvaluateOne(string formula)
+        {
+            dynamic cell = _sheet.Cells[_row, _col];
+            try
+            {
+                cell.Formula2 = formula;
+
+                var spill = false;
+                try
+                {
+                    spill = (bool)cell.HasSpill;
+                }
+                catch
+                {
+                    // Range.HasSpill is Excel-365 only; treat as scalar otherwise.
+                }
+
+                if (spill)
+                    return FormatSpill(cell);
+
+                var text = (string)cell.Text;
+                return new DebugValue(text, IsErrorText(text));
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("DebugNested/EvaluateOne", ex);
+                return new DebugValue("(uncomputable)", true);
+            }
+            finally
+            {
+                try
+                {
+                    cell.ClearContents();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("DebugNested/ClearScratch", ex);
+                }
+            }
+        }
+
+        private static DebugValue FormatSpill(dynamic anchor)
+        {
+            try
+            {
+                dynamic range = anchor.SpillingToRange;
+                var rows = (int)range.Rows.Count;
+                var cols = (int)range.Columns.Count;
+
+                var values = range.Value2;
+                var sb = new StringBuilder();
+                sb.Append('{').Append(rows).Append('×').Append(cols).Append("} ");
+
+                var shown = 0;
+                var truncated = false;
+                if (rows == 1 && cols == 1)
+                {
+                    sb.Append(Stringify(values));
+                }
+                else
+                {
+                    for (var r = 1; r <= rows && !truncated; r++)
+                    for (var c = 1; c <= cols; c++)
+                    {
+                        if (shown >= MaxPreviewCells)
+                        {
+                            truncated = true;
+                            break;
+                        }
+
+                        if (shown > 0) sb.Append(", ");
+                        sb.Append(Stringify(values[r, c]));
+                        shown++;
+                    }
+
+                    if (truncated) sb.Append(", …");
+                }
+
+                return new DebugValue(sb.ToString(), false);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("DebugNested/FormatSpill", ex);
+                return new DebugValue("(array)", false);
+            }
+        }
+
+        private static string Stringify(object? v)
+        {
+            return v switch
+            {
+                null => "",
+                double d => d.ToString("0.######", CultureInfo.InvariantCulture),
+                bool b => b ? "TRUE" : "FALSE",
+                _ => v.ToString() ?? ""
+            };
+        }
+
+        private static bool IsErrorText(string text)
+        {
+            return !string.IsNullOrEmpty(text) && text[0] == '#';
+        }
+    }
+}

--- a/addin/lambda-boss/DebugNestedEngine.cs
+++ b/addin/lambda-boss/DebugNestedEngine.cs
@@ -363,6 +363,72 @@ public static class DebugNestedEngine
     }
 
     /// <summary>
+    ///     Builds a probe formula that captures the value bound to
+    ///     <paramref name="paramName" /> on element <paramref name="index" /> of a
+    ///     <em>custom</em> higher-order host (where no slice expression exists). It
+    ///     reruns the host with the lambda's body replaced by the parameter, in the
+    ///     lambda's enclosing context with any enclosing parameters pinned to their
+    ///     own slices, then reads element <paramref name="index" />:
+    ///     <c>=LET(&lt;enclosing LET&gt;, &lt;enclosing param pins&gt;, INDEX(&lt;host with body→param&gt;, index))</c>.
+    ///     This works for a host that feeds scalar parameters (the common custom-HOF
+    ///     case); it returns null when the scope has no identifiable host node or
+    ///     the formula/scope can't be read. A host that can't yield the value (e.g.
+    ///     an array-shaped parameter, or an enclosing parameter that couldn't be
+    ///     pinned) surfaces as an Excel error at evaluation time, which the caller
+    ///     treats as "fill in by hand".
+    /// </summary>
+    public static string? BuildParamProbe(string formula, string scopeKey, string paramName, int index)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+        if (scopeKey is null) throw new ArgumentNullException(nameof(scopeKey));
+        if (paramName is null) throw new ArgumentNullException(nameof(paramName));
+
+        List<ScopeInfo> infos;
+        try
+        {
+            infos = WalkScopes(formula);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+
+        var target = infos.FirstOrDefault(s => s.Key == scopeKey);
+        if (target?.HostNode is null || target.BodyNode is null)
+            return null;
+
+        var host = target.HostNode;
+        var body = target.BodyNode;
+
+        // Rebuild the host call text with the lambda body replaced by the bare
+        // parameter, by splicing the original source around the body's span.
+        var modifiedHost =
+            formula[host.Start..body.Start] + paramName + formula[body.End..host.End];
+
+        var k = index.ToString(CultureInfo.InvariantCulture);
+        var extraction = $"INDEX({modifiedHost}, {k})";
+
+        // Pin enclosing-lambda params (e.g. an outer BYROW's row) to their own
+        // slices so the host can actually run; enclosing-LET bindings come first.
+        var enclSet = new HashSet<string>(target.EnclosingParams, StringComparer.OrdinalIgnoreCase);
+        var paramPins = SuggestPins(formula, scopeKey, index)
+            .Where(p => enclSet.Contains(p.Param) && !string.IsNullOrWhiteSpace(p.Expression))
+            .ToList();
+
+        if (target.EnclosingLet.Count == 0 && paramPins.Count == 0)
+            return "=" + extraction;
+
+        var sb = new StringBuilder();
+        sb.Append("=LET(");
+        foreach (var (name, rhs) in target.EnclosingLet)
+            sb.Append(name).Append(", ").Append(rhs).Append(", ");
+        foreach (var pin in paramPins)
+            sb.Append(pin.Param).Append(", ").Append(pin.Expression).Append(", ");
+        sb.Append(extraction).Append(')');
+        return sb.ToString();
+    }
+
+    /// <summary>
     ///     Collects, in first-encounter order, the plain-identifier names that are
     ///     free in <paramref name="node" /> — i.e. not bound by a <c>LET</c> or
     ///     <c>LAMBDA</c> nested within it, and not a function-call name. Cell
@@ -511,6 +577,10 @@ public static class DebugNestedEngine
         public List<(string Name, string Rhs)> EnclosingLet = new();
         public string BodyText = "";
         public int? ParentIndex;
+
+        // Nodes for probe splicing (positions index into the parsed source).
+        public FormulaNode? BodyNode;
+        public FunctionCallNode? HostNode;
     }
 
     private static readonly (string Name, string Rhs)[] EmptyLet = Array.Empty<(string, string)>();
@@ -519,7 +589,7 @@ public static class DebugNestedEngine
     {
         var ast = FormulaParser.Parse(formula);
         var sink = new List<ScopeInfo>();
-        Visit(ast.Root, hostName: "", Empty, Empty, EmptyLet, depth: 0, parentIndex: null, sink);
+        Visit(ast.Root, hostName: "", Empty, Empty, EmptyLet, hostNode: null, depth: 0, parentIndex: null, sink);
         return sink;
     }
 
@@ -529,6 +599,7 @@ public static class DebugNestedEngine
         IReadOnlyList<string> hostArgs,
         IReadOnlyList<string> enclosing,
         IReadOnlyList<(string Name, string Rhs)> enclosingLet,
+        FunctionCallNode? hostNode,
         int depth,
         int? parentIndex,
         List<ScopeInfo> sink)
@@ -546,7 +617,9 @@ public static class DebugNestedEngine
                 EnclosingParams = enclosing.ToList(),
                 EnclosingLet = enclosingLet.ToList(),
                 BodyText = body.ToFormula().Trim(),
-                ParentIndex = parentIndex
+                ParentIndex = parentIndex,
+                BodyNode = body,
+                HostNode = hostNode
             };
             var myIndex = sink.Count;
             sink.Add(info);
@@ -554,7 +627,7 @@ public static class DebugNestedEngine
             // Descend into the body to find nested lambda scopes; the body's own
             // params join the enclosing set for them.
             var childEnclosing = enclosing.Concat(paramNames).ToList();
-            Visit(body, hostName: "", Empty, childEnclosing, enclosingLet, depth + 1, myIndex, sink);
+            Visit(body, hostName: "", Empty, childEnclosing, enclosingLet, hostNode: null, depth + 1, myIndex, sink);
             return;
         }
 
@@ -567,12 +640,12 @@ public static class DebugNestedEngine
             var i = 0;
             for (; i + 1 < args.Count; i += 2)
             {
-                Visit(args[i + 1], "LET", Empty, enclosing, acc, depth, parentIndex, sink);
+                Visit(args[i + 1], "LET", Empty, enclosing, acc, hostNode: null, depth, parentIndex, sink);
                 acc.Add((args[i].ToFormula().Trim(), args[i + 1].ToFormula().Trim()));
             }
 
             if (i < args.Count)
-                Visit(args[i], "LET", Empty, enclosing, acc, depth, parentIndex, sink);
+                Visit(args[i], "LET", Empty, enclosing, acc, hostNode: null, depth, parentIndex, sink);
             return;
         }
 
@@ -586,12 +659,12 @@ public static class DebugNestedEngine
                 .ToList();
             var name = CleanName(call.Name);
             foreach (var arg in call.Arguments)
-                Visit(arg, name, sourceArgs, enclosing, enclosingLet, depth, parentIndex, sink);
+                Visit(arg, name, sourceArgs, enclosing, enclosingLet, hostNode: call, depth, parentIndex, sink);
             return;
         }
 
         foreach (var child in Children(node))
-            Visit(child, hostName, hostArgs, enclosing, enclosingLet, depth, parentIndex, sink);
+            Visit(child, hostName, hostArgs, enclosing, enclosingLet, hostNode, depth, parentIndex, sink);
     }
 
     private static bool IsLet(FunctionCallNode call)

--- a/addin/lambda-boss/DebugNestedEngine.cs
+++ b/addin/lambda-boss/DebugNestedEngine.cs
@@ -191,6 +191,213 @@ public static class DebugNestedEngine
         return new DebugWatch(scopeKey, debugSteps, "result", finalEval);
     }
 
+    // ---------------- scratch-sheet extraction (new approach) ----------------
+
+    /// <summary>
+    ///     The minimum set of free names a scope's body references, classified
+    ///     (<see cref="DebugInput" />) so the scratch-sheet generator knows how to
+    ///     supply each: a <see cref="DebugInputKind.Param" /> /
+    ///     <see cref="DebugInputKind.EnclosingParam" /> needs a sample value, a
+    ///     <see cref="DebugInputKind.LetBinding" /> carries its enclosing-LET
+    ///     definition to rebuild, and an <see cref="DebugInputKind.External" />
+    ///     resolves on its own. Names bound <em>within</em> the body (its own
+    ///     nested <c>LET</c>/<c>LAMBDA</c>) are not inputs. Returns an empty list
+    ///     when the formula or scope can't be found.
+    /// </summary>
+    public static IReadOnlyList<DebugInput> AnalyzeInputs(string formula, string scopeKey)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+
+        List<ScopeInfo> infos;
+        try
+        {
+            infos = WalkScopes(formula);
+        }
+        catch (FormatException)
+        {
+            return Array.Empty<DebugInput>();
+        }
+
+        var target = infos.FirstOrDefault(s => s.Key == scopeKey);
+        if (target is null) return Array.Empty<DebugInput>();
+
+        FormulaNode body;
+        try
+        {
+            body = FormulaParser.Parse(target.BodyText).Root;
+        }
+        catch (FormatException)
+        {
+            return Array.Empty<DebugInput>();
+        }
+
+        var order = new List<string>();
+        CollectFreeNames(body, new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            order, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        var ownParams = new HashSet<string>(target.Params, StringComparer.OrdinalIgnoreCase);
+        var enclParams = new HashSet<string>(target.EnclosingParams, StringComparer.OrdinalIgnoreCase);
+        var letByName = target.EnclosingLet
+            .GroupBy(b => b.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.Last().Rhs, StringComparer.OrdinalIgnoreCase);
+
+        var inputs = new List<DebugInput>(order.Count);
+        foreach (var name in order)
+        {
+            if (ownParams.Contains(name))
+                inputs.Add(new DebugInput(name, DebugInputKind.Param, null));
+            else if (enclParams.Contains(name))
+                inputs.Add(new DebugInput(name, DebugInputKind.EnclosingParam, null));
+            else if (letByName.TryGetValue(name, out var def))
+                inputs.Add(new DebugInput(name, DebugInputKind.LetBinding, def));
+            else
+                inputs.Add(new DebugInput(name, DebugInputKind.External, null));
+        }
+
+        return inputs;
+    }
+
+    /// <summary>
+    ///     Assembles the debuggable multiline <c>=LET(...)</c> for a scope: each
+    ///     parameter seeded with the supplied expression (a live slice for a known
+    ///     iterator, or a probe-captured literal), followed by the body decomposed
+    ///     into leaf-first steps (reusing <see cref="UnnestEngine" />), then the
+    ///     body. Seeding the params as the <em>first</em> bindings means a later
+    ///     <c>/LET to LAMBDA</c> lifts exactly them into the lambda's signature.
+    ///     Enclosing-LET names referenced by the body (e.g. <c>convert</c>) are
+    ///     left as free names — the scratch sheet rebuilds them as sheet-scoped
+    ///     defined names, so they resolve without becoming parameters. Returns
+    ///     the empty string when the formula or scope can't be read.
+    /// </summary>
+    public static string BuildDebugLet(
+        string formula,
+        string scopeKey,
+        IReadOnlyList<DebugPin> paramSeeds,
+        IReadOnlyCollection<string>? definedNames = null)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+        if (scopeKey is null) throw new ArgumentNullException(nameof(scopeKey));
+        if (paramSeeds is null) throw new ArgumentNullException(nameof(paramSeeds));
+
+        List<ScopeInfo> infos;
+        try
+        {
+            infos = WalkScopes(formula);
+        }
+        catch (FormatException)
+        {
+            return "";
+        }
+
+        var target = infos.FirstOrDefault(s => s.Key == scopeKey);
+        if (target is null) return "";
+
+        // Prefix '=' so a body that is itself a LET takes UnnestEngine's
+        // existing-LET path (which decomposes it) rather than being treated as
+        // an opaque scope-introducing call.
+        var un = UnnestEngine.Unnest("=" + target.BodyText, definedNames);
+        if (un.Diagnostic is not null) return "";
+
+        List<(string Name, string Value)> innerBindings;
+        string finalBody;
+        if (LetParser.IsLetFormula(un.SynthesisedLet))
+        {
+            var parsed = LetParser.Parse(un.SynthesisedLet);
+            innerBindings = parsed.Bindings.Select(b => (b.Name, b.RhsText)).ToList();
+            finalBody = parsed.Body;
+        }
+        else
+        {
+            innerBindings = new List<(string, string)>();
+            finalBody = target.BodyText;
+        }
+
+        var bindings = paramSeeds
+            .Select(p => (p.Param, p.Expression))
+            .Concat(innerBindings)
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.Append('=');
+        FormulaFormatter.AppendLet(sb, 0, bindings, finalBody);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    ///     Collects, in first-encounter order, the plain-identifier names that are
+    ///     free in <paramref name="node" /> — i.e. not bound by a <c>LET</c> or
+    ///     <c>LAMBDA</c> nested within it, and not a function-call name. Cell
+    ///     references and structured/table references are skipped (they aren't
+    ///     debug inputs); a name shadowed by an inner binding is correctly
+    ///     excluded for that sub-tree.
+    /// </summary>
+    private static void CollectFreeNames(
+        FormulaNode node, HashSet<string> bound, List<string> order, HashSet<string> seen)
+    {
+        switch (node)
+        {
+            case LeafNode leaf when leaf.TokenType == FormulaTokenType.Name:
+                var name = leaf.Text;
+                if (IsPlainName(name) && !bound.Contains(name) && seen.Add(name))
+                    order.Add(name);
+                return;
+
+            case FunctionCallNode lam when IsLambdaCall(lam, out var lamCall):
+            {
+                var (ps, body) = SplitLambda(lamCall);
+                var inner = new HashSet<string>(bound, StringComparer.OrdinalIgnoreCase);
+                foreach (var p in ps) inner.Add(p);
+                CollectFreeNames(body, inner, order, seen);
+                return;
+            }
+
+            case FunctionCallNode let when IsLet(let):
+            {
+                var args = let.Arguments;
+                var inner = new HashSet<string>(bound, StringComparer.OrdinalIgnoreCase);
+                var i = 0;
+                for (; i + 1 < args.Count; i += 2)
+                {
+                    CollectFreeNames(args[i + 1], inner, order, seen);
+                    inner.Add(args[i].ToFormula().Trim());
+                }
+
+                if (i < args.Count)
+                    CollectFreeNames(args[i], inner, order, seen);
+                return;
+            }
+
+            case FunctionCallNode call:
+                foreach (var arg in call.Arguments)
+                    CollectFreeNames(arg, bound, order, seen);
+                return;
+
+            default:
+                foreach (var child in Children(node))
+                    CollectFreeNames(child, bound, order, seen);
+                return;
+        }
+    }
+
+    /// <summary>
+    ///     True for a bare Excel identifier (a defined name or lambda parameter):
+    ///     starts with a letter or underscore, then letters/digits/<c>_ . ?</c>.
+    ///     This deliberately rejects cell addresses like <c>A1</c> (which contain
+    ///     no separator but end in digits after column letters) only loosely — a
+    ///     name like <c>data</c> or <c>convert</c> matches, while a pure reference
+    ///     token carrying <c>! : $ [ ]</c> never does. Cell-address-shaped names
+    ///     fall through to the External bucket, which is harmless.
+    /// </summary>
+    private static bool IsPlainName(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return false;
+        if (!char.IsLetter(s[0]) && s[0] != '_') return false;
+        foreach (var c in s)
+            if (!char.IsLetterOrDigit(c) && c != '_' && c != '.' && c != '?')
+                return false;
+        return true;
+    }
+
     // ---------------- evaluable-formula assembly ----------------
 
     /// <summary>
@@ -262,15 +469,18 @@ public static class DebugNestedEngine
         public List<string> HostSourceArgs = new();
         public List<string> Params = new();
         public List<string> EnclosingParams = new();
+        public List<(string Name, string Rhs)> EnclosingLet = new();
         public string BodyText = "";
         public int? ParentIndex;
     }
+
+    private static readonly (string Name, string Rhs)[] EmptyLet = Array.Empty<(string, string)>();
 
     private static List<ScopeInfo> WalkScopes(string formula)
     {
         var ast = FormulaParser.Parse(formula);
         var sink = new List<ScopeInfo>();
-        Visit(ast.Root, hostName: "", Empty, Empty, depth: 0, parentIndex: null, sink);
+        Visit(ast.Root, hostName: "", Empty, Empty, EmptyLet, depth: 0, parentIndex: null, sink);
         return sink;
     }
 
@@ -279,6 +489,7 @@ public static class DebugNestedEngine
         string hostName,
         IReadOnlyList<string> hostArgs,
         IReadOnlyList<string> enclosing,
+        IReadOnlyList<(string Name, string Rhs)> enclosingLet,
         int depth,
         int? parentIndex,
         List<ScopeInfo> sink)
@@ -294,6 +505,7 @@ public static class DebugNestedEngine
                 HostSourceArgs = hostArgs.ToList(),
                 Params = paramNames,
                 EnclosingParams = enclosing.ToList(),
+                EnclosingLet = enclosingLet.ToList(),
                 BodyText = body.ToFormula().Trim(),
                 ParentIndex = parentIndex
             };
@@ -303,7 +515,25 @@ public static class DebugNestedEngine
             // Descend into the body to find nested lambda scopes; the body's own
             // params join the enclosing set for them.
             var childEnclosing = enclosing.Concat(paramNames).ToList();
-            Visit(body, hostName: "", Empty, childEnclosing, depth + 1, myIndex, sink);
+            Visit(body, hostName: "", Empty, childEnclosing, enclosingLet, depth + 1, myIndex, sink);
+            return;
+        }
+
+        // A LET binds names visible to its later bindings and body — thread them
+        // so a lambda nested inside the LET knows which free names it can rebuild.
+        if (node is FunctionCallNode letCall && IsLet(letCall))
+        {
+            var args = letCall.Arguments;
+            var acc = enclosingLet.ToList();
+            var i = 0;
+            for (; i + 1 < args.Count; i += 2)
+            {
+                Visit(args[i + 1], "LET", Empty, enclosing, acc, depth, parentIndex, sink);
+                acc.Add((args[i].ToFormula().Trim(), args[i + 1].ToFormula().Trim()));
+            }
+
+            if (i < args.Count)
+                Visit(args[i], "LET", Empty, enclosing, acc, depth, parentIndex, sink);
             return;
         }
 
@@ -317,12 +547,17 @@ public static class DebugNestedEngine
                 .ToList();
             var name = CleanName(call.Name);
             foreach (var arg in call.Arguments)
-                Visit(arg, name, sourceArgs, enclosing, depth, parentIndex, sink);
+                Visit(arg, name, sourceArgs, enclosing, enclosingLet, depth, parentIndex, sink);
             return;
         }
 
         foreach (var child in Children(node))
-            Visit(child, hostName, hostArgs, enclosing, depth, parentIndex, sink);
+            Visit(child, hostName, hostArgs, enclosing, enclosingLet, depth, parentIndex, sink);
+    }
+
+    private static bool IsLet(FunctionCallNode call)
+    {
+        return CleanName(call.Name).Equals("LET", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsLambdaCall(FormulaNode node, out FunctionCallNode call)

--- a/addin/lambda-boss/DebugNestedEngine.cs
+++ b/addin/lambda-boss/DebugNestedEngine.cs
@@ -324,6 +324,45 @@ public static class DebugNestedEngine
     }
 
     /// <summary>
+    ///     Wraps <paramref name="expression" /> in the chosen scope's enclosing
+    ///     <c>LET</c> context so it can be evaluated to a concrete value on the
+    ///     source sheet (where sheet-local references and tables resolve). Used to
+    ///     snapshot an input for the scratch sheet: pass a parameter's slice
+    ///     expression (<c>CHOOSEROWS(both, 1)</c>) or an enclosing-LET binding's
+    ///     name (<c>convert</c>) and evaluate the result. Returns null when the
+    ///     formula or scope can't be read.
+    /// </summary>
+    public static string? BuildCaptureFormula(string formula, string scopeKey, string expression)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+        if (scopeKey is null) throw new ArgumentNullException(nameof(scopeKey));
+        if (expression is null) throw new ArgumentNullException(nameof(expression));
+
+        List<ScopeInfo> infos;
+        try
+        {
+            infos = WalkScopes(formula);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+
+        var target = infos.FirstOrDefault(s => s.Key == scopeKey);
+        if (target is null) return null;
+
+        if (target.EnclosingLet.Count == 0)
+            return "=" + expression;
+
+        var sb = new StringBuilder();
+        sb.Append("=LET(");
+        foreach (var (name, rhs) in target.EnclosingLet)
+            sb.Append(name).Append(", ").Append(rhs).Append(", ");
+        sb.Append(expression).Append(')');
+        return sb.ToString();
+    }
+
+    /// <summary>
     ///     Collects, in first-encounter order, the plain-identifier names that are
     ///     free in <paramref name="node" /> — i.e. not bound by a <c>LET</c> or
     ///     <c>LAMBDA</c> nested within it, and not a function-call name. Cell

--- a/addin/lambda-boss/DebugNestedEngine.cs
+++ b/addin/lambda-boss/DebugNestedEngine.cs
@@ -1,0 +1,436 @@
+using System.Globalization;
+using System.Text;
+
+namespace LambdaBoss;
+
+/// <summary>
+///     Spec 0010 (spike) — issue #279. The <c>/Debug Nested</c> engine. Where
+///     <see cref="UnnestEngine" /> answers "decompose this static nested formula
+///     into named steps", this engine answers the complementary, harder question:
+///     a <c>LAMBDA(...)</c> applied over an array (<c>BYROW(arr, LAMBDA(r, …))</c>,
+///     a custom <c>PAIROP(r, LAMBDA(a, b, …))</c>, …) runs its body once per
+///     element with its parameters bound dynamically, so no sub-expression has a
+///     single value to inspect. This engine lets the user <em>pin</em> one
+///     concrete example — binding each in-scope parameter to a value — and then
+///     produces, for every step of the body, a self-contained <c>=LET(...)</c>
+///     the add-in evaluates to show that step's live value for the pinned example
+///     (the "pin &amp; watch" approach: option A + mechanism C from the #279 spike).
+///
+///     <para>
+///     The engine is pure (no Excel dependency): <see cref="Discover" /> finds
+///     the lambda scopes, <see cref="SuggestPins" /> proposes default pin
+///     expressions for recognised iterators, and <see cref="BuildWatch" /> turns
+///     a chosen scope + pins into evaluable formulas. Actually running those
+///     formulas (reading values back from Excel) is the command's job.
+///     </para>
+///
+///     <para>
+///     Step decomposition reuses <see cref="UnnestEngine.Unnest" /> over the
+///     scope's body text, which already treats a deeper nested
+///     <c>LAMBDA</c>/<c>LET</c> as opaque — so a step that contains an inner
+///     lambda keeps it inline (the user drills into that inner scope separately),
+///     and nothing escapes its binding scope.
+///     </para>
+/// </summary>
+public static class DebugNestedEngine
+{
+    private static readonly string[] Empty = Array.Empty<string>();
+
+    /// <summary>
+    ///     Scans <paramref name="formula" /> for every <c>LAMBDA(...)</c> scope,
+    ///     returning them outer-first. A malformed formula or one with no lambda
+    ///     is reported via <see cref="DebugDiscovery.Diagnostic" />.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="formula" /> is null.</exception>
+    public static DebugDiscovery Discover(string formula)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+
+        List<ScopeInfo> infos;
+        try
+        {
+            infos = WalkScopes(formula);
+        }
+        catch (FormatException ex)
+        {
+            return new DebugDiscovery(
+                Array.Empty<DebugScope>(),
+                new DebugDiagnostic(
+                    DebugDiagnosticKind.MalformedFormula,
+                    $"Debug Nested can't parse this formula: {ex.Message}"));
+        }
+
+        if (infos.Count == 0)
+            return new DebugDiscovery(
+                Array.Empty<DebugScope>(),
+                new DebugDiagnostic(
+                    DebugDiagnosticKind.NoLambda,
+                    "This formula contains no LAMBDA(...) to debug. Use /Unnest for a static nested formula."));
+
+        return new DebugDiscovery(infos.Select(ToScope).ToList());
+    }
+
+    /// <summary>
+    ///     Proposes a default pin expression for every parameter in scope inside
+    ///     <paramref name="scopeKey" /> (enclosing params outer-first, then the
+    ///     scope's own), at the 1-based example <paramref name="index" />. A
+    ///     recognised array iterator yields a slice of its source
+    ///     (<c>CHOOSEROWS(arr, k)</c> for <c>BYROW</c>, <c>CHOOSECOLS</c> for
+    ///     <c>BYCOL</c>); anything else yields an empty expression for the user to
+    ///     fill in. Returns an empty list when the formula or scope can't be found.
+    /// </summary>
+    public static IReadOnlyList<DebugPin> SuggestPins(string formula, string scopeKey, int index = 1)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+
+        List<ScopeInfo> infos;
+        try
+        {
+            infos = WalkScopes(formula);
+        }
+        catch (FormatException)
+        {
+            return Array.Empty<DebugPin>();
+        }
+
+        var target = infos.FirstOrDefault(s => s.Key == scopeKey);
+        if (target is null) return Array.Empty<DebugPin>();
+
+        var pins = new List<DebugPin>();
+        foreach (var scope in ChainTo(infos, target))
+            foreach (var p in scope.Params)
+                pins.Add(new DebugPin(p, SuggestExpr(scope, p, index)));
+
+        return pins;
+    }
+
+    /// <summary>
+    ///     Builds the watch model for <paramref name="scopeKey" /> pinned with
+    ///     <paramref name="pins" />: the scope body's steps (via
+    ///     <see cref="UnnestEngine" />) each paired with a self-contained
+    ///     <c>=LET(...)</c> that binds the pins and preceding steps then returns
+    ///     the step, plus a final formula for the whole body. Pins with a blank
+    ///     expression are omitted (the corresponding parameter stays unbound, so
+    ///     its dependent steps evaluate to an Excel error — a signal to fill it
+    ///     in). A body the expression parser can't read is reported via
+    ///     <see cref="DebugWatch.Diagnostic" />.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">An argument is null.</exception>
+    public static DebugWatch BuildWatch(
+        string formula,
+        string scopeKey,
+        IReadOnlyList<DebugPin> pins,
+        IReadOnlyCollection<string>? definedNames = null)
+    {
+        if (formula is null) throw new ArgumentNullException(nameof(formula));
+        if (scopeKey is null) throw new ArgumentNullException(nameof(scopeKey));
+        if (pins is null) throw new ArgumentNullException(nameof(pins));
+
+        List<ScopeInfo> infos;
+        try
+        {
+            infos = WalkScopes(formula);
+        }
+        catch (FormatException ex)
+        {
+            return Malformed(scopeKey, DebugDiagnosticKind.MalformedFormula,
+                $"Debug Nested can't parse this formula: {ex.Message}");
+        }
+
+        var target = infos.FirstOrDefault(s => s.Key == scopeKey);
+        if (target is null)
+            return Malformed(scopeKey, DebugDiagnosticKind.MalformedBody,
+                "That lambda scope is no longer present in the formula.");
+
+        var un = UnnestEngine.Unnest(target.BodyText, definedNames);
+        if (un.Diagnostic is not null)
+            return Malformed(scopeKey, DebugDiagnosticKind.MalformedBody,
+                $"Can't decompose this lambda body: {un.Diagnostic.Message}");
+
+        // Pin bindings (outer-first); a blank expression is skipped so we never
+        // emit a syntactically invalid `LET(p, , …)`.
+        var pinBindings = pins
+            .Where(p => !string.IsNullOrWhiteSpace(p.Expression))
+            .Select(p => (Name: p.Param, Value: p.Expression.Trim()))
+            .ToList();
+
+        // Steps + final body. With no rowStates every step is included, so the
+        // synthesised LET's bindings line up with un.Steps in order; its body is
+        // the scope body with included children collapsed to step names. When the
+        // body decomposes to nothing, the body text itself is the only result.
+        var steps = un.Steps;
+        string finalBody;
+        if (steps.Count == 0)
+        {
+            finalBody = target.BodyText;
+        }
+        else
+        {
+            try
+            {
+                finalBody = LetParser.Parse(un.SynthesisedLet).Body;
+            }
+            catch (FormatException)
+            {
+                // Defensive: UnnestEngine always emits a parseable LET, but if
+                // that ever changes, fall back to the raw body text.
+                finalBody = target.BodyText;
+            }
+        }
+
+        var stepBindings = new List<(string Name, string Value)>();
+        var debugSteps = new List<DebugStep>(steps.Count);
+        foreach (var s in steps)
+        {
+            stepBindings.Add((s.Name, s.Rhs));
+            var eval = BuildEvalLet(pinBindings, stepBindings, s.Name);
+            debugSteps.Add(new DebugStep(s.Key, s.Name, s.Rhs, eval));
+        }
+
+        var finalEval = BuildEvalLet(pinBindings, stepBindings, finalBody);
+        return new DebugWatch(scopeKey, debugSteps, "result", finalEval);
+    }
+
+    // ---------------- evaluable-formula assembly ----------------
+
+    /// <summary>
+    ///     Assembles a compact, single-cell <c>=LET(pin1, e1, …, step1, r1, …, body)</c>
+    ///     from the pin bindings, the step bindings emitted so far, and the
+    ///     expression to return. With no bindings at all it degrades to <c>=body</c>.
+    /// </summary>
+    private static string BuildEvalLet(
+        IReadOnlyList<(string Name, string Value)> pins,
+        IReadOnlyList<(string Name, string Value)> steps,
+        string body)
+    {
+        if (pins.Count == 0 && steps.Count == 0)
+            return "=" + body;
+
+        var sb = new StringBuilder();
+        sb.Append("=LET(");
+        foreach (var (name, value) in pins)
+            sb.Append(name).Append(", ").Append(value).Append(", ");
+        foreach (var (name, value) in steps)
+            sb.Append(name).Append(", ").Append(value).Append(", ");
+        sb.Append(body).Append(')');
+        return sb.ToString();
+    }
+
+    private static DebugWatch Malformed(string scopeKey, DebugDiagnosticKind kind, string message)
+    {
+        return new DebugWatch(
+            scopeKey,
+            Array.Empty<DebugStep>(),
+            "result",
+            "",
+            new DebugDiagnostic(kind, message));
+    }
+
+    // ---------------- default pins ----------------
+
+    /// <summary>
+    ///     Suggests a slice expression that picks example <paramref name="index" />
+    ///     from <paramref name="scope" />'s host source, when the host is a
+    ///     recognised array iterator. Unrecognised hosts (custom higher-order
+    ///     lambdas, accumulator-style <c>SCAN</c>/<c>REDUCE</c>, multi-array
+    ///     <c>MAP</c>) return an empty string so the dialog leaves the pin blank.
+    /// </summary>
+    private static string SuggestExpr(ScopeInfo scope, string param, int index)
+    {
+        var host = scope.HostFunction;
+        var k = index.ToString(CultureInfo.InvariantCulture);
+
+        // Single-source row/column iterators have an unambiguous per-element slice.
+        if (scope.Params.Count == 1 && scope.HostSourceArgs.Count == 1)
+        {
+            if (host.Equals("BYROW", StringComparison.OrdinalIgnoreCase))
+                return $"CHOOSEROWS({scope.HostSourceArgs[0]}, {k})";
+            if (host.Equals("BYCOL", StringComparison.OrdinalIgnoreCase))
+                return $"CHOOSECOLS({scope.HostSourceArgs[0]}, {k})";
+        }
+
+        return "";
+    }
+
+    // ---------------- AST walk ----------------
+
+    private sealed class ScopeInfo
+    {
+        public string Key = "";
+        public int Depth;
+        public string HostFunction = "";
+        public List<string> HostSourceArgs = new();
+        public List<string> Params = new();
+        public List<string> EnclosingParams = new();
+        public string BodyText = "";
+        public int? ParentIndex;
+    }
+
+    private static List<ScopeInfo> WalkScopes(string formula)
+    {
+        var ast = FormulaParser.Parse(formula);
+        var sink = new List<ScopeInfo>();
+        Visit(ast.Root, hostName: "", Empty, Empty, depth: 0, parentIndex: null, sink);
+        return sink;
+    }
+
+    private static void Visit(
+        FormulaNode node,
+        string hostName,
+        IReadOnlyList<string> hostArgs,
+        IReadOnlyList<string> enclosing,
+        int depth,
+        int? parentIndex,
+        List<ScopeInfo> sink)
+    {
+        if (IsLambdaCall(node, out var fc))
+        {
+            var (paramNames, body) = SplitLambda(fc);
+            var info = new ScopeInfo
+            {
+                Key = "scope" + sink.Count.ToString(CultureInfo.InvariantCulture),
+                Depth = depth,
+                HostFunction = hostName,
+                HostSourceArgs = hostArgs.ToList(),
+                Params = paramNames,
+                EnclosingParams = enclosing.ToList(),
+                BodyText = body.ToFormula().Trim(),
+                ParentIndex = parentIndex
+            };
+            var myIndex = sink.Count;
+            sink.Add(info);
+
+            // Descend into the body to find nested lambda scopes; the body's own
+            // params join the enclosing set for them.
+            var childEnclosing = enclosing.Concat(paramNames).ToList();
+            Visit(body, hostName: "", Empty, childEnclosing, depth + 1, myIndex, sink);
+            return;
+        }
+
+        if (node is FunctionCallNode call)
+        {
+            // Args of this call are hosted by it; the non-lambda args are the
+            // "source" a default pin can slice.
+            var sourceArgs = call.Arguments
+                .Where(a => !IsLambdaCall(a, out _))
+                .Select(a => a.ToFormula().Trim())
+                .ToList();
+            var name = CleanName(call.Name);
+            foreach (var arg in call.Arguments)
+                Visit(arg, name, sourceArgs, enclosing, depth, parentIndex, sink);
+            return;
+        }
+
+        foreach (var child in Children(node))
+            Visit(child, hostName, hostArgs, enclosing, depth, parentIndex, sink);
+    }
+
+    private static bool IsLambdaCall(FormulaNode node, out FunctionCallNode call)
+    {
+        if (node is FunctionCallNode fc &&
+            CleanName(fc.Name).Equals("LAMBDA", StringComparison.OrdinalIgnoreCase))
+        {
+            call = fc;
+            return true;
+        }
+
+        call = null!;
+        return false;
+    }
+
+    /// <summary>
+    ///     Splits a <c>LAMBDA(p1, …, pN, body)</c> call into its parameter names
+    ///     (surrounding optional-arg <c>[brackets]</c> stripped) and body node. A
+    ///     bodyless <c>LAMBDA()</c> can't occur from a successful parse, but is
+    ///     guarded defensively.
+    /// </summary>
+    private static (List<string> Params, FormulaNode Body) SplitLambda(FunctionCallNode fc)
+    {
+        var args = fc.Arguments;
+        var ps = new List<string>();
+        for (var i = 0; i < args.Count - 1; i++)
+        {
+            var raw = args[i].ToFormula().Trim();
+            if (raw.Length >= 2 && raw[0] == '[' && raw[^1] == ']')
+                raw = raw[1..^1].Trim();
+            ps.Add(raw);
+        }
+
+        var body = args.Count > 0 ? args[^1] : (FormulaNode)new LeafNode(fc.CloseParen);
+        return (ps, body);
+    }
+
+    private static IEnumerable<FormulaNode> Children(FormulaNode node)
+    {
+        return node switch
+        {
+            FunctionCallNode fc => fc.Arguments,
+            BinaryNode b => new[] { b.Left, b.Right },
+            UnaryNode u => new[] { u.Operand },
+            PostfixNode p => new[] { p.Operand },
+            ParenNode pn => pn.Items,
+            _ => Array.Empty<FormulaNode>()
+        };
+    }
+
+    /// <summary>
+    ///     Strips a sheet/workbook qualifier and the <c>_xlfn.</c> / <c>_xlws.</c>
+    ///     compatibility prefixes from a function name, preserving case (so the
+    ///     dialog shows <c>BYROW</c> / <c>PAIROP</c>, not a lowercased form).
+    /// </summary>
+    private static string CleanName(string fnName)
+    {
+        var s = fnName;
+        var bang = s.LastIndexOf('!');
+        if (bang >= 0) s = s[(bang + 1)..];
+
+        if (s.StartsWith("_xlfn._xlws.", StringComparison.OrdinalIgnoreCase))
+            s = s["_xlfn._xlws.".Length..];
+        else if (s.StartsWith("_xlfn.", StringComparison.OrdinalIgnoreCase))
+            s = s["_xlfn.".Length..];
+        else if (s.StartsWith("_xlws.", StringComparison.OrdinalIgnoreCase))
+            s = s["_xlws.".Length..];
+
+        return s;
+    }
+
+    // ---------------- projection helpers ----------------
+
+    private static DebugScope ToScope(ScopeInfo info)
+    {
+        return new DebugScope(
+            info.Key,
+            info.Depth,
+            info.HostFunction,
+            info.Params,
+            info.EnclosingParams,
+            info.BodyText,
+            LabelOf(info));
+    }
+
+    private static string LabelOf(ScopeInfo info)
+    {
+        var sig = "LAMBDA(" + string.Join(", ", info.Params) + ")";
+        return string.IsNullOrEmpty(info.HostFunction)
+            ? sig
+            : $"{sig} — arg of {info.HostFunction}";
+    }
+
+    /// <summary>
+    ///     The root-to-target chain of scopes (outer-first, inclusive), so pin
+    ///     suggestion walks each enclosing scope's own params before the target's.
+    /// </summary>
+    private static IEnumerable<ScopeInfo> ChainTo(List<ScopeInfo> infos, ScopeInfo target)
+    {
+        var chain = new List<ScopeInfo>();
+        var cur = (ScopeInfo?)target;
+        while (cur is not null)
+        {
+            chain.Add(cur);
+            cur = cur.ParentIndex is { } pi ? infos[pi] : null;
+        }
+
+        chain.Reverse();
+        return chain;
+    }
+}

--- a/addin/lambda-boss/DebugNestedTypes.cs
+++ b/addin/lambda-boss/DebugNestedTypes.cs
@@ -73,6 +73,38 @@ public sealed record DebugDiscovery(
     DebugDiagnostic? Diagnostic = null);
 
 /// <summary>
+///     Spec 0010 (spike) — how a free name referenced by a lambda body is
+///     classified, which decides how it's supplied on the scratch sheet:
+///     <see cref="Param" />/<see cref="EnclosingParam" /> need a sample value
+///     (live slice or probe-captured), a <see cref="LetBinding" /> is
+///     reconstructed from its real definition as a sheet-scoped name, and an
+///     <see cref="External" /> name (table column, workbook name, cell ref)
+///     resolves on its own (modulo sheet-local ref qualification).
+/// </summary>
+public enum DebugInputKind
+{
+    /// <summary>A parameter bound by the scope's own lambda.</summary>
+    Param,
+
+    /// <summary>A parameter bound by an enclosing lambda.</summary>
+    EnclosingParam,
+
+    /// <summary>A binding from an enclosing <c>LET</c> (its definition is reconstructable).</summary>
+    LetBinding,
+
+    /// <summary>Anything else — a table ref, workbook name, or cell reference.</summary>
+    External
+}
+
+/// <summary>
+///     A free name referenced by a lambda body, classified by
+///     <see cref="DebugInputKind" />. <see cref="Definition" /> is the enclosing
+///     <c>LET</c> binding's RHS text for a <see cref="DebugInputKind.LetBinding" />
+///     (so it can be rebuilt on the scratch sheet); null otherwise.
+/// </summary>
+public sealed record DebugInput(string Name, DebugInputKind Kind, string? Definition);
+
+/// <summary>
 ///     The computed value of a step's <see cref="DebugStep.EvaluableFormula" />
 ///     for the pinned example, as Excel rendered it (mechanism C). <see cref="Display" />
 ///     is the formatted text — a scalar, an Excel error string (<c>#VALUE!</c>,

--- a/addin/lambda-boss/DebugNestedTypes.cs
+++ b/addin/lambda-boss/DebugNestedTypes.cs
@@ -1,0 +1,97 @@
+namespace LambdaBoss;
+
+/// <summary>
+///     Spec 0010 (spike) — issue #279. One <c>LAMBDA(...)</c> scope discovered
+///     inside a formula. <c>/Unnest</c> answers "show me the steps of a static
+///     nested formula"; <c>/Debug Nested</c> answers the different question
+///     "inside <c>BYROW(arr, LAMBDA(r, …))</c> the body runs once per element
+///     with <c>r</c> bound dynamically — what does each step compute?". A scope
+///     is the unit the user pins to a concrete example and watches.
+///
+///     <para>
+///     <see cref="Params" /> are the names this lambda binds; <see cref="EnclosingParams" />
+///     are the names bound by ancestor lambda scopes that are still in scope
+///     inside this body (outer-first). <see cref="HostFunction" /> is the call
+///     that receives this lambda as an argument (<c>BYROW</c>, <c>MAP</c>, a
+///     custom <c>PAIROP</c>, …) — it determines whether a sensible default pin
+///     can be suggested. <see cref="Depth" /> (0 = outermost lambda) drives the
+///     dialog's indentation.
+///     </para>
+/// </summary>
+public sealed record DebugScope(
+    string Key,
+    int Depth,
+    string HostFunction,
+    IReadOnlyList<string> Params,
+    IReadOnlyList<string> EnclosingParams,
+    string BodyText,
+    string Label);
+
+/// <summary>
+///     The complete, outer-first list of parameters in scope inside a
+///     <see cref="DebugScope" />'s body (<see cref="DebugScope.EnclosingParams" />
+///     followed by <see cref="DebugScope.Params" />). Each must be pinned to a
+///     concrete example value for the body's steps to evaluate.
+/// </summary>
+public sealed record DebugPin(string Param, string Expression);
+
+/// <summary>
+///     One inspectable step of a pinned scope's body: the <see cref="UnnestEngine" />
+///     decomposition (<see cref="Name" /> / <see cref="Rhs" />) plus an
+///     <see cref="EvaluableFormula" /> — a self-contained <c>=LET(...)</c> that
+///     binds every pin and every preceding step, then returns this step — so the
+///     add-in can compute its live value for the pinned example (mechanism C).
+/// </summary>
+public sealed record DebugStep(
+    string Key,
+    string Name,
+    string Rhs,
+    string EvaluableFormula);
+
+/// <summary>
+///     The watch model for one pinned <see cref="DebugScope" />: its body's
+///     decomposed <see cref="Steps" /> (leaf-first) and a
+///     <see cref="FinalEvaluableFormula" /> for the body's overall result. When
+///     the body can't be decomposed, <see cref="Diagnostic" /> is set and
+///     <see cref="Steps" /> is empty.
+/// </summary>
+public sealed record DebugWatch(
+    string ScopeKey,
+    IReadOnlyList<DebugStep> Steps,
+    string FinalName,
+    string FinalEvaluableFormula,
+    DebugDiagnostic? Diagnostic = null);
+
+/// <summary>
+///     Result of scanning a formula for lambda scopes. <see cref="Scopes" /> is
+///     the flattened, pre-order (outer-first) list; <see cref="Diagnostic" /> is
+///     set (and <see cref="Scopes" /> empty) when the formula can't be parsed or
+///     holds no lambda to debug.
+/// </summary>
+public sealed record DebugDiscovery(
+    IReadOnlyList<DebugScope> Scopes,
+    DebugDiagnostic? Diagnostic = null);
+
+/// <summary>
+///     The computed value of a step's <see cref="DebugStep.EvaluableFormula" />
+///     for the pinned example, as Excel rendered it (mechanism C). <see cref="Display" />
+///     is the formatted text — a scalar, an Excel error string (<c>#VALUE!</c>,
+///     <c>#NAME?</c>, …), or a compact preview of a spilled array;
+///     <see cref="IsError" /> drives the dialog's error styling.
+/// </summary>
+public sealed record DebugValue(string Display, bool IsError);
+
+/// <summary>A refusal reason surfaced by the <c>/Debug Nested</c> command instead of the dialog.</summary>
+public sealed record DebugDiagnostic(DebugDiagnosticKind Kind, string Message);
+
+public enum DebugDiagnosticKind
+{
+    /// <summary>The formula couldn't be parsed into an expression tree.</summary>
+    MalformedFormula,
+
+    /// <summary>The formula parsed but contains no <c>LAMBDA(...)</c> to debug.</summary>
+    NoLambda,
+
+    /// <summary>The selected scope's body couldn't be decomposed for inspection.</summary>
+    MalformedBody
+}

--- a/addin/lambda-boss/UI/DebugNestedWindow.xaml
+++ b/addin/lambda-boss/UI/DebugNestedWindow.xaml
@@ -1,0 +1,180 @@
+<Window x:Class="LambdaBoss.UI.DebugNestedWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Lambda Boss — Debug Nested"
+        Width="760" Height="680"
+        WindowStyle="ToolWindow"
+        ShowInTaskbar="True"
+        Topmost="True"
+        ResizeMode="CanResizeWithGrip"
+        Background="#1e1e1e"
+        PreviewKeyDown="Window_PreviewKeyDown">
+
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="Original formula"
+                   FontSize="13" FontWeight="Bold" Foreground="#dcdcaa"
+                   Margin="0,0,0,4" />
+
+        <TextBox x:Name="OriginalFormulaText"
+                 Grid.Row="1"
+                 IsReadOnly="True" IsReadOnlyCaretVisible="False"
+                 Padding="6,4" FontSize="12" FontFamily="Consolas"
+                 Background="#2d2d2d" Foreground="#cccccc"
+                 BorderBrush="#3e3e3e" BorderThickness="1"
+                 TextWrapping="Wrap" AcceptsReturn="True"
+                 VerticalScrollBarVisibility="Auto" MaxHeight="72" />
+
+        <DockPanel Grid.Row="2" Margin="0,12,0,4">
+            <TextBlock Text="Lambda scope to debug"
+                       FontSize="13" FontWeight="Bold" Foreground="#dcdcaa"
+                       VerticalAlignment="Center" />
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Right" HorizontalAlignment="Right">
+                <TextBlock Text="Example #"
+                           Foreground="#9cdcfe" FontSize="12"
+                           VerticalAlignment="Center" Margin="0,0,6,0" />
+                <TextBox x:Name="IndexBox"
+                         Text="1" Width="44" Padding="4,2"
+                         FontFamily="Consolas" FontSize="12"
+                         Background="#1e1e1e" Foreground="#cccccc"
+                         CaretBrush="#cccccc" BorderBrush="#3e3e3e" BorderThickness="1"
+                         ToolTip="Which element to pin for recognised iterators (1-based)" />
+                <Button x:Name="SuggestButton"
+                        Content="Suggest pins"
+                        Padding="10,3" Margin="8,0,0,0"
+                        Background="Transparent" Foreground="#cccccc"
+                        BorderBrush="#3e3e3e" BorderThickness="1" Cursor="Hand"
+                        Click="SuggestButton_Click" />
+            </StackPanel>
+        </DockPanel>
+
+        <ComboBox x:Name="ScopeCombo"
+                  Grid.Row="3"
+                  DisplayMemberPath="Display"
+                  Padding="6,4" FontFamily="Consolas" FontSize="12"
+                  SelectionChanged="ScopeCombo_SelectionChanged" />
+
+        <TextBlock Grid.Row="4"
+                   Text="Pin each parameter to an example value"
+                   FontSize="13" FontWeight="Bold" Foreground="#dcdcaa"
+                   Margin="0,12,0,4" />
+
+        <Border Grid.Row="5"
+                Background="#252526" BorderBrush="#3e3e3e" BorderThickness="1"
+                MaxHeight="150">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel>
+                    <ItemsControl x:Name="PinsList">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                                <DockPanel Margin="6,3">
+                                    <TextBlock DockPanel.Dock="Left"
+                                               Text="{Binding Param}"
+                                               Width="90" Foreground="#dcdcaa"
+                                               FontFamily="Consolas" FontSize="13"
+                                               VerticalAlignment="Center" />
+                                    <TextBox Text="{Binding Expression, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             Padding="4,2" FontFamily="Consolas" FontSize="13"
+                                             Background="#1e1e1e" Foreground="#cccccc"
+                                             CaretBrush="#cccccc" BorderBrush="#3e3e3e" BorderThickness="1"
+                                             ToolTip="An expression that evaluates to this parameter's example value" />
+                                </DockPanel>
+                                <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock x:Name="NoPinsText"
+                               Text="This lambda binds no parameters."
+                               Foreground="#808080" FontSize="12" FontStyle="Italic"
+                               Margin="6,8" Visibility="Collapsed" />
+                </StackPanel>
+            </ScrollViewer>
+        </Border>
+
+        <Grid Grid.Row="6" Margin="0,12,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0"
+                       Text="Steps (value shown for the pinned example)"
+                       FontSize="13" FontWeight="Bold" Foreground="#dcdcaa"
+                       Margin="0,0,0,4" />
+            <Border Grid.Row="1"
+                    Background="#252526" BorderBrush="#3e3e3e" BorderThickness="1">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <ItemsControl x:Name="StepsList">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <!-- ReSharper disable Xaml.BindingWithContextNotResolved -->
+                                    <Grid Margin="6,3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="130" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="220" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0"
+                                                   Text="{Binding Name}"
+                                                   Foreground="{Binding NameBrush}"
+                                                   FontFamily="Consolas" FontSize="13"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis" />
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding Rhs}"
+                                                   Foreground="#cccccc"
+                                                   FontFamily="Consolas" FontSize="12"
+                                                   VerticalAlignment="Center" Margin="8,0"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip="{Binding Rhs}" />
+                                        <TextBlock Grid.Column="2"
+                                                   Text="{Binding Value}"
+                                                   Foreground="{Binding ValueBrush}"
+                                                   FontFamily="Consolas" FontSize="12"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip="{Binding Value}" />
+                                    </Grid>
+                                    <!-- ReSharper restore Xaml.BindingWithContextNotResolved -->
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <TextBlock x:Name="NoStepsText"
+                                   Text="This lambda body has no inner steps — only its overall result is shown."
+                                   Foreground="#808080" FontSize="12" FontStyle="Italic"
+                                   TextWrapping="Wrap" Margin="6,8" Visibility="Collapsed" />
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
+        </Grid>
+
+        <DockPanel Grid.Row="7" Margin="0,12,0,0">
+            <Button x:Name="CloseButton"
+                    DockPanel.Dock="Right"
+                    Content="Close" Padding="16,4" Margin="6,0,0,0"
+                    Background="Transparent" Foreground="#cccccc"
+                    BorderBrush="#3e3e3e" BorderThickness="1" Cursor="Hand"
+                    Click="CloseButton_Click" />
+            <Button x:Name="EvaluateButton"
+                    DockPanel.Dock="Right"
+                    Content="Evaluate" Padding="16,4" Cursor="Hand"
+                    Background="#0e639c" Foreground="#ffffff" BorderThickness="0"
+                    Click="EvaluateButton_Click" />
+            <TextBlock x:Name="StatusText"
+                       Foreground="#808080" FontSize="11"
+                       VerticalAlignment="Center" />
+        </DockPanel>
+    </Grid>
+</Window>

--- a/addin/lambda-boss/UI/DebugNestedWindow.xaml.cs
+++ b/addin/lambda-boss/UI/DebugNestedWindow.xaml.cs
@@ -1,0 +1,306 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace LambdaBoss.UI;
+
+/// <summary>
+///     Spec 0010 (spike) / issue #279 — the <c>/Debug Nested</c> window. A
+///     modeless debugger for a formula's <c>LAMBDA(...)</c> scopes: the user
+///     picks a scope, pins each in-scope parameter to a concrete example value
+///     (defaults suggested for recognised iterators), and clicks Evaluate to see
+///     each decomposed step of the lambda body compute a live value for that
+///     pinned example. Step decomposition is pure
+///     (<see cref="DebugNestedEngine" />); the values come from the supplied
+///     <c>evaluate</c> delegate, which probes the live grid on the Excel macro
+///     thread. The window writes nothing back to the workbook — it's a read-only
+///     debugging view.
+/// </summary>
+public partial class DebugNestedWindow
+{
+    private static readonly Brush ValueBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#b5cea8"));
+
+    private static readonly Brush ErrorBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#f48771"));
+
+    private static readonly Brush PendingBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#6a6a6a"));
+
+    private static readonly Brush ResultNameBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#dcdcaa"));
+
+    private static readonly Brush StepNameBrush =
+        new SolidColorBrush((Color)ColorConverter.ConvertFromString("#9cdcfe"));
+
+    private readonly IReadOnlyList<DebugScope> _scopes;
+    private readonly string _formula;
+    private readonly Func<IReadOnlyList<string>, IReadOnlyList<DebugValue>> _evaluate;
+
+    private readonly ObservableCollection<PinVm> _pins = [];
+    private readonly ObservableCollection<StepVm> _steps = [];
+
+    private bool _suppress;
+
+    public DebugNestedWindow(
+        string formula,
+        DebugDiscovery discovery,
+        Func<IReadOnlyList<string>, IReadOnlyList<DebugValue>> evaluate)
+    {
+        InitializeComponent();
+
+        _formula = formula;
+        _scopes = discovery.Scopes;
+        _evaluate = evaluate;
+
+        OriginalFormulaText.Text = formula;
+        PinsList.ItemsSource = _pins;
+        StepsList.ItemsSource = _steps;
+
+        var scopeVms = _scopes
+            .Select(s => new ScopeVm(s.Key, ScopeDisplay(s)))
+            .ToList();
+        ScopeCombo.ItemsSource = scopeVms;
+
+        if (scopeVms.Count > 0)
+        {
+            _suppress = true;
+            ScopeCombo.SelectedIndex = 0;
+            _suppress = false;
+            LoadScope();
+        }
+    }
+
+    private DebugScope? CurrentScope =>
+        ScopeCombo.SelectedItem is ScopeVm vm
+            ? _scopes.FirstOrDefault(s => s.Key == vm.Key)
+            : null;
+
+    private int ExampleIndex
+    {
+        get
+        {
+            if (int.TryParse(IndexBox.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) && n >= 1)
+                return n;
+            return 1;
+        }
+    }
+
+    private void ScopeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppress) return;
+        LoadScope();
+    }
+
+    private void SuggestButton_Click(object sender, RoutedEventArgs e)
+    {
+        FillSuggestedPins();
+        RebuildSteps();
+    }
+
+    /// <summary>
+    ///     Switches to the selected scope: suggests a pin for every in-scope
+    ///     parameter and rebuilds the (value-less) step list.
+    /// </summary>
+    private void LoadScope()
+    {
+        FillSuggestedPins();
+        RebuildSteps();
+    }
+
+    private void FillSuggestedPins()
+    {
+        _pins.Clear();
+        var scope = CurrentScope;
+        if (scope is null) return;
+
+        var suggested = DebugNestedEngine.SuggestPins(_formula, scope.Key, ExampleIndex);
+        foreach (var p in suggested)
+            _pins.Add(new PinVm(p.Param, p.Expression));
+
+        NoPinsText.Visibility = _pins.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    /// <summary>
+    ///     Rebuilds the step rows for the current scope + pins (names / RHS only;
+    ///     values are cleared until the next Evaluate). Step structure is
+    ///     independent of the pin <em>values</em>, but a blank pin still drops out
+    ///     of the evaluable formula, so we rebuild here too.
+    /// </summary>
+    private void RebuildSteps()
+    {
+        _steps.Clear();
+
+        var scope = CurrentScope;
+        if (scope is null) return;
+
+        var watch = DebugNestedEngine.BuildWatch(_formula, scope.Key, CurrentPins());
+        if (watch.Diagnostic is not null)
+        {
+            StatusText.Text = watch.Diagnostic.Message;
+            NoStepsText.Visibility = Visibility.Collapsed;
+            return;
+        }
+
+        foreach (var s in watch.Steps)
+            _steps.Add(new StepVm(s.Name, s.Rhs, s.EvaluableFormula, isResult: false));
+
+        _steps.Add(new StepVm("result", Elide(scope.BodyText), watch.FinalEvaluableFormula, isResult: true));
+
+        NoStepsText.Visibility = watch.Steps.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+        StatusText.Text = watch.Steps.Count == 1
+            ? "1 step — click Evaluate to compute values"
+            : $"{watch.Steps.Count} steps — click Evaluate to compute values";
+    }
+
+    private async void EvaluateButton_Click(object sender, RoutedEventArgs e)
+    {
+        RebuildSteps();
+        if (_steps.Count == 0) return;
+
+        var formulas = _steps.Select(s => s.EvalFormula).ToList();
+
+        EvaluateButton.IsEnabled = false;
+        StatusText.Text = "Evaluating…";
+
+        IReadOnlyList<DebugValue> values;
+        try
+        {
+            values = await Task.Run(() => _evaluate(formulas));
+        }
+        catch (Exception)
+        {
+            StatusText.Text = "Evaluation failed — see the log.";
+            EvaluateButton.IsEnabled = true;
+            return;
+        }
+
+        for (var i = 0; i < _steps.Count && i < values.Count; i++)
+            _steps[i].SetValue(values[i]);
+
+        StatusText.Text = $"Evaluated for example #{ExampleIndex}.";
+        EvaluateButton.IsEnabled = true;
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            Close();
+            e.Handled = true;
+        }
+    }
+
+    private IReadOnlyList<DebugPin> CurrentPins()
+    {
+        return _pins.Select(p => new DebugPin(p.Param, p.Expression)).ToList();
+    }
+
+    private static string ScopeDisplay(DebugScope scope)
+    {
+        // Indent nested scopes so the lambda nesting reads at a glance.
+        var indent = scope.Depth > 0 ? new string(' ', scope.Depth * 4) + "↳ " : "";
+        return indent + scope.Label;
+    }
+
+    private static string Elide(string text)
+    {
+        const int max = 80;
+        return text.Length <= max ? text : text[..max] + "…";
+    }
+
+    private sealed record ScopeVm(string Key, string Display);
+
+    /// <summary>One bindable pin: a parameter name and its example expression.</summary>
+    private sealed class PinVm : INotifyPropertyChanged
+    {
+        private string _expression;
+
+        public PinVm(string param, string expression)
+        {
+            Param = param;
+            _expression = expression;
+        }
+
+        public string Param { get; }
+
+        public string Expression
+        {
+            get => _expression;
+            set
+            {
+                if (_expression == value) return;
+                _expression = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string? prop = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+        }
+    }
+
+    /// <summary>One bindable step row: name, RHS, the hidden evaluable formula, and its computed value.</summary>
+    private sealed class StepVm : INotifyPropertyChanged
+    {
+        private bool _isError;
+        private string _value = "";
+
+        public StepVm(string name, string rhs, string evalFormula, bool isResult)
+        {
+            Name = name;
+            Rhs = rhs;
+            EvalFormula = evalFormula;
+            IsResult = isResult;
+        }
+
+        public string Name { get; }
+        public string Rhs { get; }
+        public string EvalFormula { get; }
+        public bool IsResult { get; }
+
+        public string Value
+        {
+            get => _value;
+            private set
+            {
+                if (_value == value) return;
+                _value = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public Brush NameBrush => IsResult ? ResultNameBrush : StepNameBrush;
+
+        public Brush ValueBrush => string.IsNullOrEmpty(_value)
+            ? PendingBrush
+            : _isError ? ErrorBrush : DebugNestedWindow.ValueBrush;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public void SetValue(DebugValue v)
+        {
+            _isError = v.IsError;
+            Value = v.Display;
+            OnPropertyChanged(nameof(ValueBrush));
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? prop = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(prop));
+        }
+    }
+}

--- a/addin/lambda-boss/UI/DebugScopePickerWindow.xaml
+++ b/addin/lambda-boss/UI/DebugScopePickerWindow.xaml
@@ -1,0 +1,67 @@
+<Window x:Class="LambdaBoss.UI.DebugScopePickerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Lambda Boss — Debug Lambda"
+        Width="560" Height="300"
+        WindowStyle="ToolWindow"
+        ShowInTaskbar="True"
+        Topmost="True"
+        ResizeMode="NoResize"
+        Background="#1e1e1e"
+        PreviewKeyDown="Window_PreviewKeyDown">
+
+    <Grid Margin="14">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="Extract a nested LAMBDA to a scratch sheet"
+                   FontSize="14" FontWeight="Bold" Foreground="#dcdcaa" />
+
+        <TextBlock Grid.Row="1"
+                   Text="Pick the lambda to debug and which example element to pin. A new sheet is created with the body as an editable LET wired to sample inputs."
+                   Foreground="#9d9d9d" FontSize="11" TextWrapping="Wrap"
+                   Margin="0,4,0,10" />
+
+        <TextBlock Grid.Row="2"
+                   Text="Lambda" FontSize="12" Foreground="#dcdcaa" Margin="0,0,0,3" />
+
+        <ComboBox x:Name="ScopeCombo"
+                  Grid.Row="3"
+                  DisplayMemberPath="Display"
+                  Padding="6,4" FontFamily="Consolas" FontSize="12" />
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" Margin="0,12,0,0">
+            <TextBlock Text="Example #" Foreground="#dcdcaa" FontSize="12"
+                       VerticalAlignment="Center" Margin="0,0,8,0" />
+            <TextBox x:Name="IndexBox"
+                     Text="1" Width="56" Padding="4,2"
+                     FontFamily="Consolas" FontSize="12"
+                     Background="#252526" Foreground="#cccccc"
+                     CaretBrush="#cccccc" BorderBrush="#3e3e3e" BorderThickness="1"
+                     ToolTip="1-based element for a recognised iterator (BYROW/BYCOL/MAP)" />
+        </StackPanel>
+
+        <DockPanel Grid.Row="6" Margin="0,12,0,0" VerticalAlignment="Bottom">
+            <Button x:Name="CancelButton"
+                    DockPanel.Dock="Right"
+                    Content="Cancel" Padding="16,4" Margin="6,0,0,0"
+                    Background="Transparent" Foreground="#cccccc"
+                    BorderBrush="#3e3e3e" BorderThickness="1" Cursor="Hand"
+                    Click="CancelButton_Click" />
+            <Button x:Name="GenerateButton"
+                    DockPanel.Dock="Right"
+                    Content="Generate sheet" Padding="16,4" Cursor="Hand"
+                    Background="#0e639c" Foreground="#ffffff" BorderThickness="0"
+                    Click="GenerateButton_Click" />
+            <TextBlock Text="" />
+        </DockPanel>
+    </Grid>
+</Window>

--- a/addin/lambda-boss/UI/DebugScopePickerWindow.xaml.cs
+++ b/addin/lambda-boss/UI/DebugScopePickerWindow.xaml.cs
@@ -1,0 +1,81 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Input;
+
+namespace LambdaBoss.UI;
+
+/// <summary>
+///     Spec 0010 (spike) / issue #279 — the modal chooser for <c>/Debug Lambda</c>.
+///     Lists the formula's <c>LAMBDA(...)</c> scopes (indented by nesting) and a
+///     1-based example index, then returns the user's choice via
+///     <see cref="SelectedScopeKey" /> / <see cref="ExampleIndex" />. It does no
+///     Excel work — the command does all COM after the dialog closes, so the
+///     macro thread is free to block on <c>ShowDialog</c>.
+/// </summary>
+public partial class DebugScopePickerWindow
+{
+    public DebugScopePickerWindow(string formula, DebugDiscovery discovery)
+    {
+        InitializeComponent();
+
+        var scopeVms = discovery.Scopes
+            .Select(s => new ScopeVm(s.Key, ScopeDisplay(s)))
+            .ToList();
+        ScopeCombo.ItemsSource = scopeVms;
+        if (scopeVms.Count > 0)
+            ScopeCombo.SelectedIndex = 0;
+    }
+
+    /// <summary>The chosen scope key, or null when cancelled.</summary>
+    public string? SelectedScopeKey { get; private set; }
+
+    /// <summary>The chosen 1-based example index (defaults to 1).</summary>
+    public int ExampleIndex { get; private set; } = 1;
+
+    private void GenerateButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (ScopeCombo.SelectedItem is not ScopeVm vm)
+            return;
+
+        SelectedScopeKey = vm.Key;
+        ExampleIndex = ParseIndex(IndexBox.Text);
+        DialogResult = true;
+        Close();
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        SelectedScopeKey = null;
+        DialogResult = false;
+        Close();
+    }
+
+    private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            CancelButton_Click(this, new RoutedEventArgs());
+            e.Handled = true;
+        }
+        else if (e.Key == Key.Enter)
+        {
+            GenerateButton_Click(this, new RoutedEventArgs());
+            e.Handled = true;
+        }
+    }
+
+    private static int ParseIndex(string text)
+    {
+        return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) && n >= 1
+            ? n
+            : 1;
+    }
+
+    private static string ScopeDisplay(DebugScope scope)
+    {
+        var indent = scope.Depth > 0 ? new string(' ', scope.Depth * 4) + "↳ " : "";
+        return indent + scope.Label;
+    }
+
+    private sealed record ScopeVm(string Key, string Display);
+}

--- a/addin/lambda-boss/UI/LambdaPopup.xaml.cs
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml.cs
@@ -452,6 +452,14 @@ public partial class LambdaPopup
                 ExcelAsyncUtil.QueueAsMacro(() => UnnestCommand.Run());
             }),
         new SlashCommand(
+            "Debug Lambda",
+            "Extract a nested LAMBDA to a scratch sheet as an editable LET wired to sample inputs",
+            () =>
+            {
+                Hide();
+                ExcelAsyncUtil.QueueAsMacro(() => DebugLambdaCommand.Run());
+            }),
+        new SlashCommand(
             "Debug Nested",
             "Pin a nested LAMBDA to one example and watch each step of its body compute a live value",
             () =>

--- a/addin/lambda-boss/UI/LambdaPopup.xaml.cs
+++ b/addin/lambda-boss/UI/LambdaPopup.xaml.cs
@@ -452,6 +452,14 @@ public partial class LambdaPopup
                 ExcelAsyncUtil.QueueAsMacro(() => UnnestCommand.Run());
             }),
         new SlashCommand(
+            "Debug Nested",
+            "Pin a nested LAMBDA to one example and watch each step of its body compute a live value",
+            () =>
+            {
+                Hide();
+                ExcelAsyncUtil.QueueAsMacro(() => DebugNestedCommand.Run());
+            }),
+        new SlashCommand(
             "Load Library",
             "Switch to Library mode to pick a library",
             () =>

--- a/specs/0010-debug-nested-spike.md
+++ b/specs/0010-debug-nested-spike.md
@@ -52,19 +52,30 @@ back with `/LET to LAMBDA` and pasted into the original formula. The workflow:
 
 ### Status of this direction
 
-- Pure engine (tested): `AnalyzeInputs`, `BuildDebugLet`, `BuildCaptureFormula`.
+- Pure engine (tested): `AnalyzeInputs`, `BuildDebugLet`, `BuildCaptureFormula`,
+  `BuildParamProbe`.
 - `DebugLambdaCommand` + `DebugScopePickerWindow` (COM / sheet generation) —
-  compiles; **not yet exercised in Excel**.
+  compiles and works in Excel for the recognised-iterator case; probe-capture path
+  is wired but is the least-exercised part.
+- **Probe-capture for custom HOFs** (e.g. `PAIROP`): a custom-HOF param with no
+  slice is captured by rerunning the host with the lambda body replaced by the
+  bare param and reading element *k* — `INDEX(<host with body→param>, k)` — with
+  enclosing-lambda params pinned to their own slices and enclosing-LET bindings
+  rebuilt. A param the host can't yield (array-shaped, or an enclosing param that
+  couldn't be pinned) surfaces as an Excel error and falls back to a blank
+  "fill in" cell.
 - The `/Debug Nested` watch window below is **retained until `/Debug Lambda` is
   proven**, then retired.
 
 ### Known gaps / next steps
 
-- **Probe-capture for custom HOFs** (e.g. `PAIROP`) — return each param
-  individually, run the host in context, read the chosen element. Until then those
-  params are blank cells to fill in by hand.
-- **Deep nesting** capture (pinning enclosing-lambda params through a custom-HOF
-  ancestor) is only partial.
+- **Deep custom nesting** — if a custom-HOF param sits under *another* custom HOF
+  (no recognised-iterator slice to pin the enclosing param), the probe can't pin it
+  and the param falls back to a manual cell.
+- **Array-shaped custom-HOF params** — `INDEX(host, k)` assumes a scalar-per-element
+  host; an array-per-element param won't capture cleanly.
+- **Nested example index** — the single picker index is reused at every level
+  (outer element *k*, inner element *k*).
 - **External sheet-local cell refs** in a body (rare) would resolve to the scratch
   sheet — not yet qualified back to the source sheet.
 

--- a/specs/0010-debug-nested-spike.md
+++ b/specs/0010-debug-nested-spike.md
@@ -1,0 +1,77 @@
+# Spec 0010 (spike) — Debug Nested
+
+Status: **spike for feedback** (issue #279). Not an approved spec — this documents
+what the spike branch builds so Tim can try it and steer.
+
+## The question #279 actually asks
+
+`/Unnest` (spec 0009) answers *"this formula is a deeply nested blob of **static**
+sub-expressions — show me each step as a named, inspectable value"*. Every
+sub-expression there has **one** value, so naming it in a `LET` makes it
+inspectable.
+
+`#279` is a **different** question. When a `LAMBDA(...)` is applied over an array —
+`BYROW(arr, LAMBDA(r, …))`, a custom `PAIROP(r, LAMBDA(a, b, …))` — the body runs
+**once per element** with its parameters bound dynamically. There is no single
+value for `SQRT(SUMSQ(PAIROP(XV(VSTACK(a, b), …))))` — there's one per iteration.
+The issue's filed "Option 3" (nested-LET-in-LAMBDA) only makes the body more
+**readable**; it surfaces no **values**. So the debugging question needs a
+different mechanism, and likely a different command.
+
+## Approach taken: "Pin & Watch" (spike options A + C)
+
+1. **Pin one example (A).** Pick a lambda scope; bind each in-scope parameter
+   (the scope's own params **and** every enclosing param) to a concrete example
+   value. For a recognised single-source iterator the pin defaults to a slice
+   (`CHOOSEROWS(arr, k)` for `BYROW`, `CHOOSECOLS` for `BYCOL`); for a custom
+   higher-order function (`PAIROP`) or an accumulator iterator (`SCAN`/`REDUCE`)
+   the pin is left blank for the user to fill. Nesting is handled by listing every
+   ancestor scope's params, so the doubly-dynamic trip formula (outer `BYROW` →
+   inner `PAIROP`) is reachable by drilling to the inner scope.
+
+2. **Watch live values (C).** Once pinned, the lambda body is decomposed into
+   steps by **reusing `UnnestEngine`** (which already keeps a deeper nested
+   `LAMBDA`/`LET` opaque, so a step containing an inner lambda stays inline and the
+   user drills into it separately). For each step the engine emits a self-contained
+   `=LET(<pins>, <preceding steps>, <this step>)`, and the add-in evaluates it
+   against the **live grid** via a scratch cell beyond the used range, reading the
+   value back. Scalars show directly; spilled arrays show a compact `{r×c} …`
+   preview; Excel errors (e.g. an unfilled pin) show as `#…` in red.
+
+Nothing is written to the active cell — this is a **read-only debugging view**, not
+a refactor. The window is **modeless** (unlike `/Unnest`'s modal dialog) so Excel
+stays responsive for the live evaluation, which is marshalled onto the macro thread.
+
+## What's in the branch
+
+- `DebugNestedEngine` + `DebugNestedTypes` — pure, unit-tested (scope discovery,
+  default-pin suggestion, evaluable-formula assembly).
+- `DebugNestedCommand` + a scratch-cell evaluator (mechanism C).
+- `DebugNestedWindow` (modeless) — scope picker, example index, editable pins,
+  steps-with-values.
+- Registered as `/Debug Nested` in the popup command list.
+
+## Known limits (spike — deliberately scoped)
+
+- **Default pins only for `BYROW`/`BYCOL`** single-source iterators. `MAP` (multi-
+  array), `SCAN`/`REDUCE` (accumulator), `MAKEARRAY`, and **all custom HOFs** need a
+  hand-typed pin. (Capturing those automatically — probe-evaluating the host to read
+  the actual bound value — is the obvious v2.)
+- **Scratch-cell evaluation** writes/clears a cell beyond the used range on the
+  active sheet; it adds undo entries and assumes that region is free. Fine for
+  interactive use; not invisible.
+- **Array values** are previewed (first 12 cells), not shown in full.
+- Only **`LAMBDA`** scopes are debugged; a nested `LET` is out of scope here
+  (that's closer to `/Unnest`'s existing-LET path).
+- No example-pinning UI for `MAKEARRAY`'s `(i, j)` indices beyond blank defaults.
+
+## Open questions for Tim
+
+1. Is "pin one example + watch live values" the right shape, or do you also want
+   the **whole-array trace table** (option B — one row per iteration, one column
+   per step) as a complementary view?
+2. Should auto-pin-capture (probe the host to read the real bound value for custom
+   HOFs like `PAIROP`) be the priority for v2? It's what makes the inner scope
+   "just work" without hand-typing.
+3. Is a separate `/Debug Nested` command the right home, or should this fold into
+   `/Unnest`?

--- a/specs/0010-debug-nested-spike.md
+++ b/specs/0010-debug-nested-spike.md
@@ -18,6 +18,60 @@ The issue's filed "Option 3" (nested-LET-in-LAMBDA) only makes the body more
 **readable**; it surfaces no **values**. So the debugging question needs a
 different mechanism, and likely a different command.
 
+## Direction (after spike feedback): extract to a scratch sheet — `/Debug Lambda`
+
+The first spike built an in-popup "pin & watch" window (`/Debug Nested`, below).
+On review, the better fit for real debugging is to **materialise the inner lambda
+as an editable `=LET(...)` on a fresh scratch worksheet, wired to sample inputs** —
+so the lambda is debugged in real cells (formula bar, spill, F9), then converted
+back with `/LET to LAMBDA` and pasted into the original formula. The workflow:
+
+> write formula → `/Unnest` to a LET → narrow the bug to an inner LAMBDA →
+> **`/Debug Lambda`** (extract it to a scratch sheet with dummy inputs) → play
+> until it works → `/LET to LAMBDA` → paste the named lambda back.
+
+### How `/Debug Lambda` works
+
+1. **Pick** the lambda scope + a 1-based example index (modal picker).
+2. **Classify** the body's free names into the *minimum* input set
+   (`AnalyzeInputs`): the scope's own params, enclosing-lambda params,
+   enclosing-`LET` bindings (e.g. `convert` — carried with its real definition),
+   and externals (tables / workbook names, left alone).
+3. **Capture** each input's value by evaluating it in the lambda's enclosing
+   context **on the source sheet** (so sheet-local refs and tables resolve), via a
+   scratch cell. A recognised iterator's param is sliced (`CHOOSEROWS(both, k)`);
+   a param under a custom HOF is left blank to fill in (probe-capture is the next
+   step). Snapshots — not live formulas — so there's no ref-qualification problem
+   and the dummies are stable to edit.
+4. **Generate** a fresh `LB Debug N` sheet: each input written as a value block
+   under a **sheet-scoped** defined name (own params as `name_in`, seeded into the
+   LET so `/LET to LAMBDA` lifts exactly them; enclosing context under its own
+   name, referenced freely), then the body as a multiline `=LET(...)` decomposed
+   into steps (`BuildDebugLet`, reusing `UnnestEngine`). Deleting the sheet removes
+   its scoped names — total cleanup.
+
+### Status of this direction
+
+- Pure engine (tested): `AnalyzeInputs`, `BuildDebugLet`, `BuildCaptureFormula`.
+- `DebugLambdaCommand` + `DebugScopePickerWindow` (COM / sheet generation) —
+  compiles; **not yet exercised in Excel**.
+- The `/Debug Nested` watch window below is **retained until `/Debug Lambda` is
+  proven**, then retired.
+
+### Known gaps / next steps
+
+- **Probe-capture for custom HOFs** (e.g. `PAIROP`) — return each param
+  individually, run the host in context, read the chosen element. Until then those
+  params are blank cells to fill in by hand.
+- **Deep nesting** capture (pinning enclosing-lambda params through a custom-HOF
+  ancestor) is only partial.
+- **External sheet-local cell refs** in a body (rare) would resolve to the scratch
+  sheet — not yet qualified back to the source sheet.
+
+---
+
+## First spike (superseded): in-popup "pin & watch" (`/Debug Nested`)
+
 ## Approach taken: "Pin & Watch" (spike options A + C)
 
 1. **Pin one example (A).** Pick a lambda scope; bind each in-scope parameter


### PR DESCRIPTION
Spike for **#279**, for Tim to try and steer. **Not for merge as-is.**

## Direction (after discussion)
`/Unnest` debugs a *static* nested formula. #279 is about a `LAMBDA` applied over an array — the body runs per element with params bound dynamically, so nothing has a single value. We landed on a workflow that debugs the lambda **in real cells**:

> write formula → `/Unnest` to a LET → narrow the bug to an inner LAMBDA → **`/Debug Lambda`** → play with it on a scratch sheet → `/LET to LAMBDA` → paste the named lambda back.

## `/Debug Lambda` (the current command)
1. Modal picker: choose the lambda scope + a 1-based example index.
2. Classifies the body's **minimum input set** (own params, enclosing-lambda params, enclosing-`LET` bindings like `convert`, externals).
3. **Captures** each input's value by evaluating it in the lambda's enclosing context **on the source sheet** (recognised iterators sliced via `CHOOSEROWS`; custom-HOF params left blank to fill in).
4. Generates a fresh **`LB Debug N`** sheet: each input as a value block under a **sheet-scoped name** (own params as `name_in`, seeded into the LET so `/LET to LAMBDA` lifts exactly them; context referenced freely), then the body as a decomposed multiline `=LET(...)`. Delete the sheet → scoped names vanish.

## How to try it
On a cell like `=LET(convert, …, both, …, BYROW(both, LAMBDA(r, LET(m, MAX(r), IF(m>AVERAGE(convert), m, 0)))))`: `/Debug Lambda` → pick the `LAMBDA(r) — arg of BYROW` scope → Generate. You should get a sheet with `r_in` (a sample row), `convert` (its real value), and the body as an editable LET.

## Status / caveats
- Pure engine (`AnalyzeInputs`, `BuildDebugLet`, `BuildCaptureFormula`) is unit-tested.
- The COM / sheet-generation is **compiled but not yet exercised in Excel** — this is the part to kick the tyres on. Logging is in place for diagnosis.
- **Probe-capture for custom HOFs** (e.g. `PAIROP`) is the next step — those params currently come through as blank "fill in" cells.
- The earlier in-popup **`/Debug Nested`** watch window is retained until `/Debug Lambda` is proven, then retired.

See `specs/0010-debug-nested-spike.md` for the full design, known gaps, and the superseded first spike.

## Tests
16 engine unit tests; full suite green (1466).