### PR TITLE
Loop conditions receive the current element: LAMBDA(acc, current, i)

### DIFF
--- a/lambdas/loops/REDUCEUNTIL.lambda
+++ b/lambdas/loops/REDUCEUNTIL.lambda
@@ -1,9 +1,10 @@
 /*  FUNCTION NAME:      REDUCEUNTIL
-    DESCRIPTION:*//**REDUCE that halts when stop returns TRUE. Stop is checked after each fn call. fn signature: LAMBDA(acc, current, i). stop signature: LAMBDA(acc, i). Returns whatever the user passed in: a scalar stays a scalar, a state-string stays a state-string.*/
+    DESCRIPTION:*//**REDUCE that halts when stop returns TRUE. Stop is checked after each fn call. fn and stop share one signature: LAMBDA(acc, current, i). Returns whatever the user passed in: a scalar stays a scalar, a state-string stays a state-string.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-05-02  Claude      Initial version
                         2026-05-03  Claude      Accept horizontal or vertical cases (TOCOL up front)
                         2026-05-04  Claude      User accumulator preserved by type — scalar/array seeds wrapped in private slot, text seeds passed through. BREAK/INDEX live in a separate Meta state, FS-separated from the user portion. fn / stop see the unwrapped accumulator directly.
+                        2026-07-20  Claude      stop now receives the current element: LAMBDA(acc, current, i), matching fn's signature.
 */
 REDUCEUNTIL = LAMBDA(
 //  Parameter Declarations
@@ -15,14 +16,14 @@ REDUCEUNTIL = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →REDUCEUNTIL(seed, cases, fn, [stop])¶" &
                 "DESCRIPTION:   →REDUCE that halts when stop returns TRUE. Stop is checked after each fn call. Returns whatever the user passed in (scalar / array / state-string).¶" &
-                "VERSION:       →May 04 2026¶" &
+                "VERSION:       →Jul 20 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
-                "   stop           →(Optional) LAMBDA(acc, i) returning TRUE to halt. Default never stops (= REDUCEI).¶" &
+                "   stop           →(Optional) LAMBDA(acc, current, i) returning TRUE to halt — same signature as fn. acc is the post-fn accumulator; current is the element just consumed. Default never stops (= REDUCEI).¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=REDUCEUNTIL(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, i, a > 20))¶" &
+                "Formula        →=REDUCEUNTIL(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, a > 20))¶" &
                 "Result         →28 (number — stops on iter 5 once sum exceeds 20)¶" &
                 "NOTE:          →Excel REDUCE has no real short-circuit; all cases are visited. Once stop fires, BREAK is set internally and subsequent iterations pass the accumulator through unchanged. If you seed with a non-text value, fn must keep returning the same kind of value — to switch into state-building, seed with """" or NewState().",
                 "→", "¶"
@@ -33,7 +34,7 @@ REDUCEUNTIL = LAMBDA(
         us, CHAR(31),
         rs, CHAR(30),
         fs, CHAR(28),
-        realStop, IF(ISOMITTED(stop), LAMBDA(a, i, FALSE), stop),
+        realStop, IF(ISOMITTED(stop), LAMBDA(a, v, i, FALSE), stop),
         flat, TOCOL(cases),
         wrap?, NOT(ISTEXT(@seed)),
         initialMeta, SetVar(NewState(), "INDEX", 0),
@@ -50,7 +51,7 @@ REDUCEUNTIL = LAMBDA(
                                iter, GetVar(metaPart, "INDEX") + 1,
                                acc, IF(wrap?, GetVar(userPart, "v"), userPart),
                                newAcc, fn(acc, current, iter),
-                               stopped?, realStop(newAcc, iter),
+                               stopped?, realStop(newAcc, current, iter),
                                newUser, IF(wrap?, SetVar(userPart, "v", newAcc), newAcc),
                                meta1, SetVar(metaPart, "INDEX", iter),
                                newMeta, IF(stopped?, SetVar(meta1, "BREAK", TRUE), meta1),

--- a/lambdas/loops/REDUCEUNTIL.lambda
+++ b/lambdas/loops/REDUCEUNTIL.lambda
@@ -1,10 +1,11 @@
 /*  FUNCTION NAME:      REDUCEUNTIL
-    DESCRIPTION:*//**REDUCE that halts when stop returns TRUE. Stop is checked after each fn call. fn and stop share one signature: LAMBDA(acc, current, i). Returns whatever the user passed in: a scalar stays a scalar, a state-string stays a state-string.*/
+    DESCRIPTION:*//**REDUCE that halts when stop returns TRUE. Stop is a pre-check: evaluated before each fn call with the pre-step accumulator and the incoming element, so the element that triggers it is never consumed. fn and stop share one signature: LAMBDA(acc, current, i). Returns whatever the user passed in: a scalar stays a scalar, a state-string stays a state-string.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-05-02  Claude      Initial version
                         2026-05-03  Claude      Accept horizontal or vertical cases (TOCOL up front)
                         2026-05-04  Claude      User accumulator preserved by type — scalar/array seeds wrapped in private slot, text seeds passed through. BREAK/INDEX live in a separate Meta state, FS-separated from the user portion. fn / stop see the unwrapped accumulator directly.
                         2026-07-20  Claude      stop now receives the current element: LAMBDA(acc, current, i), matching fn's signature.
+                        2026-07-20  Claude      stop is now a pre-check: evaluated before fn with the pre-step accumulator and the incoming element; the triggering element is never consumed.
 */
 REDUCEUNTIL = LAMBDA(
 //  Parameter Declarations
@@ -15,17 +16,17 @@ REDUCEUNTIL = LAMBDA(
 //  Help
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →REDUCEUNTIL(seed, cases, fn, [stop])¶" &
-                "DESCRIPTION:   →REDUCE that halts when stop returns TRUE. Stop is checked after each fn call. Returns whatever the user passed in (scalar / array / state-string).¶" &
+                "DESCRIPTION:   →REDUCE that halts when stop returns TRUE. Stop is checked before each fn call — the element that triggers it is never consumed. Returns whatever the user passed in (scalar / array / state-string).¶" &
                 "VERSION:       →Jul 20 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
-                "   stop           →(Optional) LAMBDA(acc, current, i) returning TRUE to halt — same signature as fn. acc is the post-fn accumulator; current is the element just consumed. Default never stops (= REDUCEI).¶" &
+                "   stop           →(Optional) LAMBDA(acc, current, i) returning TRUE to halt — same signature as fn. Pre-check: acc is the accumulator so far; current is the incoming element, which is NOT consumed when stop returns TRUE. Default never stops (= REDUCEI).¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=REDUCEUNTIL(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, a > 20))¶" &
-                "Result         →28 (number — stops on iter 5 once sum exceeds 20)¶" &
-                "NOTE:          →Excel REDUCE has no real short-circuit; all cases are visited. Once stop fires, BREAK is set internally and subsequent iterations pass the accumulator through unchanged. If you seed with a non-text value, fn must keep returning the same kind of value — to switch into state-building, seed with """" or NewState().",
+                "Formula        →=REDUCEUNTIL(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, v > 9))¶" &
+                "Result         →18 (number — sums up to but not including 10, the first element > 9)¶" &
+                "NOTE:          →Excel REDUCE has no real short-circuit; all cases are visited. Once stop fires, BREAK is set internally and subsequent iterations pass the accumulator through unchanged. If stop is TRUE for the seed on iteration 1, the seed is returned untouched. If you seed with a non-text value, fn must keep returning the same kind of value — to switch into state-building, seed with """" or NewState().",
                 "→", "¶"
                 ),
     //  Check inputs
@@ -50,12 +51,15 @@ REDUCEUNTIL = LAMBDA(
                            LET(
                                iter, GetVar(metaPart, "INDEX") + 1,
                                acc, IF(wrap?, GetVar(userPart, "v"), userPart),
-                               newAcc, fn(acc, current, iter),
-                               stopped?, realStop(newAcc, current, iter),
-                               newUser, IF(wrap?, SetVar(userPart, "v", newAcc), newAcc),
-                               meta1, SetVar(metaPart, "INDEX", iter),
-                               newMeta, IF(stopped?, SetVar(meta1, "BREAK", TRUE), meta1),
-                               newMeta & fs & newUser
+                               stopped?, realStop(acc, current, iter),
+                               IF(stopped?,
+                                  SetVar(metaPart, "BREAK", TRUE) & fs & userPart,
+                                  LET(
+                                      newAcc, fn(acc, current, iter),
+                                      newUser, IF(wrap?, SetVar(userPart, "v", newAcc), newAcc),
+                                      SetVar(metaPart, "INDEX", iter) & fs & newUser
+                                  )
+                               )
                            )
                         )
                     )

--- a/lambdas/loops/REDUCEUNTIL.tests.yaml
+++ b/lambdas/loops/REDUCEUNTIL.tests.yaml
@@ -1,6 +1,6 @@
 tests:
   - name: scalar number seed - sum stops once total exceeds 20
-    args: ['=0', '={1;3;5;9;10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, a > 20)']
+    args: ['=0', '={1;3;5;9;10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, a > 20)']
     expected: 28
 
   - name: scalar number seed - no stop traverses all cases (REDUCEI behaviour)
@@ -8,8 +8,12 @@ tests:
     expected: 15
 
   - name: scalar number seed - stop fires immediately on iter 1
-    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, TRUE)']
+    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, TRUE)']
     expected: 1
+
+  - name: stop condition sees the current element
+    args: ['=0', '={1;3;5;9;10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, v = 9)']
+    expected: 18
 
   - name: scalar boolean seed - any case equals 2
     args: ['=FALSE', '={1;2;3;4}', '=LAMBDA(a, v, i, OR(a, v = 2))']
@@ -35,7 +39,7 @@ tests:
       - 6
 
   - name: horizontal cases array works the same as vertical
-    args: ['=0', '={1,3,5,9,10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, a > 20)']
+    args: ['=0', '={1,3,5,9,10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, a > 20)']
     expected: 28
 
   - name: help text

--- a/lambdas/loops/REDUCEUNTIL.tests.yaml
+++ b/lambdas/loops/REDUCEUNTIL.tests.yaml
@@ -7,13 +7,13 @@ tests:
     args: ['=0', '={1;2;3;4;5}', '=LAMBDA(a, v, i, a + v)']
     expected: 15
 
-  - name: scalar number seed - stop fires immediately on iter 1
+  - name: stop TRUE from the start - seed returned untouched, nothing consumed
     args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, TRUE)']
-    expected: 1
+    expected: 0
 
-  - name: stop condition sees the current element
+  - name: element-based stop halts before consuming the trigger
     args: ['=0', '={1;3;5;9;10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, v = 9)']
-    expected: 18
+    expected: 9
 
   - name: scalar boolean seed - any case equals 2
     args: ['=FALSE', '={1;2;3;4}', '=LAMBDA(a, v, i, OR(a, v = 2))']

--- a/lambdas/loops/REDUCEWHILE.lambda
+++ b/lambdas/loops/REDUCEWHILE.lambda
@@ -1,10 +1,11 @@
 /*  FUNCTION NAME:      REDUCEWHILE
-    DESCRIPTION:*//**REDUCE that halts when continue returns FALSE. Continue is checked after each fn call. fn and continue share one signature: LAMBDA(acc, current, i). Mechanically equivalent to REDUCEUNTIL with the predicate negated — pick whichever reads better for your condition.*/
+    DESCRIPTION:*//**REDUCE that halts when continue returns FALSE. Continue is a pre-check: evaluated before each fn call with the pre-step accumulator and the incoming element, so the element that fails it is never consumed. fn and continue share one signature: LAMBDA(acc, current, i). Mechanically equivalent to REDUCEUNTIL with the predicate negated — pick whichever reads better for your condition.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-05-02  Claude      Initial version
                         2026-05-03  Claude      Accept horizontal or vertical cases (inherits from REDUCEUNTIL)
                         2026-05-04  Claude      Inherits new "user accumulator preserved by type" contract from REDUCEUNTIL.
                         2026-07-20  Claude      continue now receives the current element: LAMBDA(acc, current, i), matching fn's signature.
+                        2026-07-20  Claude      continue is now a pre-check: evaluated before fn with the pre-step accumulator and the incoming element; the element that fails it is never consumed.
 */
 REDUCEWHILE = LAMBDA(
 //  Parameter Declarations
@@ -15,16 +16,16 @@ REDUCEWHILE = LAMBDA(
 //  Help
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →REDUCEWHILE(seed, cases, fn, continue)¶" &
-                "DESCRIPTION:   →REDUCE that halts when continue returns FALSE. Continue is checked after each fn call. Returns whatever the user passed in (scalar / array / state-string).¶" &
+                "DESCRIPTION:   →REDUCE that halts when continue returns FALSE. Continue is checked before each fn call — the element that fails it is never consumed. Returns whatever the user passed in (scalar / array / state-string).¶" &
                 "VERSION:       →Jul 20 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
-                "   continue       →(Required) LAMBDA(acc, current, i) returning TRUE to keep going, FALSE to halt — same signature as fn. acc is the post-fn accumulator; current is the element just consumed.¶" &
+                "   continue       →(Required) LAMBDA(acc, current, i) returning TRUE to keep going, FALSE to halt — same signature as fn. Pre-check: acc is the accumulator so far; current is the incoming element, which is NOT consumed when continue returns FALSE.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=REDUCEWHILE(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, a <= 20))¶" &
-                "Result         →28 (number — halts on iter 5 once sum is no longer ≤ 20)¶" &
+                "Formula        →=REDUCEWHILE(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, v <= 9))¶" &
+                "Result         →18 (number — sums while elements stay ≤ 9; halts before consuming 10)¶" &
                 "NOTE:          →Mechanically equivalent to REDUCEUNTIL with the predicate negated. Use whichever phrasing reads more naturally.",
                 "→", "¶"
                 ),

--- a/lambdas/loops/REDUCEWHILE.lambda
+++ b/lambdas/loops/REDUCEWHILE.lambda
@@ -1,9 +1,10 @@
 /*  FUNCTION NAME:      REDUCEWHILE
-    DESCRIPTION:*//**REDUCE that halts when continue returns FALSE. Continue is checked after each fn call. fn signature: LAMBDA(acc, current, i). continue signature: LAMBDA(acc, i). Mechanically equivalent to REDUCEUNTIL with the predicate negated — pick whichever reads better for your condition.*/
+    DESCRIPTION:*//**REDUCE that halts when continue returns FALSE. Continue is checked after each fn call. fn and continue share one signature: LAMBDA(acc, current, i). Mechanically equivalent to REDUCEUNTIL with the predicate negated — pick whichever reads better for your condition.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-05-02  Claude      Initial version
                         2026-05-03  Claude      Accept horizontal or vertical cases (inherits from REDUCEUNTIL)
                         2026-05-04  Claude      Inherits new "user accumulator preserved by type" contract from REDUCEUNTIL.
+                        2026-07-20  Claude      continue now receives the current element: LAMBDA(acc, current, i), matching fn's signature.
 */
 REDUCEWHILE = LAMBDA(
 //  Parameter Declarations
@@ -15,14 +16,14 @@ REDUCEWHILE = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →REDUCEWHILE(seed, cases, fn, continue)¶" &
                 "DESCRIPTION:   →REDUCE that halts when continue returns FALSE. Continue is checked after each fn call. Returns whatever the user passed in (scalar / array / state-string).¶" &
-                "VERSION:       →May 04 2026¶" &
+                "VERSION:       →Jul 20 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
-                "   continue       →(Required) LAMBDA(acc, i) returning TRUE to keep going, FALSE to halt.¶" &
+                "   continue       →(Required) LAMBDA(acc, current, i) returning TRUE to keep going, FALSE to halt — same signature as fn. acc is the post-fn accumulator; current is the element just consumed.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=REDUCEWHILE(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, i, a <= 20))¶" &
+                "Formula        →=REDUCEWHILE(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, a <= 20))¶" &
                 "Result         →28 (number — halts on iter 5 once sum is no longer ≤ 20)¶" &
                 "NOTE:          →Mechanically equivalent to REDUCEUNTIL with the predicate negated. Use whichever phrasing reads more naturally.",
                 "→", "¶"
@@ -30,7 +31,7 @@ REDUCEWHILE = LAMBDA(
     //  Check inputs
         Help?, ISOMITTED(seed),
     //  Procedure
-        result, REDUCEUNTIL(seed, cases, fn, LAMBDA(a, i, NOT(continue(a, i)))),
+        result, REDUCEUNTIL(seed, cases, fn, LAMBDA(a, v, i, NOT(continue(a, v, i)))),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/loops/REDUCEWHILE.tests.yaml
+++ b/lambdas/loops/REDUCEWHILE.tests.yaml
@@ -1,22 +1,26 @@
 tests:
   - name: scalar number seed - continue while sum at most 20
-    args: ['=0', '={1;3;5;9;10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, a <= 20)']
+    args: ['=0', '={1;3;5;9;10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, a <= 20)']
     expected: 28
 
   - name: continue uses iteration index - halts after iter 3
-    args: ['=0', '={1;2;3;4;5}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, i < 3)']
+    args: ['=0', '={1;2;3;4;5}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, i < 3)']
     expected: 6
 
   - name: continue immediately FALSE halts on iter 1
-    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, FALSE)']
+    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, FALSE)']
     expected: 1
 
+  - name: continue condition sees the current element
+    args: ['=0', '={1;3;5;9;10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, v < 9)']
+    expected: 18
+
   - name: state-string seed - user gets state-string back
-    args: ['=SetVars("sum", 0)', '={1;2;3;4;5}', '=LAMBDA(s, cur, i, SetVar(s, "sum", GetVar(s, "sum") + cur))', '=LAMBDA(s, i, GetVar(s, "sum") < 6)']
+    args: ['=SetVars("sum", 0)', '={1;2;3;4;5}', '=LAMBDA(s, cur, i, SetVar(s, "sum", GetVar(s, "sum") + cur))', '=LAMBDA(s, v, i, GetVar(s, "sum") < 6)']
     expected: "sum\x1En\x1E6"
 
   - name: horizontal cases array works the same as vertical
-    args: ['=0', '={1,3,5,9,10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, a <= 20)']
+    args: ['=0', '={1,3,5,9,10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, a <= 20)']
     expected: 28
 
   - name: help text

--- a/lambdas/loops/REDUCEWHILE.tests.yaml
+++ b/lambdas/loops/REDUCEWHILE.tests.yaml
@@ -3,17 +3,17 @@ tests:
     args: ['=0', '={1;3;5;9;10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, a <= 20)']
     expected: 28
 
-  - name: continue uses iteration index - halts after iter 3
+  - name: continue uses iteration index - halts before iter 3
     args: ['=0', '={1;2;3;4;5}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, i < 3)']
-    expected: 6
+    expected: 3
 
-  - name: continue immediately FALSE halts on iter 1
+  - name: continue FALSE from the start - seed returned untouched, nothing consumed
     args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, FALSE)']
-    expected: 1
+    expected: 0
 
-  - name: continue condition sees the current element
+  - name: element-based continue halts before consuming the failing element
     args: ['=0', '={1;3;5;9;10}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, v < 9)']
-    expected: 18
+    expected: 9
 
   - name: state-string seed - user gets state-string back
     args: ['=SetVars("sum", 0)', '={1;2;3;4;5}', '=LAMBDA(s, cur, i, SetVar(s, "sum", GetVar(s, "sum") + cur))', '=LAMBDA(s, v, i, GetVar(s, "sum") < 6)']

--- a/lambdas/loops/SCANUNTIL.lambda
+++ b/lambdas/loops/SCANUNTIL.lambda
@@ -4,6 +4,7 @@
                         2026-05-04  Claude      Initial version
                         2026-05-04  Claude      Adopt new "user accumulator preserved by type" contract — output column is the unwrapped user value at each iteration, no helper meta.
                         2026-07-20  Claude      stop now receives the current element: LAMBDA(acc, current, i), matching fn's signature.
+                        2026-07-20  Claude      stop is now a pre-check: evaluated before fn with the pre-step accumulator and the incoming element; the triggering element is never consumed.
 */
 SCANUNTIL = LAMBDA(
 //  Parameter Declarations
@@ -20,11 +21,11 @@ SCANUNTIL = LAMBDA(
                 "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
-                "   stop           →(Optional) LAMBDA(acc, current, i) returning TRUE to halt — same signature as fn. acc is the post-fn accumulator; current is the element just consumed. Default never stops.¶" &
+                "   stop           →(Optional) LAMBDA(acc, current, i) returning TRUE to halt — same signature as fn. Pre-check: acc is the accumulator so far; current is the incoming element, which is NOT consumed when stop returns TRUE. Default never stops.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=SCANUNTIL(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, a > 20))¶" &
-                "Result         →column {1; 4; 9; 18; 28} — running sums per iteration (last three identical once stop fires)¶" &
-                "NOTE:          →Once stop fires, BREAK is set and subsequent iterations pass the accumulator through unchanged — those rows look identical to the row where stop fired. For a state-string accumulator, pair with SplitState(_, TRUE) to get a tabular per-iteration view.",
+                "Formula        →=SCANUNTIL(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, v > 9))¶" &
+                "Result         →column {1; 4; 9; 18; 18} — running sums; halts before consuming 10, so the final row repeats¶" &
+                "NOTE:          →Stop is a pre-check: once it fires, BREAK is set and that iteration onwards passes the accumulator through unchanged — rows from the halt repeat the last consumed value. If stop is TRUE for the seed on iteration 1, every row is the seed. For a state-string accumulator, pair with SplitState(_, TRUE) to get a tabular per-iteration view.",
                 "→", "¶"
                 ),
     //  Check inputs
@@ -49,12 +50,15 @@ SCANUNTIL = LAMBDA(
                            LET(
                                iter, GetVar(metaPart, "INDEX") + 1,
                                acc, IF(wrap?, GetVar(userPart, "v"), userPart),
-                               newAcc, fn(acc, current, iter),
-                               stopped?, realStop(newAcc, current, iter),
-                               newUser, IF(wrap?, SetVar(userPart, "v", newAcc), newAcc),
-                               meta1, SetVar(metaPart, "INDEX", iter),
-                               newMeta, IF(stopped?, SetVar(meta1, "BREAK", TRUE), meta1),
-                               newMeta & fs & newUser
+                               stopped?, realStop(acc, current, iter),
+                               IF(stopped?,
+                                  SetVar(metaPart, "BREAK", TRUE) & fs & userPart,
+                                  LET(
+                                      newAcc, fn(acc, current, iter),
+                                      newUser, IF(wrap?, SetVar(userPart, "v", newAcc), newAcc),
+                                      SetVar(metaPart, "INDEX", iter) & fs & newUser
+                                  )
+                               )
                            )
                         )
                     )

--- a/lambdas/loops/SCANUNTIL.lambda
+++ b/lambdas/loops/SCANUNTIL.lambda
@@ -3,6 +3,7 @@
 /*  REVISIONS:          Date        Developer   Description
                         2026-05-04  Claude      Initial version
                         2026-05-04  Claude      Adopt new "user accumulator preserved by type" contract — output column is the unwrapped user value at each iteration, no helper meta.
+                        2026-07-20  Claude      stop now receives the current element: LAMBDA(acc, current, i), matching fn's signature.
 */
 SCANUNTIL = LAMBDA(
 //  Parameter Declarations
@@ -14,14 +15,14 @@ SCANUNTIL = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →SCANUNTIL(seed, cases, fn, [stop])¶" &
                 "DESCRIPTION:   →SCAN counterpart to REDUCEUNTIL. Returns a column of intermediate accumulators (one per iteration). Same signature as REDUCEUNTIL — swap the name to switch views.¶" &
-                "VERSION:       →May 04 2026¶" &
+                "VERSION:       →Jul 20 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
-                "   stop           →(Optional) LAMBDA(acc, i) returning TRUE to halt. Default never stops.¶" &
+                "   stop           →(Optional) LAMBDA(acc, current, i) returning TRUE to halt — same signature as fn. acc is the post-fn accumulator; current is the element just consumed. Default never stops.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=SCANUNTIL(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, i, a > 20))¶" &
+                "Formula        →=SCANUNTIL(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, a > 20))¶" &
                 "Result         →column {1; 4; 9; 18; 28} — running sums per iteration (last three identical once stop fires)¶" &
                 "NOTE:          →Once stop fires, BREAK is set and subsequent iterations pass the accumulator through unchanged — those rows look identical to the row where stop fired. For a state-string accumulator, pair with SplitState(_, TRUE) to get a tabular per-iteration view.",
                 "→", "¶"
@@ -32,7 +33,7 @@ SCANUNTIL = LAMBDA(
         us, CHAR(31),
         rs, CHAR(30),
         fs, CHAR(28),
-        realStop, IF(ISOMITTED(stop), LAMBDA(a, i, FALSE), stop),
+        realStop, IF(ISOMITTED(stop), LAMBDA(a, v, i, FALSE), stop),
         flat, TOCOL(cases),
         wrap?, NOT(ISTEXT(@seed)),
         initialMeta, SetVar(NewState(), "INDEX", 0),
@@ -49,7 +50,7 @@ SCANUNTIL = LAMBDA(
                                iter, GetVar(metaPart, "INDEX") + 1,
                                acc, IF(wrap?, GetVar(userPart, "v"), userPart),
                                newAcc, fn(acc, current, iter),
-                               stopped?, realStop(newAcc, iter),
+                               stopped?, realStop(newAcc, current, iter),
                                newUser, IF(wrap?, SetVar(userPart, "v", newAcc), newAcc),
                                meta1, SetVar(metaPart, "INDEX", iter),
                                newMeta, IF(stopped?, SetVar(meta1, "BREAK", TRUE), meta1),

--- a/lambdas/loops/SCANUNTIL.tests.yaml
+++ b/lambdas/loops/SCANUNTIL.tests.yaml
@@ -17,21 +17,21 @@ tests:
       - [28]
       - [28]
 
-  - name: scalar number seed - stop fires immediately on iter 1
+  - name: stop TRUE from the start - every row is the untouched seed
     args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, TRUE)']
     expected:
-      - [1]
-      - [1]
-      - [1]
+      - [0]
+      - [0]
+      - [0]
 
-  - name: stop condition sees the current element
+  - name: element-based stop halts before consuming the trigger
     args: ['=0', '={1;2;3;4;5}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, v = 3)']
     expected:
       - [1]
       - [3]
-      - [6]
-      - [6]
-      - [6]
+      - [3]
+      - [3]
+      - [3]
 
   - name: state-string seed - column of intermediate state-strings
     args: ['=SetVars("sum", 0)', '={1;2;3}', '=LAMBDA(s, cur, i, SetVar(s, "sum", GetVar(s, "sum") + cur))']

--- a/lambdas/loops/SCANUNTIL.tests.yaml
+++ b/lambdas/loops/SCANUNTIL.tests.yaml
@@ -7,7 +7,7 @@ tests:
       - [6]
 
   - name: scalar number seed - stop fires on iter 5, later rows pass through unchanged
-    args: ['=0', '={1;3;5;9;10;11;12}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, a > 20)']
+    args: ['=0', '={1;3;5;9;10;11;12}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, a > 20)']
     expected:
       - [1]
       - [4]
@@ -18,11 +18,20 @@ tests:
       - [28]
 
   - name: scalar number seed - stop fires immediately on iter 1
-    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, TRUE)']
+    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, TRUE)']
     expected:
       - [1]
       - [1]
       - [1]
+
+  - name: stop condition sees the current element
+    args: ['=0', '={1;2;3;4;5}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, v = 3)']
+    expected:
+      - [1]
+      - [3]
+      - [6]
+      - [6]
+      - [6]
 
   - name: state-string seed - column of intermediate state-strings
     args: ['=SetVars("sum", 0)', '={1;2;3}', '=LAMBDA(s, cur, i, SetVar(s, "sum", GetVar(s, "sum") + cur))']

--- a/lambdas/loops/SCANWHILE.lambda
+++ b/lambdas/loops/SCANWHILE.lambda
@@ -4,6 +4,7 @@
                         2026-05-04  Claude      Initial version
                         2026-05-04  Claude      Adopt new "user accumulator preserved by type" contract from SCANUNTIL.
                         2026-07-20  Claude      continue now receives the current element: LAMBDA(acc, current, i), matching fn's signature.
+                        2026-07-20  Claude      continue is now a pre-check: evaluated before fn with the pre-step accumulator and the incoming element; the element that fails it is never consumed.
 */
 SCANWHILE = LAMBDA(
 //  Parameter Declarations
@@ -20,10 +21,10 @@ SCANWHILE = LAMBDA(
                 "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
-                "   continue       →(Required) LAMBDA(acc, current, i) returning TRUE to keep going, FALSE to halt — same signature as fn. acc is the post-fn accumulator; current is the element just consumed.¶" &
+                "   continue       →(Required) LAMBDA(acc, current, i) returning TRUE to keep going, FALSE to halt — same signature as fn. Pre-check: acc is the accumulator so far; current is the incoming element, which is NOT consumed when continue returns FALSE.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=SCANWHILE(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, a <= 20))¶" &
-                "Result         →column {1; 4; 9; 18; 28} — running sums per iteration (last three identical once stop fires)¶" &
+                "Formula        →=SCANWHILE(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, v <= 9))¶" &
+                "Result         →column {1; 4; 9; 18; 18} — running sums; halts before consuming 10, so the final row repeats¶" &
                 "NOTE:          →Mechanically equivalent to SCANUNTIL with the predicate negated. For a state-string accumulator, pair with SplitState(_, TRUE) to get a tabular per-iteration view.",
                 "→", "¶"
                 ),

--- a/lambdas/loops/SCANWHILE.lambda
+++ b/lambdas/loops/SCANWHILE.lambda
@@ -3,6 +3,7 @@
 /*  REVISIONS:          Date        Developer   Description
                         2026-05-04  Claude      Initial version
                         2026-05-04  Claude      Adopt new "user accumulator preserved by type" contract from SCANUNTIL.
+                        2026-07-20  Claude      continue now receives the current element: LAMBDA(acc, current, i), matching fn's signature.
 */
 SCANWHILE = LAMBDA(
 //  Parameter Declarations
@@ -14,14 +15,14 @@ SCANWHILE = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →SCANWHILE(seed, cases, fn, continue)¶" &
                 "DESCRIPTION:   →SCAN counterpart to REDUCEWHILE. Returns a column of intermediate accumulators (one per iteration). Same signature as REDUCEWHILE — swap the name to switch views.¶" &
-                "VERSION:       →May 04 2026¶" &
+                "VERSION:       →Jul 20 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   seed           →(Required) Initial accumulator. Number/boolean/array -> type-preserved scalar accumulation. Text (including """" / NewState() / a state-string) -> free-form text/state accumulation.¶" &
                 "   cases          →(Required) Array to iterate over. Vertical or horizontal — flattened with TOCOL.¶" &
                 "   fn             →(Required) LAMBDA(acc, current, i) returning the new accumulator. i is 1-based.¶" &
-                "   continue       →(Required) LAMBDA(acc, i) returning TRUE to keep going, FALSE to halt.¶" &
+                "   continue       →(Required) LAMBDA(acc, current, i) returning TRUE to keep going, FALSE to halt — same signature as fn. acc is the post-fn accumulator; current is the element just consumed.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=SCANWHILE(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, i, a <= 20))¶" &
+                "Formula        →=SCANWHILE(0, {1,3,5,9,10}, LAMBDA(a, v, i, a + v), LAMBDA(a, v, i, a <= 20))¶" &
                 "Result         →column {1; 4; 9; 18; 28} — running sums per iteration (last three identical once stop fires)¶" &
                 "NOTE:          →Mechanically equivalent to SCANUNTIL with the predicate negated. For a state-string accumulator, pair with SplitState(_, TRUE) to get a tabular per-iteration view.",
                 "→", "¶"
@@ -29,7 +30,7 @@ SCANWHILE = LAMBDA(
     //  Check inputs
         Help?, ISOMITTED(seed),
     //  Procedure
-        result, SCANUNTIL(seed, cases, fn, LAMBDA(a, i, NOT(continue(a, i)))),
+        result, SCANUNTIL(seed, cases, fn, LAMBDA(a, v, i, NOT(continue(a, v, i)))),
         IF(Help?, Help, result)
 )
 );

