### PR TITLE
Fix help text broken by stray arrow delimiter in 7 LAMBDAs

### DIFF
--- a/.claude/skills/create-lambda/SKILL.md
+++ b/.claude/skills/create-lambda/SKILL.md
@@ -360,6 +360,7 @@ Tell the user:
 - **Carriage returns:** The Write tool on Windows may produce `\r\n`. After writing, verify with format tests. If CR errors occur, re-write the file content ensuring `\n`-only line endings.
 - **Missing trailing comma:** Every LET variable line (including `Help?` and `result`) must end with a comma.
 - **Help string alignment:** Keep the `→` and `¶` delimiters consistent. The last Help string line must NOT end with `¶" &` — it ends with just `",`.
+- **Never let the `→` (or `¶`) delimiter appear inside Help *content*.** `TEXTSPLIT(..., "→", "¶")` builds a 2-column grid, so any row carrying a stray `→` in its prose (e.g. `array → type-preserved`, `(row,col)→address`) splits into extra columns and `TEXTSPLIT` pads *every other row* with `#N/A` — the whole help table renders broken. In prose, write the arrow as `->` (ASCII) instead of `→`. If the content genuinely needs the `→` glyph (e.g. a lambda that outputs compass arrows), switch that one file's column delimiter to a character absent from all its content — `¦` works well — updating both the label separators and the `TEXTSPLIT` delimiter arg. Grep new help blocks with `→[^¶"]*→` before committing; any hit is a broken row.
 - **Parameter brackets:** ALL parameters must be `[param]`, not `param`.
 - **Tab characters:** Never use tabs. Use spaces for all indentation.
 

