### PR TITLE
Add LABELCLUSTERS connected-components lambda — #288

### DIFF
--- a/lambdas/maps/LABELCLUSTERS.lambda
+++ b/lambdas/maps/LABELCLUSTERS.lambda
@@ -1,0 +1,49 @@
+/*  FUNCTION NAME:      LABELCLUSTERS
+    DESCRIPTION:*//**Labels each input cell with an integer connected-component id, so adjacent cells (directly or transitively) in the same group share an id. Order-independent via min-label relaxation.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-07-01  Claude      Initial version
+*/
+LABELCLUSTERS = LAMBDA(
+//  Parameter Declarations
+    [cells],
+    [deltas],
+    [group],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →LABELCLUSTERS(cells, [deltas], [group])¶" &
+                "DESCRIPTION:   →Labels each input cell with an integer cluster id such that two cells in the same group share an id whenever they are adjacent, directly or transitively. Uses full transitive closure (min-label relaxation) so the result is independent of input order.¶" &
+                "VERSION:       →Jul 01 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   cells          →(Required) A column of cells — A1 address text (e.g. ""B7"") OR encoded scalar positions (row*100000+col). Auto-detected per element via ISNUMBER; text is normalised internally via CELLTOPOS.¶" &
+                "   deltas         →(Optional) A 1-D array of scalar position deltas defining connectivity. Default: the 8 compass directions ({-100000;100000;-1;1;-100001;-99999;99999;100001}). Pass {-100000;100000;-1;1} for 4-way, or any custom stencil (e.g. knight moves). Assumes the library default mult=100000.¶" &
+                "   group          →(Optional) Column of area / sheet keys (numeric or text). Adjacency is only tested between cells sharing the same key, so multi-sheet maps stay partitioned. Omitted: all cells treated as one group.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=LABELCLUSTERS({""A1"";""A3"";""A2""})¶" &
+                "Result         →{1;1;1} (A2 bridges A1 and A3 into one cluster)",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(cells),
+    //  Procedure
+        wasRow, AND(ROWS(cells) = 1, COLUMNS(cells) > 1),
+        cellsC, IF(wasRow, TRANSPOSE(cells), cells),
+        n, ROWS(cellsC),
+        pos, MAP(cellsC, LAMBDA(c, IF(ISNUMBER(c), c, CELLTOPOS(c)))),
+        grpRaw, IF(ISOMITTED(group), SEQUENCE(n, , 0, 0), IF(wasRow, TRANSPOSE(group), group)),
+        gi, XMATCH(grpRaw, UNIQUE(grpRaw)),
+        BIG, 1000000000000,
+        K, gi * BIG + pos,
+        dts, IF(ISOMITTED(deltas), {-100000;100000;-1;1;-100001;-99999;99999;100001}, deltas),
+        relaxStep, LAMBDA(lab,
+                      REDUCE(lab, dts, LAMBDA(acc, dlt,
+                        LET(nl, XLOOKUP(K + dlt, K, lab, n + 1),
+                            IF(nl < acc, nl, acc))))),
+        relax, LAMBDA(self, lab,
+                 LET(nxt, relaxStep(lab),
+                     IF(SUM(--(nxt <> lab)) = 0, lab, self(self, nxt)))),
+        finalLab, relax(relax, SEQUENCE(n)),
+        ids, XMATCH(finalLab, SORT(UNIQUE(finalLab))),
+        result, IF(wasRow, TRANSPOSE(ids), ids),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/LABELCLUSTERS.tests.yaml
+++ b/lambdas/maps/LABELCLUSTERS.tests.yaml
@@ -1,0 +1,32 @@
+tests:
+  - name: two orthogonally-adjacent cells share a cluster
+    args: ['={"B2";"B3"}']
+    expected: [[1], [1]]
+
+  - name: split region discovered out of order still merges (transitive closure)
+    args: ['={"A1";"A3";"A2"}']
+    expected: [[1], [1], [1]]
+
+  - name: isolated cell gets its own id, numbered by first appearance
+    args: ['={"B2";"B3";"E5"}']
+    expected: [[1], [1], [2]]
+
+  - name: diagonal pair merges under default 8-way connectivity
+    args: ['={"B2";"C3"}']
+    expected: [[1], [1]]
+
+  - name: diagonal pair splits under 4-way deltas
+    args: ['={"B2";"C3"}', '={-100000;100000;-1;1}']
+    expected: [[1], [2]]
+
+  - name: same position on different sheets stays partitioned by group
+    args: ['={"A1";"A2";"A1";"A2"}', '={-100000;100000;-1;1}', '={"S1";"S1";"S2";"S2"}']
+    expected: [[1], [1], [2], [2]]
+
+  - name: accepts encoded position integers directly
+    args: ['={200002;300002}']
+    expected: [[1], [1]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
Closes #288

## What

Adds `LABELCLUSTERS(cells, [deltas], [group])` to the Maps library — a connected-components labeller. It assigns each input cell an integer cluster id such that two cells in the same group get the same id whenever they are adjacent, directly or transitively. Fills a gap: no existing library lambda does connected-components labelling (MAZE traverses, GRIDAREA extracts, this one *partitions* a point set).

## Signature

`=LABELCLUSTERS(cells, [deltas], [group])`

| Param | Req | Behaviour |
|---|---|---|
| `cells` | Yes | Column of cells — A1 text (`"B7"`) or encoded positions (`row*100000+col`). Auto-detected per element via `ISNUMBER`; text normalised via `CELLTOPOS`. |
| `deltas` | No | 1-D array of scalar position deltas defining connectivity. Default: 8-way `_dirAll`. Pass `{-100000;100000;-1;1}` for 4-way, or any custom stencil. |
| `group` | No | Column of area / sheet keys (numeric **or** text). Adjacency only within a shared key. Omitted → one group. |

Returns a single column of cluster ids, same length/orientation as `cells`, numbered `1..k` in order of first appearance.

## How

Min-label relaxation to a fixpoint:

1. Normalise `cells` → encoded positions; map `group` keys → integer indices.
2. Composite key `K = groupIndex * 1e12 + pos` bakes the partition into the lookup — cells at the same (row,col) on different sheets get different keys and never connect.
3. Init `lab = SEQUENCE(n)`; relax step is a `REDUCE` over `deltas`, each taking the element-wise min of neighbour labels via a 1-D `XLOOKUP(K + delta, K, lab, n+1)`.
4. A recursive self-LAMBDA repeats the relax step until labels stabilise → full transitive closure, so order-of-discovery never causes a split-region mis-merge.
5. Because each component converges to its smallest original index, `XMATCH(finalLab, SORT(UNIQUE(finalLab)))` renumbers to first-appearance order for free.

Departs from the issue's `CONTAINS`/`POSAT`/`ROWOF` primitive sketch in favour of the composite-key `XLOOKUP` formulation — tighter body, and it handles the multi-sheet partition natively.

## Tests

8 harness cases: orthogonal adjacency, **split-region transitive merge** (bridge cell last), first-appearance numbering, diagonal merge under 8-way vs. split under 4-way `deltas`, **multi-sheet partition** (same position on two groups stays separate), encoded-integer input, and help text.

- Format tests: 672 passed
- Full harness suite: 733 passed (no regressions)