### PR TITLE
Add FILLLIKE - constant array shaped like an existing array

### DIFF
--- a/lambdas/array/FILLLIKE.lambda
+++ b/lambdas/array/FILLLIKE.lambda
@@ -1,0 +1,30 @@
+/*  FUNCTION NAME:      FILLLIKE
+    DESCRIPTION:*//**Constant array with the same shape as an existing array.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-07-16  Claude      Initial version
+*/
+FILLLIKE = LAMBDA(
+//  Parameter Declarations
+    [array],
+    [value],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →FILLLIKE(array, [value])¶" &
+                "DESCRIPTION:   →Constant array with the same shape as an existing array. Copies the shape, not the contents. Handy for building default MAZE inputs: FILLLIKE(map) is a uniform cost grid, FILLLIKE(map, TRUE) an all-walkable mask.¶" &
+                "VERSION:       →Jul 16 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   array         →(Required) The array whose shape to copy. Contents are ignored; only ROWS x COLUMNS matter.¶" &
+                "   value         →(Optional) The fill value - number, text, or boolean. Default 1.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=FILLLIKE({1,2;3,4})¶" &
+                "Result         →2-row x 2-col array of 1s",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(array),
+    //  Procedure
+        v, IF(ISOMITTED(value), 1, value),
+        result, EXPAND(v, ROWS(array), COLUMNS(array), v),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/FILLLIKE.tests.yaml
+++ b/lambdas/array/FILLLIKE.tests.yaml
@@ -1,0 +1,24 @@
+tests:
+  - name: 2x2 numeric grid defaults to fill of 1
+    args: ['={1,2;3,4}']
+    expected: [[1, 1], [1, 1]]
+
+  - name: text map fills with TRUE for a walkability mask
+    args: ['={"a","b","c"}', "=TRUE"]
+    expected: [[True, True, True]]
+
+  - name: vertical array with explicit zero fill
+    args: ["={1;2;3}", "=0"]
+    expected: [[0], [0], [0]]
+
+  - name: text fill value
+    args: ['={1,2;3,4}', "x"]
+    expected: [["x", "x"], ["x", "x"]]
+
+  - name: scalar input returns scalar fill
+    args: ["solo"]
+    expected: 1
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

`FILLLIKE(array, [value])` returns a constant array with the same shape (ROWS x COLUMNS) as an existing array, filled with `value` (default 1). The source array's contents are ignored — only its shape is copied.

## Motivation

Companion helper for MAZE. MAZE already defaults `Costs` to uniform 1 when `AllowMp` supplies the shape, so FILLLIKE earns its keep when the map is neither a valid cost grid nor a boolean mask (e.g. a character terrain map used only for shape):

- `=MAZE(st, FILLLIKE(mp),,,,,,, mp)` — uniform cost grid shaped like `mp`
- `FILLLIKE(mp, TRUE)` — all-walkable `AllowMp` mask from the same helper

## Design notes

- Identity is "copy the shape of an existing array", which is what EXPAND/MAKEARRAY can't do without ROWS/COLUMNS boilerplate. Scope deliberately capped at one optional fill value — patterns or per-cell logic remain MAKEARRAY's job.
- No array-lifting dispatcher: output is inherently array-shaped (generator).
- Lives in `array/` under the generic name (not maps/COSTS) so it serves non-MAZE uses; it calls no other lambda, so colocation is not a concern.

## Testing

- Format validation: 760/760 passed
- FILLLIKE harness cases: 6/6 passed (numeric default, TRUE mask, zero fill, text fill, scalar input, help)
- Full harness suite: 829/829 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)