### PR TITLE
MAZE: fix step counter inflation from frontier row index

### DIFF
--- a/lambdas/maps/MAZE.lambda
+++ b/lambdas/maps/MAZE.lambda
@@ -8,6 +8,7 @@
                         2026-07-01  Claude      Add origin parameter (workbook reference; top-left used) so an in-memory map can be anchored to a worksheet position — the coordinate frame (rowArr/colArr, offsets) derives from origin, so st/Targets addresses and the distance grid map into the anchored frame. Matches SUBGRID/GRIDLOOKUP/GRIDAREA convention; replaces the old noRowCol (1,1)-fallback.
                         2026-07-10  Claude      Remove mp parameter — its values were never used, only its shape and position. st is promoted to first (the only always-required argument); grid shape now derives from Costs, else AllowMp, and the default anchor from the first of those that is a workbook reference (origin still overrides). Uniform-cost default switched from mp-mp+1 to SEQUENCE, fixing silently-unreachable text cells. New order: st, Costs, AllowMp, Targets, No_Diag, Show_Steps, Cus_Dir, Mazelam, origin (#299)
                         2026-07-18  Claude      Show_Steps promoted to numeric enum: (0) cumulative cost [default], (1) step counter (TRUE still accepted), (2) path — back-walks the pool's dirDelta predecessor pointers from a single target to return the shortest path as an Nx1 column of A1 addresses
+                        2026-07-18  Claude      Fix step counter inflation: the frontier-rows SEQUENCE omitted its step argument, so each proposal's step number gained the source cell's index within the sorted frontier. Now a true zero column — stepNum is uniformly iter+1, i.e. the number of moves on the path
 */
 MAZE = LAMBDA(
 //  Parameter Declarations
@@ -74,7 +75,7 @@ MAZE = LAMBDA(
                 toCol, MOD(toPos, M) - colOffset,
                 costFrom, INDEX(costGrid, fromRow, fromCol),
                 costTo, INDEX(costGrid, toRow, toCol),
-                stepNum, TOCOL(SEQUENCE(ROWS(frontier), , 0) + SEQUENCE(, COUNTA(moveSet), iter + 1, 0)),
+                stepNum, TOCOL(SEQUENCE(ROWS(frontier), , 0, 0) + SEQUENCE(, COUNTA(moveSet), iter + 1, 0)),
                 distFrom, TOCOL(frontDist + SEQUENCE(, COUNTA(moveSet), 0, 0)),
                 dirDelta, TOCOL(moveSet + SEQUENCE(COUNTA(frontPos), , 0, 0)),
                 prevDir, TOCOL(frontPrev + SEQUENCE(, COUNTA(moveSet), 0, 0)),

--- a/lambdas/maps/MAZE.tests.yaml
+++ b/lambdas/maps/MAZE.tests.yaml
@@ -51,7 +51,7 @@ tests:
     args: ['="C3"', "=costRng", "=", '="E5"', "=FALSE"]
     expected: 4
 
-  - name: Show_Steps returns the body's step counter for the path to a target
+  - name: Show_Steps returns the number of moves on the path to a target
     setup:
       cells:
         - address: "C3:E5"
@@ -62,7 +62,7 @@ tests:
       names:
         - { name: "costRng", refers_to: "C3:E5" }
     args: ['="C3"', "=costRng", "=", '="E5"', "=FALSE", "=TRUE"]
-    expected: 4
+    expected: 2
 
   - name: custom Mazelam — inline LAMBDA, diagonals cost 1.5x (default uniform Costs)
     setup:
@@ -166,7 +166,7 @@ tests:
 
   - name: Show_Steps numeric 1 matches the TRUE step-counter output
     args: ['="A1"', "={2,2,2;2,2,2;2,2,2}", "=", '="C3"', "=FALSE", "=1"]
-    expected: 4
+    expected: 2
 
   - name: st supplied but neither Costs nor AllowMp returns help text
     args: ['="C3"']


### PR DESCRIPTION
## Summary

Fixes a bug in the `Show_Steps` step counter: `SEQUENCE(ROWS(frontier), , 0)` in the `stepNum` computation omitted its step argument, producing 0,1,2,... down the sorted frontier instead of a column of zeros. Every proposal's step number was therefore `iter + 1 + frontierRowIndex` — inflated by where the source cell happened to sit in the frontier. Any cell not expanded from frontier row 0 reported too many steps: the 8-way diagonal C3->E5, genuinely 2 moves, reported 4 (and the old test pinned that wrong value).

## Fix

One character of substance: `SEQUENCE(ROWS(frontier), , 0, 0)` — an explicit zero step, so `stepNum` is uniformly `iter + 1`, the true number of moves on the path. Cost output, path selection, and dedup are untouched (they read pool columns 1–2 only).

The two step-counter tests now assert real move counts (4 -> 2). Path mode (`Show_Steps = 2`) never depended on stepNum exactness — the back-walk guards on the seed's zero `dirDelta` — and all 9 of its tests pass unchanged.

## Stacking

⚠️ Based on `lambda-maze-path-mode` (#309), because one of the corrected tests lives on that branch. Merge #309 first; this PR should then retarget to `main` cleanly.

## Tests

- Format validation: 768 passed
- Full AddinTests harness: 889 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)