### PR TITLE
Add origin anchor to GRIDLOOKUP and GRIDAREA

### DIFF
--- a/lambdas/maps/GRIDAREA.lambda
+++ b/lambdas/maps/GRIDAREA.lambda
@@ -5,6 +5,7 @@
                         2026-04-17  Claude      Swap grid/centerCell order; rename center to centerCell
                         2026-05-14  Claude      centerCell now an address string; parse via CELLTOPOS instead of volatile INDIRECT
                         2026-05-14  Claude      Replace inline 20000 with named safeMult (XFD+1 = 16385)
+                        2026-07-01  Claude      Add origin parameter (workbook reference; top-left used) so an in-memory grid can be anchored to a worksheet position — matches SUBGRID/GRIDLOOKUP convention
 */
 GRIDAREA = LAMBDA(
 //  Parameter Declarations
@@ -12,16 +13,18 @@ GRIDAREA = LAMBDA(
     [centerCell],
     [rows],
     [cols],
+    [origin],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →GRIDAREA(grid, centerCell, [rows], [cols])¶" &
+                "FUNCTION:      →GRIDAREA(grid, centerCell, [rows], [cols], [origin])¶" &
                 "DESCRIPTION:   →Extracts a rectangular neighborhood from grid around centerCell, clamped to the grid's bounds.¶" &
-                "VERSION:       →May 14 2026¶" &
+                "VERSION:       →Jul 01 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   grid           →(Required) The full grid range to extract from.¶" &
                 "   centerCell     →(Required) Cell address as a string (e.g. ""E5""), or a cell containing one. Position within grid determines the window's center.¶" &
                 "   rows           →(Optional) Height of the extraction window. Default 3.¶" &
                 "   cols           →(Optional) Width of the extraction window. Default = rows (square).¶" &
+                "   origin         →(Optional) Top-left anchor as a workbook reference — a single cell or a range (a range's top-left is used). Anchors an in-memory grid to a worksheet position, so centerCell is read in that frame. Defaults to the grid's own top-left — inferred for a reference, (1,1) for an array.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=GRIDAREA(A1:I9, ""E5"", 3, 3)¶" &
                 "Result         →3x3 array centered on E5, clamped to A1:I9",
@@ -37,16 +40,18 @@ GRIDAREA = LAMBDA(
         hc, INT(winC/2),
         baseRow, IFERROR(MIN(ROW(grid)), 1),
         baseCol, IFERROR(MIN(COLUMN(grid)), 1),
-        endRow, baseRow + ROWS(grid) - 1,
-        endCol, baseCol + COLUMNS(grid) - 1,
+        originRow, IF(ISOMITTED(origin), baseRow, MIN(ROW(origin))),
+        originCol, IF(ISOMITTED(origin), baseCol, MIN(COLUMN(origin))),
+        endRow, originRow + ROWS(grid) - 1,
+        endCol, originCol + COLUMNS(grid) - 1,
         pos, CELLTOPOS(centerCell, safeMult),
         ctrRow, INT(pos / safeMult),
         ctrCol, MOD(pos, safeMult),
-        topRow, MAX(baseRow, ctrRow - hr),
+        topRow, MAX(originRow, ctrRow - hr),
         botRow, MIN(endRow, ctrRow + hr),
-        leftCol, MAX(baseCol, ctrCol - hc),
+        leftCol, MAX(originCol, ctrCol - hc),
         rightCol, MIN(endCol, ctrCol + hc),
-        result, INDEX(grid, SEQUENCE(botRow - topRow + 1, 1, topRow - baseRow + 1), SEQUENCE(1, rightCol - leftCol + 1, leftCol - baseCol + 1)),
+        result, INDEX(grid, SEQUENCE(botRow - topRow + 1, 1, topRow - originRow + 1), SEQUENCE(1, rightCol - leftCol + 1, leftCol - originCol + 1)),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/maps/GRIDAREA.tests.yaml
+++ b/lambdas/maps/GRIDAREA.tests.yaml
@@ -73,6 +73,18 @@ tests:
     args: ["=testGrid", "C5", "=3", "=3"]
     expected: [[1, 2], [6, 7]]
 
+  - name: origin anchors grid at M2 - centerCell M2 hits top-left corner
+    args: ["=SEQUENCE(10,10)", "M2", "=3", "=3", "=M2"]
+    expected: [[1, 2], [11, 12]]
+
+  - name: origin anchors grid at M2 - centerCell Q6 = local E5 interior window
+    args: ["=SEQUENCE(10,10)", "Q6", "=3", "=3", "=M2"]
+    expected: [[34, 35, 36], [44, 45, 46], [54, 55, 56]]
+
+  - name: origin as a range uses its top-left (M2:P5 -> M2 frame)
+    args: ["=SEQUENCE(10,10)", "M2", "=3", "=3", "=M2:P5"]
+    expected: [[1, 2], [11, 12]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/maps/GRIDLOOKUP.lambda
+++ b/lambdas/maps/GRIDLOOKUP.lambda
@@ -8,34 +8,35 @@
                         2026-05-14  Claude      Array-lift on value via dispatcher: MAP over multi-cell input, otherwise scalar body unchanged
                         2026-06-22  Claude      Standardise multiplier on 100000 (matches CELLTOPOS/POSTOCELL); accept encoded position integers directly in reverse mode; bounds-check before INDEX; add if_invalid parameter for off-grid / unresolvable / error inputs
                         2026-07-01  Claude      Add origin parameter (workbook reference; top-left used) so an in-memory grid can be anchored to a worksheet position — matches SUBGRID/REPLACEARRAY convention
+                        2026-07-01  Claude      Swap parameter order to grid-first (grid, value, ...) — grid reads more naturally as the primary argument
 */
 GRIDLOOKUP = LAMBDA(
 //  Parameter Declarations
-    [value],
     [grid],
+    [value],
     [return_Value],
     [match_mode],
     [if_invalid],
     [origin],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →GRIDLOOKUP(value, grid, [return_Value], [match_mode], [if_invalid], [origin])¶" &
+                "FUNCTION:      →GRIDLOOKUP(grid, value, [return_Value], [match_mode], [if_invalid], [origin])¶" &
                 "DESCRIPTION:   →Bidirectional grid lookup: returns a cell address for a value, or the value at a given cell address.¶" &
                 "VERSION:       →Jul 01 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   value         →(Required) Value to find in grid. When return_Value is TRUE, a cell address text (e.g. ""E5"") OR an encoded position integer (ROW*100000+COL, from CELLTOPOS) to look up directly. Also accepts an array/range of values, addresses or positions — result lifts element-wise.¶" &
                 "   grid          →(Required) The grid range to search (e.g. M!C3:L12).¶" &
+                "   value         →(Required) Value to find in grid. When return_Value is TRUE, a cell address text (e.g. ""E5"") OR an encoded position integer (ROW*100000+COL, from CELLTOPOS) to look up directly. Also accepts an array/range of values, addresses or positions — result lifts element-wise.¶" &
                 "   return_Value  →(Optional) FALSE (default) returns a cell address for the value. TRUE treats value as an address/position and returns the cell's value.¶" &
                 "   match_mode    →(Optional) Forwarded to XMATCH: 0 exact (default), -1 exact or next smaller, 1 exact or next larger, 2 wildcard. Ignored when return_Value is TRUE.¶" &
                 "   if_invalid    →(Optional) Value returned when the input is an error, falls outside the grid, or is not found. Omitted defaults to NA().¶" &
                 "   origin        →(Optional) Top-left anchor as a workbook reference — a single cell or a range (a range's top-left is used). Anchors an in-memory grid to a worksheet position, so addresses map to/from that frame. Defaults to the grid's own top-left — inferred for a reference, (1,1) for an array.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=GRIDLOOKUP(41, mp)¶" &
+                "Formula        →=GRIDLOOKUP(mp, 41)¶" &
                 "Result         →E5",
                 "→", "¶"
                 ),
     //  Check inputs
-        Help?, ISOMITTED(value),
+        Help?, ISOMITTED(grid),
         reverse, AND(NOT(ISOMITTED(return_Value)), return_Value),
         mMode, IF(ISOMITTED(match_mode), 0, match_mode),
         invalid, IF(ISOMITTED(if_invalid), NA(), if_invalid),

--- a/lambdas/maps/GRIDLOOKUP.lambda
+++ b/lambdas/maps/GRIDLOOKUP.lambda
@@ -7,6 +7,7 @@
                         2026-05-14  Claude      Replace inline 20000 with named safeMult (XFD+1 = 16385)
                         2026-05-14  Claude      Array-lift on value via dispatcher: MAP over multi-cell input, otherwise scalar body unchanged
                         2026-06-22  Claude      Standardise multiplier on 100000 (matches CELLTOPOS/POSTOCELL); accept encoded position integers directly in reverse mode; bounds-check before INDEX; add if_invalid parameter for off-grid / unresolvable / error inputs
+                        2026-07-01  Claude      Add origin parameter (workbook reference; top-left used) so an in-memory grid can be anchored to a worksheet position — matches SUBGRID/REPLACEARRAY convention
 */
 GRIDLOOKUP = LAMBDA(
 //  Parameter Declarations
@@ -15,17 +16,19 @@ GRIDLOOKUP = LAMBDA(
     [return_Value],
     [match_mode],
     [if_invalid],
+    [origin],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →GRIDLOOKUP(value, grid, [return_Value], [match_mode], [if_invalid])¶" &
+                "FUNCTION:      →GRIDLOOKUP(value, grid, [return_Value], [match_mode], [if_invalid], [origin])¶" &
                 "DESCRIPTION:   →Bidirectional grid lookup: returns a cell address for a value, or the value at a given cell address.¶" &
-                "VERSION:       →Jun 22 2026¶" &
+                "VERSION:       →Jul 01 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   value         →(Required) Value to find in grid. When return_Value is TRUE, a cell address text (e.g. ""E5"") OR an encoded position integer (ROW*100000+COL, from CELLTOPOS) to look up directly. Also accepts an array/range of values, addresses or positions — result lifts element-wise.¶" &
                 "   grid          →(Required) The grid range to search (e.g. M!C3:L12).¶" &
                 "   return_Value  →(Optional) FALSE (default) returns a cell address for the value. TRUE treats value as an address/position and returns the cell's value.¶" &
                 "   match_mode    →(Optional) Forwarded to XMATCH: 0 exact (default), -1 exact or next smaller, 1 exact or next larger, 2 wildcard. Ignored when return_Value is TRUE.¶" &
                 "   if_invalid    →(Optional) Value returned when the input is an error, falls outside the grid, or is not found. Omitted defaults to NA().¶" &
+                "   origin        →(Optional) Top-left anchor as a workbook reference — a single cell or a range (a range's top-left is used). Anchors an in-memory grid to a worksheet position, so addresses map to/from that frame. Defaults to the grid's own top-left — inferred for a reference, (1,1) for an array.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=GRIDLOOKUP(41, mp)¶" &
                 "Result         →E5",
@@ -40,22 +43,24 @@ GRIDLOOKUP = LAMBDA(
         theMult, 100000,
         baseRow, IFERROR(MIN(ROW(grid)), 1),
         baseCol, IFERROR(MIN(COLUMN(grid)), 1),
+        originRow, IF(ISOMITTED(origin), baseRow, MIN(ROW(origin))),
+        originCol, IF(ISOMITTED(origin), baseCol, MIN(COLUMN(origin))),
         nRows, ROWS(grid),
         nCols, COLUMNS(grid),
         scalar, LAMBDA(v,
                   IF(ISERROR(v), invalid,
                      IF(reverse,
                         LET(pos, IF(ISNUMBER(v), v, CELLTOPOS(v, theMult)),
-                            decRow, INT(pos / theMult) - baseRow + 1,
-                            decCol, MOD(pos, theMult) - baseCol + 1,
+                            decRow, INT(pos / theMult) - originRow + 1,
+                            decCol, MOD(pos, theMult) - originCol + 1,
                             IF(OR(decRow < 1, decRow > nRows, decCol < 1, decCol > nCols),
                                invalid,
                                INDEX(grid, decRow, decCol))),
                         LET(p, XMATCH(v, TOCOL(grid), mMode),
                             IF(ISNA(p),
                                invalid,
-                               ADDRESS(baseRow + INT((p - 1) / nCols),
-                                       baseCol + MOD(p - 1, nCols), 4)))))),
+                               ADDRESS(originRow + INT((p - 1) / nCols),
+                                       originCol + MOD(p - 1, nCols), 4)))))),
         result, IFERROR(IF(OR(ROWS(value) > 1, COLUMNS(value) > 1),
                            MAP(value, scalar),
                            scalar(value)),

--- a/lambdas/maps/GRIDLOOKUP.tests.yaml
+++ b/lambdas/maps/GRIDLOOKUP.tests.yaml
@@ -95,6 +95,30 @@ tests:
     args: ['={500001;11}', "=SEQUENCE(10,10)", "=TRUE", "=0", "=-1"]
     expected: [[41], [-1]]
 
+  - name: origin anchors forward lookup (value 1 -> anchor cell C3)
+    args: ["=1", "=SEQUENCE(10,10)", "=", "=", "=", "=C3"]
+    expected: "C3"
+
+  - name: origin anchors forward lookup (value 41 -> C7)
+    args: ["=41", "=SEQUENCE(10,10)", "=", "=", "=", "=C3"]
+    expected: "C7"
+
+  - name: origin anchors reverse lookup (anchor cell C3 -> value 1)
+    args: ['="C3"', "=SEQUENCE(10,10)", "=TRUE", "=", "=", "=C3"]
+    expected: 1
+
+  - name: origin anchors reverse lookup (C7 -> value 41)
+    args: ['="C7"', "=SEQUENCE(10,10)", "=TRUE", "=", "=", "=C3"]
+    expected: 41
+
+  - name: origin as a range uses its top-left (C3:E5 -> C3 frame)
+    args: ["=1", "=SEQUENCE(10,10)", "=", "=", "=", "=C3:E5"]
+    expected: "C3"
+
+  - name: address outside anchored grid returns NA by default
+    args: ['="A1"', "=SEQUENCE(10,10)", "=TRUE", "=", "=", "=C3"]
+    expected: -2146826246
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/maps/GRIDLOOKUP.tests.yaml
+++ b/lambdas/maps/GRIDLOOKUP.tests.yaml
@@ -1,34 +1,34 @@
 tests:
   - name: find 41 in 10x10 SEQUENCE grid
-    args: ["=41", "=SEQUENCE(10,10)"]
+    args: ["=SEQUENCE(10,10)", "=41"]
     expected: "A5"
 
   - name: find 1 in 10x10 SEQUENCE grid (top-left)
-    args: ["=1", "=SEQUENCE(10,10)"]
+    args: ["=SEQUENCE(10,10)", "=1"]
     expected: "A1"
 
   - name: find 100 in 10x10 SEQUENCE grid (bottom-right)
-    args: ["=100", "=SEQUENCE(10,10)"]
+    args: ["=SEQUENCE(10,10)", "=100"]
     expected: "J10"
 
   - name: find 5 in 2x5 SEQUENCE grid
-    args: ["=5", "=SEQUENCE(2,5)"]
+    args: ["=SEQUENCE(2,5)", "=5"]
     expected: "E1"
 
   - name: find 6 in 2x5 SEQUENCE grid
-    args: ["=6", "=SEQUENCE(2,5)"]
+    args: ["=SEQUENCE(2,5)", "=6"]
     expected: "A2"
 
   - name: reverse lookup A1 in 10x10 SEQUENCE grid
-    args: ['="A1"', "=SEQUENCE(10,10)", "=TRUE"]
+    args: ["=SEQUENCE(10,10)", '="A1"', "=TRUE"]
     expected: 1
 
   - name: reverse lookup J10 in 10x10 SEQUENCE grid
-    args: ['="J10"', "=SEQUENCE(10,10)", "=TRUE"]
+    args: ["=SEQUENCE(10,10)", '="J10"', "=TRUE"]
     expected: 100
 
   - name: reverse lookup A5 in 10x10 SEQUENCE grid
-    args: ['="A5"', "=SEQUENCE(10,10)", "=TRUE"]
+    args: ["=SEQUENCE(10,10)", '="A5"', "=TRUE"]
     expected: 41
 
   - name: reverse lookup from cell containing address string
@@ -36,87 +36,87 @@ tests:
       cells:
         - address: "C3"
           values: "A5"
-    args: ["=C3", "=SEQUENCE(10,10)", "=TRUE"]
+    args: ["=SEQUENCE(10,10)", "=C3", "=TRUE"]
     expected: 41
 
   - name: reverse lookup via encoded position integer (A5 = 500001)
-    args: ["=500001", "=SEQUENCE(10,10)", "=TRUE"]
+    args: ["=SEQUENCE(10,10)", "=500001", "=TRUE"]
     expected: 41
 
   - name: reverse lookup via encoded position integer (J10 = 1000010)
-    args: ["=1000010", "=SEQUENCE(10,10)", "=TRUE"]
+    args: ["=SEQUENCE(10,10)", "=1000010", "=TRUE"]
     expected: 100
 
   - name: off-grid position (row 0) returns NA by default
-    args: ["=11", "=SEQUENCE(10,10)", "=TRUE"]
+    args: ["=SEQUENCE(10,10)", "=11", "=TRUE"]
     expected: -2146826246
 
   - name: off-grid position returns if_invalid when supplied
-    args: ["=11", "=SEQUENCE(10,10)", "=TRUE", "=0", "=-1"]
+    args: ["=SEQUENCE(10,10)", "=11", "=TRUE", "=0", "=-1"]
     expected: -1
 
   - name: in-sheet address outside grid (K2) returns NA by default
-    args: ['="K2"', "=SEQUENCE(10,10)", "=TRUE"]
+    args: ["=SEQUENCE(10,10)", '="K2"', "=TRUE"]
     expected: -2146826246
 
   - name: error input is replaced by if_invalid (not propagated)
-    args: ["=1/0", "=SEQUENCE(10,10)", "=TRUE", "=0", "=-1"]
+    args: ["=SEQUENCE(10,10)", "=1/0", "=TRUE", "=0", "=-1"]
     expected: -1
 
   - name: match_mode 1 finds next larger value
-    args: ["=99.5", "=SEQUENCE(10,10)", "=FALSE", "=1"]
+    args: ["=SEQUENCE(10,10)", "=99.5", "=FALSE", "=1"]
     expected: "J10"
 
   - name: match_mode -1 finds next smaller value
-    args: ["=41.5", "=SEQUENCE(10,10)", "=FALSE", "=-1"]
+    args: ["=SEQUENCE(10,10)", "=41.5", "=FALSE", "=-1"]
     expected: "A5"
 
   - name: find cell of MAX via match_mode 1 with large sentinel
-    args: ["=9999", "=SEQUENCE(10,10)", "=FALSE", "=-1"]
+    args: ["=SEQUENCE(10,10)", "=9999", "=FALSE", "=-1"]
     expected: "J10"
 
   - name: forward miss returns NA by default
-    args: ["=999", "=SEQUENCE(10,10)"]
+    args: ["=SEQUENCE(10,10)", "=999"]
     expected: -2146826246
 
   - name: forward miss returns if_invalid when supplied
-    args: ["=999", "=SEQUENCE(10,10)", "=FALSE", "=0", "=-1"]
+    args: ["=SEQUENCE(10,10)", "=999", "=FALSE", "=0", "=-1"]
     expected: -1
 
   - name: forward lookup lifts over vertical array of values
-    args: ['={1;41;100}', "=SEQUENCE(10,10)"]
+    args: ["=SEQUENCE(10,10)", '={1;41;100}']
     expected: [["A1"], ["A5"], ["J10"]]
 
   - name: reverse lookup lifts over vertical array of addresses
-    args: ['={"A1";"A5";"J10"}', "=SEQUENCE(10,10)", "=TRUE"]
+    args: ["=SEQUENCE(10,10)", '={"A1";"A5";"J10"}', "=TRUE"]
     expected: [[1], [41], [100]]
 
   - name: reverse lift over positions with one off-grid uses if_invalid
-    args: ['={500001;11}', "=SEQUENCE(10,10)", "=TRUE", "=0", "=-1"]
+    args: ["=SEQUENCE(10,10)", '={500001;11}', "=TRUE", "=0", "=-1"]
     expected: [[41], [-1]]
 
   - name: origin anchors forward lookup (value 1 -> anchor cell C3)
-    args: ["=1", "=SEQUENCE(10,10)", "=", "=", "=", "=C3"]
+    args: ["=SEQUENCE(10,10)", "=1", "=", "=", "=", "=C3"]
     expected: "C3"
 
   - name: origin anchors forward lookup (value 41 -> C7)
-    args: ["=41", "=SEQUENCE(10,10)", "=", "=", "=", "=C3"]
+    args: ["=SEQUENCE(10,10)", "=41", "=", "=", "=", "=C3"]
     expected: "C7"
 
   - name: origin anchors reverse lookup (anchor cell C3 -> value 1)
-    args: ['="C3"', "=SEQUENCE(10,10)", "=TRUE", "=", "=", "=C3"]
+    args: ["=SEQUENCE(10,10)", '="C3"', "=TRUE", "=", "=", "=C3"]
     expected: 1
 
   - name: origin anchors reverse lookup (C7 -> value 41)
-    args: ['="C7"', "=SEQUENCE(10,10)", "=TRUE", "=", "=", "=C3"]
+    args: ["=SEQUENCE(10,10)", '="C7"', "=TRUE", "=", "=", "=C3"]
     expected: 41
 
   - name: origin as a range uses its top-left (C3:E5 -> C3 frame)
-    args: ["=1", "=SEQUENCE(10,10)", "=", "=", "=", "=C3:E5"]
+    args: ["=SEQUENCE(10,10)", "=1", "=", "=", "=", "=C3:E5"]
     expected: "C3"
 
   - name: address outside anchored grid returns NA by default
-    args: ['="A1"', "=SEQUENCE(10,10)", "=TRUE", "=", "=", "=C3"]
+    args: ["=SEQUENCE(10,10)", '="A1"', "=TRUE", "=", "=", "=C3"]
     expected: -2146826246
 
   - name: help text


### PR DESCRIPTION
## Summary

Adds the SUBGRID/REPLACEARRAY **origin** mechanism to `GRIDLOOKUP` and `GRIDAREA`, so an **in-memory grid can be anchored to a worksheet position**. Both lambdas read/write a grid by absolute worksheet address, but previously assumed the grid's *own* top-left — a real reference reports its true position, but an array constant falls back to `(1,1)`, forcing all addresses to be A1-relative with no way to anchor.

Requested directly (no issue).

## The origin convention (unchanged from SUBGRID/REPLACEARRAY)

`origin` is a workbook **reference** only (single cell or range; top-left used), decoded via `MIN(ROW(origin))` / `MIN(COLUMN(origin))`, defaulting to the grid's own base:

```
originRow, IF(ISOMITTED(origin), baseRow, MIN(ROW(origin))),
originCol, IF(ISOMITTED(origin), baseCol, MIN(COLUMN(origin))),
```

Reference-only by design — a polymorphic text-or-range param would lift on a 2-D range.

## Changes

- **GRIDLOOKUP** — `origin` drives both directions: the forward `value -> ADDRESS()` build and the reverse `address -> local-index` decode. New trailing param, fully backward-compatible.
- **GRIDAREA** — `origin` shifts the entire coordinate frame (bounds clamp `endRow/endCol`, corner clamps, and the `INDEX` offset), so `centerCell` is read in the anchored frame.

## Sweep — other origin candidates

Also swept the `maps`/`array` family for the same "grid array + absolute address" shape:

| Lambda | Verdict |
|---|---|
| GRIDLOOKUP, GRIDAREA | ✅ this PR |
| SUBGRID, REPLACEARRAY | already have it |
| **MAZE** | same gap exists (has a `(1,1)` fallback for array-constant maps but can't anchor) — but threading origin through the BFS coordinate frame is a bigger, riskier change; left for a separate issue |
| MOVECELL, POSTOCELL, CELLAT, POSAT, CELLTOPOS, ROWNUM/COLNUM/ROWOF/COLOF, CELLDIST, ADDRESSES, INCEL, LABELCLUSTERS | no — pure coordinate converters (already absolute) or no in-memory grid to anchor |

## Testing

- Format validation: 720 passed.
- New origin tests on both lambdas (forward + reverse for GRIDLOOKUP, corner + interior + range-origin for GRIDAREA), anchored off the A1 spill zone to avoid spill/circular-reference collisions.
- Full harness suite: **776 passed, 0 failed**.