--- a/lambdas/loops/SCANWHILE.tests.yaml
+++ b/lambdas/loops/SCANWHILE.tests.yaml
@@ -1,6 +1,6 @@
 tests:
   - name: scalar number seed - continue while sum at most 20
-    args: ['=0', '={1;3;5;9;10;11;12}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, a <= 20)']
+    args: ['=0', '={1;3;5;9;10;11;12}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, a <= 20)']
     expected:
       - [1]
       - [4]
@@ -11,21 +11,30 @@ tests:
       - [28]
 
   - name: continue always TRUE traverses all cases
-    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, TRUE)']
+    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, TRUE)']
     expected:
       - [1]
       - [3]
       - [6]
 
   - name: continue immediately FALSE halts on iter 1
-    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, FALSE)']
+    args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, FALSE)']
     expected:
       - [1]
       - [1]
       - [1]
 
+  - name: continue condition sees the current element
+    args: ['=0', '={1;2;3;4;5}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, v < 3)']
+    expected:
+      - [1]
+      - [3]
+      - [6]
+      - [6]
+      - [6]
+
   - name: state-string seed - column of intermediate state-strings
-    args: ['=SetVars("sum", 0)', '={1;2;3;4;5}', '=LAMBDA(s, cur, i, SetVar(s, "sum", GetVar(s, "sum") + cur))', '=LAMBDA(s, i, GetVar(s, "sum") < 6)']
+    args: ['=SetVars("sum", 0)', '={1;2;3;4;5}', '=LAMBDA(s, cur, i, SetVar(s, "sum", GetVar(s, "sum") + cur))', '=LAMBDA(s, v, i, GetVar(s, "sum") < 6)']
     expected:
       - ["sum\x1En\x1E1"]
       - ["sum\x1En\x1E3"]
