### PR TITLE
Add UNTILE - extract items from repeated key-shaped map sections into a tidy table

### DIFF
--- a/lambdas/maps/UNTILE.lambda
+++ b/lambdas/maps/UNTILE.lambda
@@ -1,0 +1,75 @@
+/*  FUNCTION NAME:      UNTILE
+    DESCRIPTION:*//**Extracts items from repeated key-shaped sections of a tiled map into a flat Section/Item/Value table.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-07-20  Claude      Initial version
+*/
+UNTILE = LAMBDA(
+//  Parameter Declarations
+    [map],
+    [key],
+    [items],
+    [section_names],
+    [h_buffer],
+    [v_buffer],
+    [headers],
+    [if_invalid],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →UNTILE(map, key, items, [section_names], [h_buffer], [v_buffer], [headers], [if_invalid])¶" &
+                "DESCRIPTION:   →Extracts items from repeated key-shaped sections of a tiled map into a flat Section/Item/Value table. Returns #VALUE! when the map does not tile cleanly with the key size and buffers.¶" &
+                "VERSION:       →Jul 20 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   map           →(Required) The tiled grid: identical key-shaped sections repeated left-to-right, top-to-bottom (range or array).¶" &
+                "   key           →(Required) One section template whose cells hold item labels at the positions to read. Its size defines the section size; the section grid dimensions are derived from it.¶" &
+                "   items         →(Required) Item labels to extract, matched against the key (row or column). Duplicate labels in the key resolve to the first match.¶" &
+                "   section_names →(Optional) One name per section, left-to-right then top-to-bottom (row or column). Fewer names than sections reads only the first N sections (partial last row); more names than sections returns #VALUE!. Omitted -> sections numbered 1..N.¶" &
+                "   h_buffer      →(Optional) Blank columns between horizontally adjacent sections. Default 0.¶" &
+                "   v_buffer      →(Optional) Blank rows between vertically adjacent sections. Default 0.¶" &
+                "   headers       →(Optional) TRUE prepends the default header row {Section, Item, Value}; or pass a 3-element array of custom column names. Default FALSE.¶" &
+                "   if_invalid    →(Optional) Value placed in the Value column when an item is not found in the key. Default NA().¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=UNTILE({1,2,3,4}, {""x"",""y""}, {""x"",""y""})¶" &
+                "Result         →4x3 table: rows (1,x,1) (1,y,2) (2,x,3) (2,y,4)",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(map),
+        hBuf, IF(ISOMITTED(h_buffer), 0, h_buffer),
+        vBuf, IF(ISOMITTED(v_buffer), 0, v_buffer),
+        invalid, IF(ISOMITTED(if_invalid), NA(), if_invalid),
+    //  Procedure
+        theMult, 100000,
+        mapRows, ROWS(map),
+        mapCols, COLUMNS(map),
+        keyRows, ROWS(key),
+        keyCols, COLUMNS(key),
+        gridRows, (mapRows + vBuf) / (keyRows + vBuf),
+        gridCols, (mapCols + hBuf) / (keyCols + hBuf),
+        geomOK, AND(gridRows = INT(gridRows), gridCols = INT(gridCols), gridRows >= 1, gridCols >= 1),
+        allSec, gridRows * gridCols,
+        secNames, IF(ISOMITTED(section_names), SEQUENCE(allSec), TOCOL(section_names)),
+        nSec, ROWS(secNames),
+        itemsRow, TOROW(items),
+        nItems, COLUMNS(itemsRow),
+        matchPos, XMATCH(itemsRow, TOCOL(key)),
+        itemRel, INT((matchPos - 1) / keyCols) * theMult + MOD(matchPos - 1, keyCols),
+        baseRow, IFERROR(MIN(ROW(map)), 1),
+        baseCol, IFERROR(MIN(COLUMN(map)), 1),
+        mapOrigin, baseRow * theMult + baseCol,
+        secPos, TOCOL(SEQUENCE(gridRows, 1, 0, keyRows + vBuf) * theMult + SEQUENCE(1, gridCols, 0, keyCols + hBuf)),
+        secUsed, TAKE(secPos, nSec) + mapOrigin,
+        posGrid, secUsed + itemRel,
+        vals, GRIDLOOKUP(map, posGrid, TRUE, , invalid),
+        idx, SEQUENCE(nSec * nItems, 1, 0),
+        secCol, CHOOSEROWS(secNames, INT(idx / nItems) + 1),
+        itemCol, INDEX(itemsRow, 1, MOD(idx, nItems) + 1),
+        valCol, TOCOL(vals),
+        body, HSTACK(secCol, itemCol, valCol),
+        hdrCount, IF(ISOMITTED(headers), 0, ROWS(headers) * COLUMNS(headers)),
+        header?, IF(ISOMITTED(headers), FALSE, IF(hdrCount > 1, TRUE, N(headers))),
+        headerRow, IF(hdrCount > 1, TOROW(headers), HSTACK("Section", "Item", "Value")),
+        table, IF(header?, VSTACK(headerRow, body), body),
+        result, IF(OR(NOT(geomOK), nSec > allSec), VALUE("!"), table),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/UNTILE.tests.yaml
+++ b/lambdas/maps/UNTILE.tests.yaml
@@ -1,0 +1,68 @@
+tests:
+  - name: two side-by-side sections, no buffers, default section numbers
+    args: ['={1,2,3,4}', '={"x","y"}', '={"x","y"}']
+    expected: [[1, "x", 1], [1, "y", 2], [2, "x", 3], [2, "y", 4]]
+
+  - name: vertical stack with v_buffer gap row
+    args: ['={10,0;0,20;99,99;30,0;0,40}', '={"a","";"","b"}', '={"a","b"}', "=", "=", "=1"]
+    expected: [[1, "a", 10], [1, "b", 20], [2, "a", 30], [2, "b", 40]]
+
+  - name: section names with default headers
+    args: ['={1,2,3,4}', '={"x","y"}', '={"x","y"}', '={"N","S"}', "=", "=", "=TRUE"]
+    expected: [["Section", "Item", "Value"], ["N", "x", 1], ["N", "y", 2], ["S", "x", 3], ["S", "y", 4]]
+
+  - name: custom header row
+    args: ['={1,2,3,4}', '={"x","y"}', '={"x","y"}', "=", "=", "=", '={"Sec","It","Val"}']
+    expected: [["Sec", "It", "Val"], [1, "x", 1], [1, "y", 2], [2, "x", 3], [2, "y", 4]]
+
+  - name: fewer names than sections reads only the first N sections
+    args: ['={1,2,3,4,5,6}', '={"x","y"}', '={"x","y"}', '={"A","B"}']
+    expected: [["A", "x", 1], ["A", "y", 2], ["B", "x", 3], ["B", "y", 4]]
+
+  - name: items as column, order preserved
+    args: ['={1,2,3,4}', '={"x","y"}', '={"y";"x"}']
+    expected: [[1, "y", 2], [1, "x", 1], [2, "y", 4], [2, "x", 3]]
+
+  - name: single section, single item
+    args: ['={5,6}', '={"x","y"}', "x"]
+    expected: [[1, "x", 5]]
+
+  - name: geometry misfit returns VALUE error
+    args: ['={1,2,3,4,5}', '={"x","y"}', '={"x","y"}']
+    expected: -2146826273
+
+  - name: more names than sections returns VALUE error
+    args: ['={1,2,3,4}', '={"x","y"}', '={"x","y"}', '={"A","B","C"}']
+    expected: -2146826273
+
+  - name: item missing from key defaults to NA in value cells
+    args: ['={1,2,3,4}', '={"x","y"}', '={"x","z"}']
+    expected: [[1, "x", 1], [1, "z", -2146826246], [2, "x", 3], [2, "z", -2146826246]]
+
+  - name: item missing from key uses if_invalid
+    args: ['={1,2,3,4}', '={"x","y"}', '={"x","z"}', "=", "=", "=", "=", "?"]
+    expected: [[1, "x", 1], [1, "z", "?"], [2, "x", 3], [2, "z", "?"]]
+
+  - name: real ranges with both buffers via setup
+    setup:
+      cells:
+        - address: "F3:J7"
+          values:
+            - ["A1s", "", "", "A2s", ""]
+            - ["", 10, "", "", 20]
+            - ["", "", "", "", ""]
+            - ["B1s", "", "", "B2s", ""]
+            - ["", 30, "", "", 40]
+        - address: "L3:M4"
+          values:
+            - ["name", ""]
+            - ["", "score"]
+      names:
+        - { name: "mapRng", refers_to: "F3:J7" }
+        - { name: "keyRng", refers_to: "L3:M4" }
+    args: ["=mapRng", "=keyRng", '={"name","score"}', '={"NW","NE","SW","SE"}', "=1", "=1"]
+    expected: [["NW", "name", "A1s"], ["NW", "score", 10], ["NE", "name", "A2s"], ["NE", "score", 20], ["SW", "name", "B1s"], ["SW", "score", 30], ["SE", "name", "B2s"], ["SE", "score", 40]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

New `maps/UNTILE` lambda: takes a map tiled with identical sections, a key template marking where each item lives within a section, and a list of items to extract - returns a flat Section/Item/Value table.

Signature: `UNTILE(map, key, items, [section_names], [h_buffer], [v_buffer], [headers], [if_invalid])`

## Design decisions (from brainstorm with Tim)

- **Section grid derived, not declared.** The key *is* one section, so rows/cols of the section grid are computed from map size, key size, and the optional buffers (default 0). A map that doesn't tile cleanly returns `#VALUE!` instead of silently reading wrong offsets.
- **Partial grids.** Fewer `section_names` than derived sections reads only the first N (handles a partial last row); more names than sections is `#VALUE!`. Omitted names default to 1..N.
- **Headers** mirror UNPIVOT's `resultHeaders` convention: default FALSE, TRUE = `{Section, Item, Value}`, or a custom 3-element array.
- **Missing items** degrade per-cell to `NA()` (or `if_invalid`), matching GRIDLOOKUP's convention.
- **Colocation:** lives in `maps/` with GRIDLOOKUP; the unpivot step is inlined (~5 lines) rather than calling `array/UNPIVOT` cross-library. Item positions use direct XMATCH arithmetic instead of a CELLTOPOS address-string round-trip.

## Testing

- 13 harness cases: buffers (h and v), default/custom headers, partial grid, item orientation, geometry misfit, missing items with and without `if_invalid`, real ranges via `setup:` named ranges, help text.
- Format tests: 784/784. Full harness suite: 904/904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)