### PR TITLE
Add FOLDROWS table-growing fold lambda — #289

### DIFF
--- a/lambdas/loops/FOLDROWS.lambda
+++ b/lambdas/loops/FOLDROWS.lambda
@@ -1,0 +1,41 @@
+/*  FUNCTION NAME:      FOLDROWS
+    DESCRIPTION:*//**A REDUCE that grows a table for you: fn receives the table built so far, the current item row, and the 1-based index, and returns the row(s) to append. Owns the empty-state, column-shape and VSTACK bookkeeping.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-07-01  Claude      Initial version
+*/
+FOLDROWS = LAMBDA(
+//  Parameter Declarations
+    [items],
+    [fn],
+    [seed],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →FOLDROWS(items, fn, [seed])¶" &
+                "DESCRIPTION:   →A REDUCE that grows a table for you. fn receives the table accumulated so far, the current item row, and the 1-based index, and returns the new row(s) to append. FOLDROWS owns the empty-state, column-shape and VSTACK bookkeeping — the return is the full accumulated table with no shape-fixing seed row to strip.¶" &
+                "VERSION:       →Jul 01 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   items          →(Required) The rows to fold over, one logical item per row. A 1-D column or a 2-D table. A single horizontal row is treated as one item — transpose a horizontal list first.¶" &
+                "   fn             →(Required) LAMBDA(accSoFar, currentRow, i). accSoFar is the table built so far, or """" before the first row is appended; currentRow is the current item as a 1-row array; i is the 1-based item index. Return the new row(s) to append, or """" to append nothing (skip). Keep the appended width constant across steps.¶" &
+                "   seed           →(Optional) Initial accumulator rows — kept in the output and used to pin the column count. Default: empty (accSoFar starts as """").¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=FOLDROWS({10;20;30}, LAMBDA(acc, r, i, HSTACK(INDEX(r,1,1), IF(i=1, INDEX(r,1,1), INDEX(acc, ROWS(acc), 2) + INDEX(r,1,1)))))¶" &
+                "Result         →3x2 table: value in col 1, running total in col 2 ({10,10; 20,30; 30,60})",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(items),
+    //  Procedure
+        hasSeed, NOT(ISOMITTED(seed)),
+        n, ROWS(items),
+        init, IF(hasSeed, seed, ""),
+        result, REDUCE(init, SEQUENCE(n), LAMBDA(acc, i,
+                  LET(
+                    row, CHOOSEROWS(items, i),
+                    ret, fn(acc, row, i),
+                    skip?, AND(ROWS(ret) = 1, COLUMNS(ret) = 1, @ret = ""),
+                    empty?, AND(ROWS(acc) = 1, COLUMNS(acc) = 1, @acc = ""),
+                    IF(skip?, acc, IF(empty?, ret, VSTACK(acc, ret)))
+                  ))),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/loops/FOLDROWS.tests.yaml
+++ b/lambdas/loops/FOLDROWS.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: running total grows a 2-col table (base case on i=1, queries acc)
+    args: ['={10;20;30}', '=LAMBDA(acc, r, i, HSTACK(INDEX(r,1,1), IF(i=1, INDEX(r,1,1), INDEX(acc, ROWS(acc), 2) + INDEX(r,1,1))))']
+    expected: [[10, 10], [20, 30], [30, 60]]
+
+  - name: fn returning empty string skips the item (running de-duplication)
+    args: ['={5;5;7;5;7;9}', '=LAMBDA(acc, r, i, LET(v, INDEX(r,1,1), IF(i=1, v, IF(ISNUMBER(XMATCH(v, CHOOSECOLS(acc,1))), "", v))))']
+    expected: [[5], [7], [9]]
+
+  - name: seed pre-loads rows and is kept in the output
+    args: ['={2;3}', '=LAMBDA(acc, r, i, INDEX(r,1,1))', '={100}']
+    expected: [[100], [2], [3]]
+
+  - name: fn may append multiple rows per item
+    args: ['={1;2}', '=LAMBDA(acc, r, i, VSTACK(INDEX(r,1,1), INDEX(r,1,1)*10))']
+    expected: [[1], [10], [2], [20]]
+
+  - name: sequential id assignment via MAX of the id column
+    args: ['={"a";"b";"a";"c"}', '=LAMBDA(acc, r, i, LET(k, INDEX(r,1,1), IF(i=1, HSTACK(k, 1), LET(hit, FILTER(CHOOSECOLS(acc,2), CHOOSECOLS(acc,1)=k, 0), IF(@hit=0, HSTACK(k, MAX(CHOOSECOLS(acc,2))+1), HSTACK(k, @hit))))))']
+    expected: [["a", 1], ["b", 2], ["a", 1], ["c", 3]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
Closes #289

## What

Adds `FOLDROWS(items, fn, [seed])` to the Loops library — a `REDUCE` that grows a 2-D table for you. It owns the empty-state, column-shape and `VSTACK` bookkeeping that makes the whole class of *order-dependent, online list-building* formulas painful to hand-write: connected-components labelling, running de-duplication with memory, sequential id assignment, greedy interval scheduling.

It's the 2-D-table-native sibling of the Loops library's scalar/1-D state primitives (`NewState` / `SetVar` / `GetVar`).

## Signature

`=FOLDROWS(items, fn, [seed])`

| Param | Req | Behaviour |
|---|---|---|
| `items` | Yes | Rows to fold over, one logical item per row (1-D column or 2-D table). |
| `fn` | Yes | `LAMBDA(accSoFar, currentRow, i)`. `accSoFar` is the table so far, or `""` before the first append; `currentRow` is the current item as a 1-row array; `i` is the 1-based index. Return the row(s) to append, or `""` to append nothing (skip). |
| `seed` | No | Initial accumulator rows — kept in the output and used to pin the column count. Default: empty. |

Returns the accumulated table, in order, with **no shape-fixing seed row to strip**.

## Design decisions (confirmed with Tim)

- **`fn` takes the index `i`** (matching `REDUCEUNTIL` / `REDUCEWHILE`), so the base case keys off the scalar `i=1` rather than a fragile array-compare against the empty accumulator. Excel has no true zero-row typed array, so the empty state is represented as the Loops-library `""` sentinel.
- **Skip support:** `fn` returning `""` appends nothing that step — this is what running de-dup and greedy-skip need. Detected scalar-safely via `AND(ROWS(ret)=1, COLUMNS(ret)=1, @ret="")`.

## Before / after

The single-pass labelling sketch from the issue, boilerplate collapsed — the seed row, the `DROP`, and the manual `VSTACK` all move inside the primitive; `fn` is just the logic.

## Tests

6 harness cases: running-total table (base case + querying `acc`), **skip / running de-duplication**, seed pre-load kept in output, multi-row appends per item, **sequential id assignment** (MAX-of-id-column, the clustering-flavoured case), and help text.

- Format tests: 680 passed
- Full harness suite: 739 passed (no regressions)

## Note on performance

Inherently `O(n × cost-of-querying-acc)` — it trades speed for expressiveness, as the issue calls out. Fine for the small grids/lists these algorithms target; `LABELCLUSTERS` keeps its own faster order-independent algorithm.