@@ -34,7 +43,7 @@ tests:
       - ["sum\x1En\x1E6"]
 
   - name: horizontal cases array works the same as vertical
-    args: ['=0', '={1,2,3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, i, TRUE)']
+    args: ['=0', '={1,2,3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, TRUE)']
     expected:
       - [1]
       - [3]

--- a/lambdas/loops/SCANWHILE.tests.yaml
+++ b/lambdas/loops/SCANWHILE.tests.yaml
@@ -17,21 +17,21 @@ tests:
       - [3]
       - [6]
 
-  - name: continue immediately FALSE halts on iter 1
+  - name: continue FALSE from the start - every row is the untouched seed
     args: ['=0', '={1;2;3}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, FALSE)']
     expected:
-      - [1]
-      - [1]
-      - [1]
+      - [0]
+      - [0]
+      - [0]
 
-  - name: continue condition sees the current element
+  - name: element-based continue halts before consuming the failing element
     args: ['=0', '={1;2;3;4;5}', '=LAMBDA(a, v, i, a + v)', '=LAMBDA(a, v, i, v < 3)']
     expected:
       - [1]
       - [3]
-      - [6]
-      - [6]
-      - [6]
+      - [3]
+      - [3]
+      - [3]
 
   - name: state-string seed - column of intermediate state-strings
     args: ['=SetVars("sum", 0)', '={1;2;3;4;5}', '=LAMBDA(s, cur, i, SetVar(s, "sum", GetVar(s, "sum") + cur))', '=LAMBDA(s, v, i, GetVar(s, "sum") < 6)']


