### PR TITLE
Add DISTFROM — nearest-match distance grid

### DIFF
--- a/lambdas/maps/DISTFROM.lambda
+++ b/lambdas/maps/DISTFROM.lambda
@@ -1,0 +1,51 @@
+/*  FUNCTION NAME:      DISTFROM
+    DESCRIPTION:*//**For every cell in a grid, returns the grid distance to the nearest cell whose value matches the target.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-07-01  Claude      Initial version
+*/
+DISTFROM = LAMBDA(
+//  Parameter Declarations
+    [grid],
+    [target],
+    [metric],
+    [test],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →DISTFROM(grid, target, [metric], [test])¶" &
+                "DESCRIPTION:   →For every cell in a grid, returns the distance to the nearest cell whose value matches the target. Result is the same shape as grid; a cell that itself matches is distance 0. Every cell returns #N/A when nothing matches.¶" &
+                "VERSION:       →Jul 01 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   grid           →(Required) The 2-D range or array to scan.¶" &
+                "   target         →(Required) Value to match by equality. Also accepts an array of values — a cell matches if it equals ANY of them (e.g. nearest wall OR door). Matching is case-insensitive (via XMATCH). When test is supplied, target is passed to it as the second argument instead.¶" &
+                "   metric         →(Optional) Distance metric: 0 Manhattan (default, 4-directional), 1 Chebyshev (8-directional, diagonals count as 1), 2 Euclidean (straight-line). Mirrors CELLDIST.¶" &
+                "   test           →(Optional) A predicate LAMBDA(value, target) returning TRUE for a matching cell, e.g. LAMBDA(v,t, v>=t) for a threshold or LAMBDA(v,t, ISNUMBER(v)). Overrides the default equality / membership match.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=DISTFROM({0,1,0;0,0,0}, 1)¶" &
+                "Result         →{1,0,1;2,1,2} (Manhattan distance to the nearest 1)",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(grid),
+    //  Procedure
+        nRows, ROWS(grid),
+        nCols, COLUMNS(grid),
+        vals, TOCOL(grid),
+        rws, TOCOL(SEQUENCE(nRows) + 0 * SEQUENCE(, nCols)),
+        cls, TOCOL(SEQUENCE(nRows) * 0 + SEQUENCE(, nCols)),
+        met, IF(ISOMITTED(metric), 0, metric),
+        matched, IF(ISOMITTED(test),
+                    ISNUMBER(XMATCH(vals, target)),
+                    MAP(vals, LAMBDA(v, test(v, target)))),
+        nMatch, SUM(--matched),
+        Mrws, TOROW(FILTER(rws, matched, 0)),
+        Mcls, TOROW(FILTER(cls, matched, 0)),
+        rdist, ABS(rws - Mrws),
+        cdist, ABS(cls - Mcls),
+        perCell, IF(met = 2, SQRT(BYROW(rdist ^ 2 + cdist ^ 2, MIN)),
+                 IF(met = 1, BYROW(IF(rdist > cdist, rdist, cdist), MIN),
+                             BYROW(rdist + cdist, MIN))),
+        distGrid, WRAPROWS(perCell, nCols),
+        result, IF(nMatch = 0, SEQUENCE(nRows, nCols) * 0 + NA(), distGrid),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/DISTFROM.tests.yaml
+++ b/lambdas/maps/DISTFROM.tests.yaml
@@ -1,0 +1,28 @@
+tests:
+  - name: manhattan distance to single target
+    args: ['={0,1,0;0,0,0}', '=1']
+    expected: [[1, 0, 1], [2, 1, 2]]
+
+  - name: chebyshev metric (diagonals count as 1)
+    args: ['={0,1,0;0,0,0}', '=1', '=1']
+    expected: [[1, 0, 1], [1, 1, 1]]
+
+  - name: euclidean metric (straight-line)
+    args: ['={0,1,0;0,0,0}', '=1', '=2']
+    expected: [[1, 0, 1], [1.4142135623730951, 1, 1.4142135623730951]]
+
+  - name: membership - nearest of any target value
+    args: ['={1,0,0,2}', '={1,2}']
+    expected: [[0, 1, 1, 0]]
+
+  - name: test predicate - threshold match
+    args: ['={1,5,1;1,1,1}', '=5', '=0', '=LAMBDA(v,t, v>=t)']
+    expected: [[1, 0, 1], [2, 1, 2]]
+
+  - name: no match returns NA grid
+    args: ['={0,0;0,0}', '=9']
+    expected: [[-2146826246, -2146826246], [-2146826246, -2146826246]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

Adds `DISTFROM(grid, target, [metric], [test])` to the `maps/` library. For every cell in a grid it returns the grid distance to the nearest cell whose value matches the target — same shape as the input, matching cells are distance `0`, and an all-`#N/A` grid when nothing matches.

```
=DISTFROM({0,1,0;0,0,0}, 1)   ->  {1,0,1;2,1,2}   (Manhattan distance to the nearest 1)
```

Based on a community DISTFROM (`MAP(rdist, cdist, func)` + `BYROW(MIN)`), refined to fit the library:

- **`metric` is a numeric enum** — `0` Manhattan (default), `1` Chebyshev, `2` Euclidean — matching its sibling `CELLDIST`. This gives *true* Euclidean via `SQRT` (the original's `func=SUMSQ` silently produced squared-Euclidean), and lets the body drop the per-element `MAP` for pure broadcast + `BYROW`, which is faster.
- **`target` accepts an array of values** — a cell matches if it equals ANY of them (nearest wall OR door), via `ISNUMBER(XMATCH(...))` membership.
- **Optional `test` predicate** `LAMBDA(value, target)` for conditional matches — e.g. `LAMBDA(v,t, v>=t)` (threshold) or `LAMBDA(v,t, ISNUMBER(v))` — overriding the default equality/membership match.

## Placement

Lives in `maps/` next to `CELLDIST`. Built entirely from Excel built-ins (no lambda-to-lambda dependencies), so colocation is unconstrained.

## Testing

- Format tests: pass (728).
- Harness — 7 DISTFROM cases (Manhattan / Chebyshev / Euclidean, array membership, `test` predicate, no-match `#N/A` grid, help): pass.
- Full harness suite: **787 passed, 0 failed**.

## Notes / possible follow-ups

- Default membership matching is case-insensitive (inherits `XMATCH` behaviour) — noted in the help text.
- A caller-supplied `if_none` sentinel and a custom-metric lambda were considered and deferred as future extensions; the current no-match behaviour is a clean `#N/A` grid.