### PR TITLE
Add SEARCHALL — spill all substring match positions

### DIFF
--- a/lambdas/string/SEARCHALL.lambda
+++ b/lambdas/string/SEARCHALL.lambda
@@ -1,0 +1,47 @@
+/*  FUNCTION NAME:      SEARCHALL
+    DESCRIPTION:*//**Returns a spilled column of the 1-based start positions of every occurrence of a substring within a string.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-07-09  Claude      Initial version
+*/
+SEARCHALL = LAMBDA(
+//  Parameter Declarations
+    [inText],
+    [searchFor],
+    [match_case],
+    [overlapping],
+    [if_not_found],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →SEARCHALL(inText, searchFor, [match_case], [overlapping], [if_not_found])¶" &
+                "DESCRIPTION:   →Returns a spilled column of the 1-based start positions of every occurrence of a substring within a string.¶" &
+                "VERSION:       →Jul 09 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   inText         →(Required) Text to search within.¶" &
+                "   searchFor      →(Required) Substring to locate.¶" &
+                "   match_case     →(Optional) FALSE (default) matches case-insensitively; TRUE matches case-sensitively (EXACT).¶" &
+                "   overlapping    →(Optional) TRUE (default) counts overlapping matches; FALSE consumes searchFor after each hit (non-overlapping).¶" &
+                "   if_not_found   →(Optional) Value returned when no match is found. Default #N/A.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=SEARCHALL(""KTTKBPK"", ""K"")¶" &
+                "Result         →{1;4;7}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(inText),
+        caseFlag, IF(ISOMITTED(match_case), FALSE, match_case),
+        overlapFlag, IF(ISOMITTED(overlapping), TRUE, overlapping),
+        notFound, IF(ISOMITTED(if_not_found), NA(), if_not_found),
+    //  Procedure
+        lw, LEN(inText),
+        ls, LEN(searchFor),
+        idx, SEQUENCE(MAX(lw - ls + 1, 1)),
+        segs, MID(inText, idx, ls),
+        isMatch, IF(caseFlag, EXACT(segs, searchFor), segs = searchFor),
+        allPos, FILTER(idx, isMatch),
+        ends, SCAN(0, allPos, LAMBDA(lastEnd, p, IF(p > lastEnd, p + ls - 1, lastEnd))),
+        nonOv, FILTER(allPos, ends = allPos + ls - 1),
+        chosen, IF(overlapFlag, allPos, nonOv),
+        result, IF(ls = 0, notFound, IFERROR(chosen, notFound)),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/string/SEARCHALL.tests.yaml
+++ b/lambdas/string/SEARCHALL.tests.yaml
@@ -1,0 +1,44 @@
+tests:
+  - name: all positions of a single character
+    args: ["KTTKBPK", "K"]
+    expected: [[1], [4], [7]]
+
+  - name: overlapping matches (default)
+    args: ["aaaa", "aa"]
+    expected: [[1], [2], [3]]
+
+  - name: non-overlapping matches consume the substring
+    args: ["aaaa", "aa", "=", "=FALSE"]
+    expected: [[1], [3]]
+
+  - name: case-sensitive match finds only exact case
+    args: ["abcABC", "abc", "=TRUE"]
+    expected: 1
+
+  - name: case-insensitive match finds both cases (default)
+    args: ["abcABC", "abc", "=FALSE"]
+    expected: [[1], [4]]
+
+  - name: case-sensitive multi-match
+    args: ["aAaA", "A", "=TRUE"]
+    expected: [[2], [4]]
+
+  - name: no match returns error by default
+    args: ["HELLO", "Z"]
+    expected: -2146826246
+
+  - name: no match returns if_not_found sentinel
+    args: ["HELLO", "Z", "=", "=", "none"]
+    expected: "none"
+
+  - name: searchFor longer than inText yields no match
+    args: ["ab", "abc"]
+    expected: -2146826246
+
+  - name: empty searchFor is guarded and returns sentinel
+    args: ["abc", "", "=", "=", "empty"]
+    expected: "empty"
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
Closes #297

## Summary

`SEARCHALL(inText, searchFor, [match_case], [overlapping], [if_not_found])` returns a spilled column of the 1-based start positions of every occurrence of `searchFor` within `inText`. Native `SEARCH`/`FIND` only ever return the *first* match; `SEARCHALL` gives the full list for tallying, windowing, or feeding downstream MAP/INDEX logic.

## Behaviour

- **match_case** — `FALSE` (default) matches case-insensitively (Excel `=`); `TRUE` uses `EXACT` for case-sensitive matching (same pattern as XV/XH).
- **overlapping** — `TRUE` (default) counts overlapping matches (`"aa"` in `"aaaa"` → `{1;2;3}`); `FALSE` greedily consumes `searchFor` after each hit for non-overlapping matches (`{1;3}`). Implemented with a `SCAN` that tracks the end position of the last accepted match and keeps a candidate only when its scanned end equals its own end.
- **if_not_found** — sentinel returned when there are no matches (default `#N/A`), baking in the `IFERROR` wrap callers otherwise need. Also used to guard an empty `searchFor` (`ls = 0`) so it doesn't produce a spurious full-length array.

## Complements CHARQ

`ROWS(SEARCHALL(...))` gives the match count, and the non-overlapping mode aligns with CHARQ's literal (non-overlapping) count.

## Tests

11 harness cases covering: single-char multi-match, overlapping vs non-overlapping, case-sensitive vs case-insensitive, no-match (error default + sentinel), `searchFor` longer than `inText`, empty-`searchFor` guard, and help text. Full harness suite passes (798 cases); format tests pass (736).

Scope note: array-of-needles lifting and `start_num` are left for a future issue per the proposal's "possible further features".