### PR DESCRIPTION
## What

Two changes to the condition callback in the four loop lambdas — `stop` in REDUCEUNTIL/SCANUNTIL, `continue` in REDUCEWHILE/SCANWHILE:

1. **Same signature as `fn`:** the condition now receives the current element — `LAMBDA(acc, current, i)`.
2. **Pre-check semantics:** the condition is evaluated *before* `fn`, with the pre-step accumulator and the incoming element. If it halts, that element is never consumed — classic while-loop behaviour matching the WHILE/UNTIL names.

## Why

- "Sum up to but not including the first element > 9" is now just `LAMBDA(a, v, i, v > 9)` — previously impossible without duplicating the predicate inside `fn`.
- One callback signature across the whole loops library.
- Accumulator-based conditions ("stop once total > 20") produce identical results to the old post-check, for both REDUCE and SCAN outputs — the flip only changes behaviour for element conditions and for conditions already true on the seed (seed is now returned untouched, nothing consumed).

## Breaking change

Existing 2-arg conditions (`LAMBDA(a, i, ...)`) return `#VALUE!` until the middle param is added, and any condition that relied on the trigger element being included must be rewritten (guard inside `fn` or condition on the accumulator).

## Testing

- Format tests: 784/784 pass
- Harness scoped runs: UNTIL 31/31, WHILE 14/14 — including per-lambda cases for element-based halting (trigger excluded) and condition-true-on-seed (seed returned untouched)
- Full suite: 908/908 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)