### PR TITLE
Add ALLOCATE - sequential fill allocation across container capacities

### DIFF
--- a/lambdas/math/ALLOCATE.lambda
+++ b/lambdas/math/ALLOCATE.lambda
@@ -1,0 +1,43 @@
+/*  FUNCTION NAME:      ALLOCATE
+    DESCRIPTION:*//**Sequentially fill container capacities with a value; returns per-container allocations in the same shape.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-07-18  Claude      Initial version
+*/
+ALLOCATE = LAMBDA(
+//  Parameter Declarations
+    [value],
+    [containers],
+    [overflow],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →ALLOCATE(value, containers, [overflow])¶" &
+                "DESCRIPTION:   →Sequentially fill container capacities with a value; returns per-container allocations in the same shape.¶" &
+                "VERSION:       →Jul 18 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   value         →(Required) Total amount to allocate across the containers. Zero or negative allocates nothing.¶" &
+                "   containers    →(Required) Capacities filled in reading order (vertical, horizontal, or 2D grid). Result keeps this shape. Any negative capacity returns #NUM!.¶" &
+                "   overflow      →(Optional) When value exceeds total capacity: (0) clip - fill all, drop the remainder [default], (1) error - return #NUM! (also errors when value < 0), (2) absorb - add the excess to the last container.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=ALLOCATE(10, {3;4;5;6})¶" &
+                "Result         →{3;4;3;0}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(value),
+    //  Procedure
+        Ovf, IF(ISOMITTED(overflow), 0, overflow),
+        total, SUM(containers),
+        prior, SCAN(0, containers, SUM) - containers,
+        avail, value - prior,
+        filled, IF(avail <= 0, 0, IF(avail >= containers, containers, avail)),
+        nRows, ROWS(containers),
+        nCols, COLUMNS(containers),
+        posGrid, (SEQUENCE(nRows) - 1) * nCols + SEQUENCE(1, nCols),
+        excess, MAX(0, value - total),
+        result, IF(OR(containers < 0), SQRT(-1),
+                IF(AND(Ovf = 1, OR(value > total, value < 0)), SQRT(-1),
+                IF(Ovf = 2, filled + IF(posGrid = nRows * nCols, excess, 0),
+                filled))),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/math/ALLOCATE.tests.yaml
+++ b/lambdas/math/ALLOCATE.tests.yaml
@@ -1,0 +1,68 @@
+tests:
+  - name: happy path vertical
+    args: ["=10", "={3;4;5;6}"]
+    expected: [[3], [4], [3], [0]]
+
+  - name: horizontal orientation preserved
+    args: ["=10", "={3,4,5,6}"]
+    expected: [[3, 4, 3, 0]]
+
+  - name: exact fill on first container
+    args: ["=3", "={3;4;5}"]
+    expected: [[3], [0], [0]]
+
+  - name: exact fill of total capacity
+    args: ["=18", "={3;4;5;6}"]
+    expected: [[3], [4], [5], [6]]
+
+  - name: partial fill lands in last container
+    args: ["=17", "={3;4;5;6}"]
+    expected: [[3], [4], [5], [5]]
+
+  - name: fractional value
+    args: ["=7.5", "={3;4;5}"]
+    expected: [[3], [4], [0.5]]
+
+  - name: zero value allocates nothing
+    args: ["=0", "={3;4;5}"]
+    expected: [[0], [0], [0]]
+
+  - name: negative value clips to zeros
+    args: ["=-5", "={3;4;5}"]
+    expected: [[0], [0], [0]]
+
+  - name: overflow default clips at capacity
+    args: ["=100", "={3;4;5;6}"]
+    expected: [[3], [4], [5], [6]]
+
+  - name: overflow mode 1 errors when value exceeds capacity
+    args: ["=100", "={3;4;5;6}", "=1"]
+    expected: -2146826252
+
+  - name: overflow mode 1 errors on negative value
+    args: ["=-1", "={3;4;5}", "=1"]
+    expected: -2146826252
+
+  - name: overflow mode 2 absorbs excess into last container
+    args: ["=20", "={3;4;5;6}", "=2"]
+    expected: [[3], [4], [5], [8]]
+
+  - name: zero-capacity container mid-sequence
+    args: ["=5", "={3;0;5}"]
+    expected: [[3], [0], [2]]
+
+  - name: negative capacity returns NUM error
+    args: ["=5", "={3;-1;5}"]
+    expected: -2146826252
+
+  - name: 2D grid fills in reading order
+    args: ["=7", "={1,2;3,4}"]
+    expected: [[1, 2], [3, 1]]
+
+  - name: single container partial fill
+    args: ["=2", "={5}"]
+    expected: 2
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

New `ALLOCATE(value, containers, [overflow])` in `lambdas/math/` - sequentially fills container capacities with a value and returns per-container allocations in the same shape as the input.

## Design

Replaces the XMATCH-locate + TAKE/VSTACK/EXPAND splice approach with an array-native clamp:

```
prior  = SCAN(0, containers, SUM) - containers
result = clamp(value - prior, 0, containers)   // as nested IFs
```

This removes every boundary edge case by construction: exact fill on first/last container, value = 0, negative value, overflow, and orientation all fall out of the uniform clamp. Works on vertical, horizontal, and 2D grid inputs (SCAN fills in reading order; result keeps the input shape).

- `overflow` enum: (0) clip - fill all, drop remainder [default], (1) error - #NUM! when value > total or value < 0, (2) absorb - excess added to the last container so SUM(result) = value.
- Any negative capacity returns #NUM!.
- No array-lift dispatcher: output is inherently array-shaped (matches containers).

## Testing

- Format validation: 768/768 passed
- ALLOCATE harness (17 cases): all passed - both orientations, boundary fills, fractional value, zero/negative value, all three overflow modes, zero-capacity mid-sequence, negative capacity, 2D grid, help text
- Full harness suite: 867/867 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)