### PR TITLE
Add PIPS — decode a Unicode die face to its pip value

### DIFF
--- a/lambdas/string/PIPS.lambda
+++ b/lambdas/string/PIPS.lambda
@@ -1,0 +1,30 @@
+/*  FUNCTION NAME:      PIPS
+    DESCRIPTION:*//**Returns the pip value (1-6) of a Unicode die face.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-07-16  Claude      Initial version
+*/
+PIPS = LAMBDA(
+//  Parameter Declarations
+    [Dice],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →PIPS(Dice)¶" &
+                "DESCRIPTION:   →Returns the pip value (1-6) of a Unicode die face.¶" &
+                "VERSION:       →Jul 16 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   Dice           →(Required) A Unicode die face ⚀-⚅ (U+2680-U+2685). Also accepts a range or array of dice - result lifts element-wise. Non-dice or blanks return #N/A.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=PIPS(""⚄"")¶" &
+                "Result         →5",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(Dice),
+    //  Procedure
+        result, IFERROR(
+                    LET(v, UNICODE(Dice) - 9855,
+                        IF((v >= 1) * (v <= 6), v, NA())),
+                    NA()),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/string/PIPS.tests.yaml
+++ b/lambdas/string/PIPS.tests.yaml
@@ -1,0 +1,36 @@
+tests:
+  - name: face one
+    args: ["⚀"]
+    expected: 1
+
+  - name: face three
+    args: ["⚂"]
+    expected: 3
+
+  - name: face six
+    args: ["⚅"]
+    expected: 6
+
+  - name: non-die letter returns #N/A
+    args: ["Z"]
+    expected: -2146826246
+
+  - name: error input is caught and returns #N/A
+    args: ["=1/0"]
+    expected: -2146826246
+
+  - name: horizontal array of dice lifts
+    args: ['={"⚀","⚂","⚅"}']
+    expected: [[1, 3, 6]]
+
+  - name: vertical array of dice lifts
+    args: ['={"⚀";"⚂";"⚅"}']
+    expected: [[1], [3], [6]]
+
+  - name: mixed array guards per element
+    args: ['={"⚀","X","⚅"}']
+    expected: [[1, -2146826246, 6]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## What

`PIPS(Dice)` returns the pip value (1–6) of a Unicode die face (⚀–⚅, U+2680–U+2685):

```
=PIPS("⚄")   → 5
=PIPS(G6#)   → {1;3;6;...}   (array of pips over a spilled range of dice)
```

Core formula is `UNICODE(Dice) - 9855`, wrapped in a guard.

## Design notes

There was no Notion idea for this one — built from Tim's one-line description. Two nuances confirmed with Tim before building:

- **Array-lifting is free.** `UNICODE` and the subtraction both broadcast element-wise, so a spill range or 2D array of dice returns an array of pip values with **no dispatcher**. Locked in with horizontal, vertical, and mixed-array tests.
- **Invalid input is guarded → `#N/A`.** A bare `UNICODE(x)-9855` silently emits nonsense for non-dice (`UNICODE("A")-9855 = -9790`) and errors on blank cells. The body `IFERROR(LET(v, UNICODE(Dice)-9855, IF((v>=1)*(v<=6), v, NA())), NA())` returns `#N/A` for anything outside 1–6, plus blanks and error inputs — per-element on arrays, since `IFERROR` lifts too.

Placed in `string/` as a character-decode sibling to `CHARQ`; it has no lambda dependencies so placement is purely semantic.

## Tests

9 cases (faces 1/3/6, non-die letter → #N/A, error input → #N/A, horizontal/vertical/mixed arrays, help text). Format tests pass (752); full harness suite green (823 passed).