--- a/lambdas/loops/REDUCEUNTIL.lambda
+++ b/lambdas/loops/REDUCEUNTIL.lambda
@@ -17,7 +17,7 @@ REDUCEUNTIL = LAMBDA(
                 "DESCRIPTION:   →REDUCE that halts when stop returns TRUE. Stop is checked after each fn call. Returns whatever the user passed in (scalar / array / state-string).¶" &
                 "VERSION:       →May 04 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   seed           →(Required) Initial accumulator. Number/boolean/array → type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) → free-form text/state accumulation.¶" &
+                "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
                 "   stop           →(Optional) LAMBDA(acc, i) returning TRUE to halt. Default never stops (= REDUCEI).¶" &

--- a/lambdas/loops/REDUCEWHILE.lambda
+++ b/lambdas/loops/REDUCEWHILE.lambda
@@ -17,7 +17,7 @@ REDUCEWHILE = LAMBDA(
                 "DESCRIPTION:   →REDUCE that halts when continue returns FALSE. Continue is checked after each fn call. Returns whatever the user passed in (scalar / array / state-string).¶" &
                 "VERSION:       →May 04 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   seed           →(Required) Initial accumulator. Number/boolean/array → type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) → free-form text/state accumulation.¶" &
+                "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
                 "   continue       →(Required) LAMBDA(acc, i) returning TRUE to keep going, FALSE to halt.¶" &

--- a/lambdas/loops/SCANUNTIL.lambda
+++ b/lambdas/loops/SCANUNTIL.lambda
@@ -16,7 +16,7 @@ SCANUNTIL = LAMBDA(
                 "DESCRIPTION:   →SCAN counterpart to REDUCEUNTIL. Returns a column of intermediate accumulators (one per iteration). Same signature as REDUCEUNTIL — swap the name to switch views.¶" &
                 "VERSION:       →May 04 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   seed           →(Required) Initial accumulator. Number/boolean/array → type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) → free-form text/state accumulation.¶" &
+                "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
                 "   stop           →(Optional) LAMBDA(acc, i) returning TRUE to halt. Default never stops.¶" &

--- a/lambdas/loops/SCANWHILE.lambda
+++ b/lambdas/loops/SCANWHILE.lambda
@@ -16,7 +16,7 @@ SCANWHILE = LAMBDA(
                 "DESCRIPTION:   →SCAN counterpart to REDUCEWHILE. Returns a column of intermediate accumulators (one per iteration). Same signature as REDUCEWHILE — swap the name to switch views.¶" &
                 "VERSION:       →May 04 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   seed           →(Required) Initial accumulator. Number/boolean/array → type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) → free-form text/state accumulation.¶" &
+                "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
                 "   continue       →(Required) LAMBDA(acc, i) returning TRUE to keep going, FALSE to halt.¶" &

--- a/lambdas/maps/CELLAT.lambda
+++ b/lambdas/maps/CELLAT.lambda
@@ -10,7 +10,7 @@ CELLAT = LAMBDA(
 //  Help
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →CELLAT(row, col)¶" &
-                "DESCRIPTION:   →Builds a relative A1 address string (no $) from a row and column number. The (row,col)→address converter; inverse of ROWNUM/COLNUM. A thin, family-consistent wrapper over ADDRESS.¶" &
+                "DESCRIPTION:   →Builds a relative A1 address string (no $) from a row and column number. The (row,col)->address converter; inverse of ROWNUM/COLNUM. A thin, family-consistent wrapper over ADDRESS.¶" &
                 "VERSION:       →Jun 16 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   row            →(Required) Row number. Also accepts an array of rows — result lifts element-wise (and broadcasts against col).¶" &

--- a/lambdas/maps/DEFAULTARROWS.lambda
+++ b/lambdas/maps/DEFAULTARROWS.lambda
@@ -8,15 +8,15 @@ DEFAULTARROWS = LAMBDA(
     [ShowHelp],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →DEFAULTARROWS()¶" &
-                "DESCRIPTION:   →Returns the 8 default compass arrow characters as a vertical array, in canonical order matching DEFAULTMOVEDELTAS.¶" &
-                "VERSION:       →Apr 15 2026¶" &
-                "PARAMETERS:    →¶" &
-                "   ShowHelp       →(Optional) Pass TRUE to show this help text instead of the arrow list.¶" &
-                "EXAMPLE:       →¶" &
-                "Formula        →=DEFAULTARROWS()¶" &
-                "Result         →{↑;↓;←;→;↖;↗;↙;↘}",
-                "→", "¶"
+                "FUNCTION:      ¦DEFAULTARROWS()¶" &
+                "DESCRIPTION:   ¦Returns the 8 default compass arrow characters as a vertical array, in canonical order matching DEFAULTMOVEDELTAS.¶" &
+                "VERSION:       ¦Apr 15 2026¶" &
+                "PARAMETERS:    ¦¶" &
+                "   ShowHelp       ¦(Optional) Pass TRUE to show this help text instead of the arrow list.¶" &
+                "EXAMPLE:       ¦¶" &
+                "Formula        ¦=DEFAULTARROWS()¶" &
+                "Result         ¦{↑;↓;←;→;↖;↗;↙;↘}",
+                "¦", "¶"
                 ),
     //  Check inputs
         Help?, ISOMITTED(ShowHelp),

--- a/lambdas/maps/POSAT.lambda
+++ b/lambdas/maps/POSAT.lambda
@@ -11,7 +11,7 @@ POSAT = LAMBDA(
 //  Help
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →POSAT(row, col, [mult])¶" &
-                "DESCRIPTION:   →Builds an encoded position integer (row*mult+col) from a row and column number. The (row,col)→pos converter; inverse of ROWOF/COLOF.¶" &
+                "DESCRIPTION:   →Builds an encoded position integer (row*mult+col) from a row and column number. The (row,col)->pos converter; inverse of ROWOF/COLOF.¶" &
                 "VERSION:       →Jun 16 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   row            →(Required) Row number. Also accepts an array of rows — result lifts element-wise (and broadcasts against col).¶" &


### PR DESCRIPTION
## Problem

Reported for REDUCEUNTIL: its help text renders with multiple `#N/A` cells. Help blocks build a 2-column grid with `TEXTSPLIT(..., "→", "¶")`, where `→` (U+2192) is the **column delimiter**. `TEXTSPLIT` pads short rows with `#N/A`, so any help row carrying a *stray* `→` in its content splits into extra columns and forces `#N/A` padding across **every other row** — the whole table renders broken.

A repo-wide scan (`→[^¶"]*→`) found 7 affected LAMBDAs.

## Fixes

**Prose arrows** — literal `→` used as "maps to" in the text, swapped for `->`:
- `REDUCEUNTIL`, `REDUCEWHILE`, `SCANUNTIL`, `SCANWHILE` — the shared `seed` param line (`array → type-preserved ... state-string) → free-form ...`, two stray arrows each)
- `CELLAT` — `The (row,col)→address converter`
- `POSAT` — `The (row,col)→pos converter`

**Genuine arrow content** — `DEFAULTARROWS`:
- Its Result row legitimately outputs the `→` glyph (`{↑;↓;←;→;↖;↗;↙;↘}`), so the arrow can't just be replaced. Switched that one file's column delimiter to `¦` (absent from all its content) and updated the label separators to match.

## Prevention

Added a note to the `create-lambda` skill's "Common Mistakes to Avoid" section explaining the trap and the `→[^¶"]*→` grep to catch it before committing.

## Verification

- Re-scan for `→…→` in any help row now returns nothing.
- Full Excel harness: **800/800 pass**. Help tests only assert `expected_type: array`, so no test needed updating.