### PR TITLE
TLOOKUP: whole-column mode + default lookup column

### DIFF
--- a/lambdas/lookup/TLOOKUP.lambda
+++ b/lambdas/lookup/TLOOKUP.lambda
@@ -3,6 +3,7 @@
 /*  REVISIONS:          Date        Developer   Description
                         2026-05-07  Claude      Initial version
                         2026-05-14  Claude      Array-lift on Item via dispatcher: MAP over multi-item input, otherwise scalar body unchanged
+                        2026-07-18  Claude      Item now optional (omitted returns whole data column under HeaderName); LookupCol now optional (defaults to first table column)
 */
 TLOOKUP = LAMBDA(
 //  Parameter Declarations
@@ -13,13 +14,13 @@ TLOOKUP = LAMBDA(
     [If_not_found],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →TLOOKUP(Table, Item, LookupCol, HeaderName, [If_not_found])¶" &
+                "FUNCTION:      →TLOOKUP(Table, [Item], [LookupCol], HeaderName, [If_not_found])¶" &
                 "DESCRIPTION:   →Looks up a value from a header-row table by matching a row key in one column and returning the value under a named header.¶" &
-                "VERSION:       →May 14 2026¶" &
+                "VERSION:       →Jul 18 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   Table          →(Required) Full table including its header row (e.g. tblData[#All]).¶" &
-                "   Item           →(Required) Value to find in LookupCol to identify the row. Also accepts an array of items — result lifts element-wise.¶" &
-                "   LookupCol      →(Required) Column to search for Item (e.g. tblData[Person]). Excluding headers.¶" &
+                "   Item           →(Optional) Value to find in LookupCol to identify the row. Also accepts an array of items - result lifts element-wise. If omitted, returns the entire data column under HeaderName (header row excluded).¶" &
+                "   LookupCol      →(Optional) Column to search for Item (e.g. tblData[Person]). Excluding headers. Defaults to the first column of Table.¶" &
                 "   HeaderName     →(Required) Header text identifying the column whose value should be returned.¶" &
                 "   If_not_found   →(Optional) Value to return when Item or HeaderName is not found. Defaults to #N/A.¶" &
                 "EXAMPLE:       →¶" &
@@ -31,18 +32,23 @@ TLOOKUP = LAMBDA(
         Help?, ISOMITTED(Table),
     //  Procedure
         notFound, IF(ISOMITTED(If_not_found), NA(), If_not_found),
+        lookCol, IF(ISOMITTED(LookupCol), DROP(TAKE(Table, , 1), 1), LookupCol),
+        colIdx, MATCH(HeaderName, INDEX(Table, 1, ), 0),
+        wholeCol, IFERROR(DROP(INDEX(Table, , colIdx), 1), notFound),
         scalar, LAMBDA(it,
                   IFERROR(
                     INDEX(
                         Table,
-                        MATCH(it, LookupCol, 0) + 1,
-                        MATCH(HeaderName, INDEX(Table, 1, ), 0)
+                        MATCH(it, lookCol, 0) + 1,
+                        colIdx
                     ),
                     notFound
                   )),
-        result, IF(OR(ROWS(Item) > 1, COLUMNS(Item) > 1),
-                    MAP(Item, scalar),
-                    scalar(Item)),
+        result, IF(ISOMITTED(Item),
+                    wholeCol,
+                    IF(OR(ROWS(Item) > 1, COLUMNS(Item) > 1),
+                        MAP(Item, scalar),
+                        scalar(Item))),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/lookup/TLOOKUP.lambda
+++ b/lambdas/lookup/TLOOKUP.lambda
@@ -4,6 +4,7 @@
                         2026-05-07  Claude      Initial version
                         2026-05-14  Claude      Array-lift on Item via dispatcher: MAP over multi-item input, otherwise scalar body unchanged
                         2026-07-18  Claude      Item now optional (omitted returns whole data column under HeaderName); LookupCol now optional (defaults to first table column)
+                        2026-07-18  Claude      Row mode: omitted HeaderName returns the matched row's other columns; works with or without a header row; array Items stack rows
 */
 TLOOKUP = LAMBDA(
 //  Parameter Declarations
@@ -14,14 +15,14 @@ TLOOKUP = LAMBDA(
     [If_not_found],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →TLOOKUP(Table, [Item], [LookupCol], HeaderName, [If_not_found])¶" &
+                "FUNCTION:      →TLOOKUP(Table, [Item], [LookupCol], [HeaderName], [If_not_found])¶" &
                 "DESCRIPTION:   →Looks up a value from a header-row table by matching a row key in one column and returning the value under a named header.¶" &
                 "VERSION:       →Jul 18 2026¶" &
                 "PARAMETERS:    →¶" &
-                "   Table          →(Required) Full table including its header row (e.g. tblData[#All]).¶" &
-                "   Item           →(Optional) Value to find in LookupCol to identify the row. Also accepts an array of items - result lifts element-wise. If omitted, returns the entire data column under HeaderName (header row excluded).¶" &
+                "   Table          →(Required) Full table including its header row (e.g. tblData[#All]). Row mode (HeaderName omitted) also accepts a data-only table (e.g. tblData).¶" &
+                "   Item           →(Optional) Value to find in LookupCol to identify the row. Also accepts an array of items - result lifts element-wise (row mode stacks one row per item). If omitted, returns the entire data column under HeaderName (header row excluded).¶" &
                 "   LookupCol      →(Optional) Column to search for Item (e.g. tblData[Person]). Excluding headers. Defaults to the first column of Table.¶" &
-                "   HeaderName     →(Required) Header text identifying the column whose value should be returned.¶" &
+                "   HeaderName     →(Optional) Header text identifying the column whose value should be returned. If omitted (row mode), returns the matched row; when LookupCol is also omitted the first (key) column is dropped from the result. Note: in row mode an Item equal to the header text matches the header row - pass a data-only Table if keys could collide with headers.¶" &
                 "   If_not_found   →(Optional) Value to return when Item or HeaderName is not found. Defaults to #N/A.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=TLOOKUP(tblData[#All], ""Tim"", tblData[Person], ""Age"")¶" &
@@ -44,11 +45,28 @@ TLOOKUP = LAMBDA(
                     ),
                     notFound
                   )),
-        result, IF(ISOMITTED(Item),
-                    wholeCol,
-                    IF(OR(ROWS(Item) > 1, COLUMNS(Item) > 1),
-                        MAP(Item, scalar),
-                        scalar(Item))),
+    //  Row mode: HeaderName omitted - match Item against the lookup column and return the whole row.
+    //  With LookupCol omitted, match spans the full first column (a header row simply never matches),
+    //  so headered and header-less tables both work; the key column is dropped from the result.
+    //  With LookupCol given (data-only by convention), the row-count difference vs Table supplies the offset.
+        keyDropped?, ISOMITTED(LookupCol),
+        fullLook, IF(ISOMITTED(LookupCol), TAKE(Table, , 1), LookupCol),
+        rowOffset, ROWS(Table) - ROWS(fullLook),
+        rowWidth, COLUMNS(Table) - IF(keyDropped?, 1, 0),
+        rowFor, LAMBDA(it,
+                  LET(fullRow, INDEX(Table, MATCH(it, fullLook, 0) + rowOffset, ),
+                      IF(keyDropped?, DROP(fullRow, , 1), fullRow))),
+        rowResult, IF(OR(ROWS(Item) > 1, COLUMNS(Item) > 1),
+                      DROP(REDUCE(0, Item, LAMBDA(acc, it,
+                          VSTACK(acc, IFERROR(rowFor(it), EXPAND(notFound, 1, rowWidth, notFound))))), 1),
+                      IFERROR(rowFor(Item), notFound)),
+        result, IF(AND(ISOMITTED(HeaderName), NOT(ISOMITTED(Item))),
+                    rowResult,
+                    IF(ISOMITTED(Item),
+                        wholeCol,
+                        IF(OR(ROWS(Item) > 1, COLUMNS(Item) > 1),
+                            MAP(Item, scalar),
+                            scalar(Item)))),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/lookup/TLOOKUP.tests.yaml
+++ b/lambdas/lookup/TLOOKUP.tests.yaml
@@ -218,6 +218,106 @@ tests:
     args: ["=tblAll", "=", "=", "Salary", "none"]
     expected: "none"
 
+  - name: row mode with headered table drops key column
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", "Tim"]
+    expected: [[42, "Sydney"]]
+
+  - name: row mode with header-less table drops key column
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblData", refers_to: "C4:E6" }
+    args: ["=tblData", "Sam"]
+    expected: [[30, "Melbourne"]]
+
+  - name: row mode with explicit LookupCol returns whole row (headered table)
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+        - { name: "tblPerson", refers_to: "C4:C6" }
+    args: ["=tblAll", "Sam", "=tblPerson"]
+    expected: [["Sam", 30, "Melbourne"]]
+
+  - name: row mode with explicit LookupCol returns whole row (header-less table)
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblData", refers_to: "C4:E6" }
+        - { name: "tblPerson", refers_to: "C4:C6" }
+    args: ["=tblData", "Alex", "=tblPerson"]
+    expected: [["Alex", 25, "Perth"]]
+
+  - name: row mode with array of items stacks rows
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", '={"Tim";"Alex"}']
+    expected: [[42, "Sydney"], [25, "Perth"]]
+
+  - name: row mode item not found returns NA by default
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", "Jordan"]
+    expected: -2146826246
+
+  - name: row mode array with missing item fills its row with fallback
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", '={"Tim";"Jordan"}', "=", "=", "missing"]
+    expected: [[42, "Sydney"], ["missing", "missing"]]
+
   - name: help text
     args: []
     expected_type: array

--- a/lambdas/lookup/TLOOKUP.tests.yaml
+++ b/lambdas/lookup/TLOOKUP.tests.yaml
@@ -134,6 +134,90 @@ tests:
     args: ["=tblAll", '={"Tim";"Jordan";"Alex"}', "=tblPerson", "Age", "=-1"]
     expected: [[42], [-1], [25]]
 
+  - name: omitted LookupCol defaults to first table column
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", "Tim", "=", "Age"]
+    expected: 42
+
+  - name: omitted LookupCol with array of items lifts
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", '={"Tim";"Alex"}', "=", "Age"]
+    expected: [[42], [25]]
+
+  - name: omitted Item returns whole numeric column under header
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", "=", "=", "Age"]
+    expected: [[42], [30], [25]]
+
+  - name: omitted Item returns whole string column under header
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", "=", "=", "City"]
+    expected: [["Sydney"], ["Melbourne"], ["Perth"]]
+
+  - name: whole column mode with header not found returns NA by default
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", "=", "=", "Salary"]
+    expected: -2146826246
+
+  - name: whole column mode with header not found uses fallback
+    setup:
+      cells:
+        - address: "C3:E6"
+          values:
+            - ["Person", "Age", "City"]
+            - ["Tim", 42, "Sydney"]
+            - ["Sam", 30, "Melbourne"]
+            - ["Alex", 25, "Perth"]
+      names:
+        - { name: "tblAll", refers_to: "C3:E6" }
+    args: ["=tblAll", "=", "=", "Salary", "none"]
+    expected: "none"
+
   - name: help text
     args: []
     expected_type: array


### PR DESCRIPTION
## Summary

Three backward-compatible enhancements to TLOOKUP:

- **Whole-column mode.** `Item` is now optional. When omitted, TLOOKUP returns the entire data column under `HeaderName` (header row excluded) - the equivalent of `XLOOKUP(colName, t[#Headers], t)`. E.g. `=TLOOKUP(tblData[#All], , , "Age")` spills the whole Age column.
- **Default lookup column.** `LookupCol` is now optional. When omitted, it defaults to the first column of `Table` (minus the header row), so `=TLOOKUP(tblData[#All], "Tim", , "Age")` looks Tim up in the first column.
- **Row mode.** `HeaderName` is now optional. `=TLOOKUP(t, "Tim")` returns all other columns of Tim's row. With `LookupCol` omitted, Item is matched against the full first column with no offset, so a header row never matches - both `t[#All]` and plain data-only `t` work, and the key column is dropped from the result. With an explicit `LookupCol`, the row-count difference vs `Table` supplies the offset and the whole row is returned. An array of Items stacks one row per item; missing items fill their row with `If_not_found`.

Parameter order is unchanged and all existing calls behave identically. Known edge (documented in help): in row mode, an Item equal to the header text matches the header row - pass a data-only Table if keys could collide with headers.

## Testing

- Format validation: 768 passed
- Full AddIn harness suite: 880 passed, 0 failed
- The 9 pre-existing TLOOKUP cases pass unmodified (backward compatibility); 13 new cases cover the default lookup column (scalar + array-lift), whole-column mode (numeric/string columns, header-not-found), and row mode (headered + header-less tables, default + explicit LookupCol, stacked rows, not-found handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)