### PR TITLE
Add MATCHSPLIT - flatten two-sided match tables to one row per team per match

### DIFF
--- a/lambdas/array/MATCHSPLIT.lambda
+++ b/lambdas/array/MATCHSPLIT.lambda
@@ -1,0 +1,56 @@
+/*  FUNCTION NAME:      MATCHSPLIT
+    DESCRIPTION:*//**Flattens a two-sided match table into one row per team per match, with own and opponent columns side by side plus an explicit Side flag.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-07-24  Claude      Initial version
+*/
+MATCHSPLIT = LAMBDA(
+//  Parameter Declarations
+    [sideA],
+    [sideB],
+    [keyCols],
+    [interleave],
+    [resultHeaders],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →MATCHSPLIT(sideA, sideB, keyCols, interleave, resultHeaders)¶" &
+                "DESCRIPTION:   →Flattens a two-sided match table (one row per match) into one row per team per match: keys, Side (1 = listed first, 2 = listed second), own-side values, opponent values. Eliminates the opponent self-XLOOKUP.¶" &
+                "VERSION:       →Jul 24 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   sideA          →(Required) N x W block of side-1 (""home"") columns, one match per row (e.g. team name, score).¶" &
+                "   sideB          →(Required) N x W block of side-2 (""away"") columns, same width and column order as sideA. Returns #VALUE! if the shapes differ.¶" &
+                "   keyCols        →(Optional) N x K per-match identifier column(s) repeated on both output rows (match number, date, ...).¶" &
+                "   interleave     →(Optional) TRUE (default) pairs each match's two rows adjacently, side 1 first; FALSE stacks all side-1 rows then all side-2 rows.¶" &
+                "   resultHeaders  →(Optional) TRUE prepends a default header row (Key1..KeyK, Side, Own1..OwnW, Opp1..OppW); or pass a custom header array. Default FALSE.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=MATCHSPLIT({""Ann"",3;""Cat"",1}, {""Bob"",2;""Dan"",4}, {""M1"";""M2""})¶" &
+                "Result         →4 rows: M1,1,Ann,3,Bob,2 / M1,2,Bob,2,Ann,3 / M2,1,Cat,1,Dan,4 / M2,2,Dan,4,Cat,1",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(sideA),
+    //  Procedure
+        nRows, ROWS(sideA),
+        sideW, COLUMNS(sideA),
+        shapeOk, AND(ROWS(sideB) = nRows, COLUMNS(sideB) = sideW),
+        hasKeys, NOT(ISOMITTED(keyCols)),
+        nKeys, IF(hasKeys, COLUMNS(keyCols), 0),
+        sideOnes, SEQUENCE(nRows, 1, 1, 0),
+        sideTwos, SEQUENCE(nRows, 1, 2, 0),
+        blockA, IF(hasKeys, HSTACK(keyCols, sideOnes, sideA, sideB), HSTACK(sideOnes, sideA, sideB)),
+        blockB, IF(hasKeys, HSTACK(keyCols, sideTwos, sideB, sideA), HSTACK(sideTwos, sideB, sideA)),
+        stacked, VSTACK(blockA, blockB),
+        inter?, IF(ISOMITTED(interleave), TRUE, interleave),
+        ordered, IF(inter?,
+                    CHOOSEROWS(stacked, TOCOL(HSTACK(SEQUENCE(nRows), SEQUENCE(nRows) + nRows))),
+                    stacked),
+        hdrCount, IF(ISOMITTED(resultHeaders), 0, ROWS(resultHeaders) * COLUMNS(resultHeaders)),
+        header?, IF(ISOMITTED(resultHeaders), FALSE, IF(hdrCount > 1, TRUE, N(resultHeaders))),
+        defaultHeader, IF(hasKeys,
+                          HSTACK("Key" & SEQUENCE(1, nKeys), "Side", "Own" & SEQUENCE(1, sideW), "Opp" & SEQUENCE(1, sideW)),
+                          HSTACK("Side", "Own" & SEQUENCE(1, sideW), "Opp" & SEQUENCE(1, sideW))),
+        headerRow, IF(hdrCount > 1, TOROW(resultHeaders), defaultHeader),
+        body, IF(header?, VSTACK(headerRow, ordered), ordered),
+        result, IF(shapeOk, body, VALUE("x")),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/MATCHSPLIT.lambda
+++ b/lambdas/array/MATCHSPLIT.lambda
@@ -7,23 +7,27 @@ MATCHSPLIT = LAMBDA(
 //  Parameter Declarations
     [sideA],
     [sideB],
+    [teamIdA],
+    [teamIdB],
     [keyCols],
     [interleave],
     [resultHeaders],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →MATCHSPLIT(sideA, sideB, keyCols, interleave, resultHeaders)¶" &
-                "DESCRIPTION:   →Flattens a two-sided match table (one row per match) into one row per team per match: keys, Side (1 = listed first, 2 = listed second), own-side values, opponent values. Eliminates the opponent self-XLOOKUP.¶" &
+                "FUNCTION:      →MATCHSPLIT(sideA, sideB, teamIdA, teamIdB, keyCols, interleave, resultHeaders)¶" &
+                "DESCRIPTION:   →Flattens a two-sided match table (one row per match) into one row per team per match: keys, Side (1 = listed first, 2 = listed second), own team ID, own-side values, opponent team ID, opponent values. Eliminates the opponent self-XLOOKUP.¶" &
                 "VERSION:       →Jul 24 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   sideA          →(Required) N x W block of side-1 (""home"") columns, one match per row (e.g. team name, score).¶" &
                 "   sideB          →(Required) N x W block of side-2 (""away"") columns, same width and column order as sideA. Returns #VALUE! if the shapes differ.¶" &
+                "   teamIdA        →(Optional) N x 1 column of side-1 team IDs. Appears as the row's own Team column on side-1 rows and as OppTeam on side-2 rows. Supply both teamIdA and teamIdB or neither.¶" &
+                "   teamIdB        →(Optional) N x 1 column of side-2 team IDs, paired with teamIdA.¶" &
                 "   keyCols        →(Optional) N x K per-match identifier column(s) repeated on both output rows (match number, date, ...).¶" &
                 "   interleave     →(Optional) TRUE (default) pairs each match's two rows adjacently, side 1 first; FALSE stacks all side-1 rows then all side-2 rows.¶" &
-                "   resultHeaders  →(Optional) TRUE prepends a default header row (Key1..KeyK, Side, Own1..OwnW, Opp1..OppW); or pass a custom header array. Default FALSE.¶" &
+                "   resultHeaders  →(Optional) TRUE prepends a default header row (Key1..KeyK, Side, Team, Own1..OwnW, OppTeam, Opp1..OppW); or pass a custom header array. Default FALSE.¶" &
                 "EXAMPLE:       →¶" &
-                "Formula        →=MATCHSPLIT({""Ann"",3;""Cat"",1}, {""Bob"",2;""Dan"",4}, {""M1"";""M2""})¶" &
-                "Result         →4 rows: M1,1,Ann,3,Bob,2 / M1,2,Bob,2,Ann,3 / M2,1,Cat,1,Dan,4 / M2,2,Dan,4,Cat,1",
+                "Formula        →=MATCHSPLIT({3;1}, {2;4}, {""G"";""H""}, {""H"";""G""}, {""M1"";""M2""})¶" &
+                "Result         →4 rows: M1,1,G,3,H,2 / M1,2,H,2,G,3 / M2,1,H,1,G,4 / M2,2,G,4,H,1",
                 "→", "¶"
                 ),
     //  Check inputs
@@ -31,13 +35,20 @@ MATCHSPLIT = LAMBDA(
     //  Procedure
         nRows, ROWS(sideA),
         sideW, COLUMNS(sideA),
-        shapeOk, AND(ROWS(sideB) = nRows, COLUMNS(sideB) = sideW),
+        hasIds, NOT(ISOMITTED(teamIdA)),
+        idsPaired, ISOMITTED(teamIdA) = ISOMITTED(teamIdB),
+        idsOk, IF(hasIds,
+                  AND(ROWS(teamIdA) = nRows, COLUMNS(teamIdA) = 1, ROWS(teamIdB) = nRows, COLUMNS(teamIdB) = 1),
+                  TRUE),
+        shapeOk, AND(ROWS(sideB) = nRows, COLUMNS(sideB) = sideW, idsPaired, idsOk),
         hasKeys, NOT(ISOMITTED(keyCols)),
         nKeys, IF(hasKeys, COLUMNS(keyCols), 0),
         sideOnes, SEQUENCE(nRows, 1, 1, 0),
         sideTwos, SEQUENCE(nRows, 1, 2, 0),
-        blockA, IF(hasKeys, HSTACK(keyCols, sideOnes, sideA, sideB), HSTACK(sideOnes, sideA, sideB)),
-        blockB, IF(hasKeys, HSTACK(keyCols, sideTwos, sideB, sideA), HSTACK(sideTwos, sideB, sideA)),
+        augA, IF(hasIds, HSTACK(teamIdA, sideA), sideA),
+        augB, IF(hasIds, HSTACK(teamIdB, sideB), sideB),
+        blockA, IF(hasKeys, HSTACK(keyCols, sideOnes, augA, augB), HSTACK(sideOnes, augA, augB)),
+        blockB, IF(hasKeys, HSTACK(keyCols, sideTwos, augB, augA), HSTACK(sideTwos, augB, augA)),
         stacked, VSTACK(blockA, blockB),
         inter?, IF(ISOMITTED(interleave), TRUE, interleave),
         ordered, IF(inter?,
@@ -45,9 +56,11 @@ MATCHSPLIT = LAMBDA(
                     stacked),
         hdrCount, IF(ISOMITTED(resultHeaders), 0, ROWS(resultHeaders) * COLUMNS(resultHeaders)),
         header?, IF(ISOMITTED(resultHeaders), FALSE, IF(hdrCount > 1, TRUE, N(resultHeaders))),
+        ownHdr, IF(hasIds, HSTACK("Team", "Own" & SEQUENCE(1, sideW)), "Own" & SEQUENCE(1, sideW)),
+        oppHdr, IF(hasIds, HSTACK("OppTeam", "Opp" & SEQUENCE(1, sideW)), "Opp" & SEQUENCE(1, sideW)),
         defaultHeader, IF(hasKeys,
-                          HSTACK("Key" & SEQUENCE(1, nKeys), "Side", "Own" & SEQUENCE(1, sideW), "Opp" & SEQUENCE(1, sideW)),
-                          HSTACK("Side", "Own" & SEQUENCE(1, sideW), "Opp" & SEQUENCE(1, sideW))),
+                          HSTACK("Key" & SEQUENCE(1, nKeys), "Side", ownHdr, oppHdr),
+                          HSTACK("Side", ownHdr, oppHdr)),
         headerRow, IF(hdrCount > 1, TOROW(resultHeaders), defaultHeader),
         body, IF(header?, VSTACK(headerRow, ordered), ordered),
         result, IF(shapeOk, body, VALUE("x")),

--- a/lambdas/array/MATCHSPLIT.lambda
+++ b/lambdas/array/MATCHSPLIT.lambda
@@ -15,7 +15,7 @@ MATCHSPLIT = LAMBDA(
 //  Help
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →MATCHSPLIT(sideA, sideB, teamIdA, teamIdB, keyCols, interleave, resultHeaders)¶" &
-                "DESCRIPTION:   →Flattens a two-sided match table (one row per match) into one row per team per match: keys, Side (1 = listed first, 2 = listed second), own team ID, own-side values, opponent team ID, opponent values. Eliminates the opponent self-XLOOKUP.¶" &
+                "DESCRIPTION:   →Flattens a two-sided match table (one row per match) into one row per team per match: keys, Side (1 = listed first, 2 = listed second), then own/opponent column pairs (Team, OppTeam, Own1, Opp1, Own2, Opp2, ...). Eliminates the opponent self-XLOOKUP.¶" &
                 "VERSION:       →Jul 24 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   sideA          →(Required) N x W block of side-1 (""home"") columns, one match per row (e.g. team name, score).¶" &
@@ -24,10 +24,10 @@ MATCHSPLIT = LAMBDA(
                 "   teamIdB        →(Optional) N x 1 column of side-2 team IDs, paired with teamIdA.¶" &
                 "   keyCols        →(Optional) N x K per-match identifier column(s) repeated on both output rows (match number, date, ...).¶" &
                 "   interleave     →(Optional) TRUE (default) pairs each match's two rows adjacently, side 1 first; FALSE stacks all side-1 rows then all side-2 rows.¶" &
-                "   resultHeaders  →(Optional) TRUE prepends a default header row (Key1..KeyK, Side, Team, Own1..OwnW, OppTeam, Opp1..OppW); or pass a custom header array. Default FALSE.¶" &
+                "   resultHeaders  →(Optional) TRUE prepends a default header row (Key1..KeyK, Side, Team, OppTeam, Own1, Opp1, ..., OwnW, OppW); or pass a custom header array. Default FALSE.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=MATCHSPLIT({3;1}, {2;4}, {""G"";""H""}, {""H"";""G""}, {""M1"";""M2""})¶" &
-                "Result         →4 rows: M1,1,G,3,H,2 / M1,2,H,2,G,3 / M2,1,H,1,G,4 / M2,2,G,4,H,1",
+                "Result         →4 rows: M1,1,G,H,3,2 / M1,2,H,G,2,3 / M2,1,H,G,1,4 / M2,2,G,H,4,1",
                 "→", "¶"
                 ),
     //  Check inputs
@@ -47,8 +47,12 @@ MATCHSPLIT = LAMBDA(
         sideTwos, SEQUENCE(nRows, 1, 2, 0),
         augA, IF(hasIds, HSTACK(teamIdA, sideA), sideA),
         augB, IF(hasIds, HSTACK(teamIdB, sideB), sideB),
-        blockA, IF(hasKeys, HSTACK(keyCols, sideOnes, augA, augB), HSTACK(sideOnes, augA, augB)),
-        blockB, IF(hasKeys, HSTACK(keyCols, sideTwos, augB, augA), HSTACK(sideTwos, augB, augA)),
+        augW, sideW + IF(hasIds, 1, 0),
+        pairIdx, TOROW(VSTACK(SEQUENCE(1, augW), SEQUENCE(1, augW) + augW), , TRUE),
+        pairedA, CHOOSECOLS(HSTACK(augA, augB), pairIdx),
+        pairedB, CHOOSECOLS(HSTACK(augB, augA), pairIdx),
+        blockA, IF(hasKeys, HSTACK(keyCols, sideOnes, pairedA), HSTACK(sideOnes, pairedA)),
+        blockB, IF(hasKeys, HSTACK(keyCols, sideTwos, pairedB), HSTACK(sideTwos, pairedB)),
         stacked, VSTACK(blockA, blockB),
         inter?, IF(ISOMITTED(interleave), TRUE, interleave),
         ordered, IF(inter?,
@@ -58,9 +62,10 @@ MATCHSPLIT = LAMBDA(
         header?, IF(ISOMITTED(resultHeaders), FALSE, IF(hdrCount > 1, TRUE, N(resultHeaders))),
         ownHdr, IF(hasIds, HSTACK("Team", "Own" & SEQUENCE(1, sideW)), "Own" & SEQUENCE(1, sideW)),
         oppHdr, IF(hasIds, HSTACK("OppTeam", "Opp" & SEQUENCE(1, sideW)), "Opp" & SEQUENCE(1, sideW)),
+        pairedHdr, CHOOSECOLS(HSTACK(ownHdr, oppHdr), pairIdx),
         defaultHeader, IF(hasKeys,
-                          HSTACK("Key" & SEQUENCE(1, nKeys), "Side", ownHdr, oppHdr),
-                          HSTACK("Side", ownHdr, oppHdr)),
+                          HSTACK("Key" & SEQUENCE(1, nKeys), "Side", pairedHdr),
+                          HSTACK("Side", pairedHdr)),
         headerRow, IF(hdrCount > 1, TOROW(resultHeaders), defaultHeader),
         body, IF(header?, VSTACK(headerRow, ordered), ordered),
         result, IF(shapeOk, body, VALUE("x")),

--- a/lambdas/array/MATCHSPLIT.tests.yaml
+++ b/lambdas/array/MATCHSPLIT.tests.yaml
@@ -1,6 +1,22 @@
 tests:
+  - name: team IDs and keys give Match Side Team Own OppTeam Opp rows
+    args: ['={3;1}', '={2;4}', '={"G";"H"}', '={"H";"G"}', '={"M1";"M2"}']
+    expected:
+      - ["M1", 1, "G", 3, "H", 2]
+      - ["M1", 2, "H", 2, "G", 3]
+      - ["M2", 1, "H", 1, "G", 4]
+      - ["M2", 2, "G", 4, "H", 1]
+
+  - name: team IDs without keys start at Side
+    args: ['={3;1}', '={2;4}', '={"G";"H"}', '={"H";"G"}']
+    expected:
+      - [1, "G", 3, "H", 2]
+      - [2, "H", 2, "G", 3]
+      - [1, "H", 1, "G", 4]
+      - [2, "G", 4, "H", 1]
+
   - name: basic with keys interleaves each match's two rows adjacently
-    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1";"M2"}']
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", '={"M1";"M2"}']
     expected:
       - ["M1", 1, "Ann", 3, "Bob", 2]
       - ["M1", 2, "Bob", 2, "Ann", 3]
@@ -16,15 +32,24 @@ tests:
       - [2, "Dan", 4, "Cat", 1]
 
   - name: interleave FALSE stacks all side-1 rows then all side-2 rows
-    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1";"M2"}', "=FALSE"]
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", '={"M1";"M2"}', "=FALSE"]
     expected:
       - ["M1", 1, "Ann", 3, "Bob", 2]
       - ["M2", 1, "Cat", 1, "Dan", 4]
       - ["M1", 2, "Bob", 2, "Ann", 3]
       - ["M2", 2, "Dan", 4, "Cat", 1]
 
-  - name: default resultHeaders with keys prepends Key1 Side Own Opp row
-    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1";"M2"}', "=", "=TRUE"]
+  - name: default resultHeaders with IDs and keys includes Team and OppTeam
+    args: ['={3;1}', '={2;4}', '={"G";"H"}', '={"H";"G"}', '={"M1";"M2"}', "=", "=TRUE"]
+    expected:
+      - ["Key1", "Side", "Team", "Own1", "OppTeam", "Opp1"]
+      - ["M1", 1, "G", 3, "H", 2]
+      - ["M1", 2, "H", 2, "G", 3]
+      - ["M2", 1, "H", 1, "G", 4]
+      - ["M2", 2, "G", 4, "H", 1]
+
+  - name: default resultHeaders without IDs prepends Key1 Side Own Opp row
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", '={"M1";"M2"}', "=", "=TRUE"]
     expected:
       - ["Key1", "Side", "Own1", "Own2", "Opp1", "Opp2"]
       - ["M1", 1, "Ann", 3, "Bob", 2]
@@ -32,8 +57,8 @@ tests:
       - ["M2", 1, "Cat", 1, "Dan", 4]
       - ["M2", 2, "Dan", 4, "Cat", 1]
 
-  - name: default resultHeaders without keys starts at Side
-    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", "=TRUE"]
+  - name: default resultHeaders without keys or IDs starts at Side
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", "=", "=", "=TRUE"]
     expected:
       - ["Side", "Own1", "Own2", "Opp1", "Opp2"]
       - [1, "Ann", 3, "Bob", 2]
@@ -42,16 +67,16 @@ tests:
       - [2, "Dan", 4, "Cat", 1]
 
   - name: custom resultHeaders array
-    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1";"M2"}', "=", '={"Match","Side","Team","For","Opp","Against"}']
+    args: ['={3;1}', '={2;4}', '={"G";"H"}', '={"H";"G"}', '={"M1";"M2"}', "=", '={"Match","Side","Team","For","Opp","Against"}']
     expected:
       - ["Match", "Side", "Team", "For", "Opp", "Against"]
-      - ["M1", 1, "Ann", 3, "Bob", 2]
-      - ["M1", 2, "Bob", 2, "Ann", 3]
-      - ["M2", 1, "Cat", 1, "Dan", 4]
-      - ["M2", 2, "Dan", 4, "Cat", 1]
+      - ["M1", 1, "G", 3, "H", 2]
+      - ["M1", 2, "H", 2, "G", 3]
+      - ["M2", 1, "H", 1, "G", 4]
+      - ["M2", 2, "G", 4, "H", 1]
 
   - name: multi-key columns repeat on both rows and header numbers them
-    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1","Jan";"M2","Feb"}', "=", "=TRUE"]
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", '={"M1","Jan";"M2","Feb"}', "=", "=TRUE"]
     expected:
       - ["Key1", "Key2", "Side", "Own1", "Own2", "Opp1", "Opp2"]
       - ["M1", "Jan", 1, "Ann", 3, "Bob", 2]
@@ -79,6 +104,14 @@ tests:
 
   - name: width mismatch returns VALUE error
     args: ['={"Ann",3;"Cat",1}', '={"Bob";"Dan"}']
+    expected: -2146826273
+
+  - name: only one team ID column supplied returns VALUE error
+    args: ['={3;1}', '={2;4}', '={"G";"H"}']
+    expected: -2146826273
+
+  - name: team ID row-count mismatch returns VALUE error
+    args: ['={3;1}', '={2;4}', '={"G"}', '={"H";"G"}']
     expected: -2146826273
 
   - name: help text

--- a/lambdas/array/MATCHSPLIT.tests.yaml
+++ b/lambdas/array/MATCHSPLIT.tests.yaml
@@ -1,94 +1,94 @@
 tests:
-  - name: team IDs and keys give Match Side Team Own OppTeam Opp rows
+  - name: team IDs and keys give Match Side Team OppTeam Own Opp rows
     args: ['={3;1}', '={2;4}', '={"G";"H"}', '={"H";"G"}', '={"M1";"M2"}']
     expected:
-      - ["M1", 1, "G", 3, "H", 2]
-      - ["M1", 2, "H", 2, "G", 3]
-      - ["M2", 1, "H", 1, "G", 4]
-      - ["M2", 2, "G", 4, "H", 1]
+      - ["M1", 1, "G", "H", 3, 2]
+      - ["M1", 2, "H", "G", 2, 3]
+      - ["M2", 1, "H", "G", 1, 4]
+      - ["M2", 2, "G", "H", 4, 1]
 
   - name: team IDs without keys start at Side
     args: ['={3;1}', '={2;4}', '={"G";"H"}', '={"H";"G"}']
     expected:
-      - [1, "G", 3, "H", 2]
-      - [2, "H", 2, "G", 3]
-      - [1, "H", 1, "G", 4]
-      - [2, "G", 4, "H", 1]
+      - [1, "G", "H", 3, 2]
+      - [2, "H", "G", 2, 3]
+      - [1, "H", "G", 1, 4]
+      - [2, "G", "H", 4, 1]
 
-  - name: basic with keys interleaves each match's two rows adjacently
+  - name: basic with keys pairs own and opp columns
     args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", '={"M1";"M2"}']
     expected:
-      - ["M1", 1, "Ann", 3, "Bob", 2]
-      - ["M1", 2, "Bob", 2, "Ann", 3]
-      - ["M2", 1, "Cat", 1, "Dan", 4]
-      - ["M2", 2, "Dan", 4, "Cat", 1]
+      - ["M1", 1, "Ann", "Bob", 3, 2]
+      - ["M1", 2, "Bob", "Ann", 2, 3]
+      - ["M2", 1, "Cat", "Dan", 1, 4]
+      - ["M2", 2, "Dan", "Cat", 4, 1]
 
-  - name: no keyCols yields Side plus own plus opp columns only
+  - name: no keyCols yields Side plus paired own opp columns only
     args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}']
     expected:
-      - [1, "Ann", 3, "Bob", 2]
-      - [2, "Bob", 2, "Ann", 3]
-      - [1, "Cat", 1, "Dan", 4]
-      - [2, "Dan", 4, "Cat", 1]
+      - [1, "Ann", "Bob", 3, 2]
+      - [2, "Bob", "Ann", 2, 3]
+      - [1, "Cat", "Dan", 1, 4]
+      - [2, "Dan", "Cat", 4, 1]
 
   - name: interleave FALSE stacks all side-1 rows then all side-2 rows
     args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", '={"M1";"M2"}', "=FALSE"]
     expected:
-      - ["M1", 1, "Ann", 3, "Bob", 2]
-      - ["M2", 1, "Cat", 1, "Dan", 4]
-      - ["M1", 2, "Bob", 2, "Ann", 3]
-      - ["M2", 2, "Dan", 4, "Cat", 1]
+      - ["M1", 1, "Ann", "Bob", 3, 2]
+      - ["M2", 1, "Cat", "Dan", 1, 4]
+      - ["M1", 2, "Bob", "Ann", 2, 3]
+      - ["M2", 2, "Dan", "Cat", 4, 1]
 
-  - name: default resultHeaders with IDs and keys includes Team and OppTeam
+  - name: default resultHeaders with IDs and keys pairs Team OppTeam then Own1 Opp1
     args: ['={3;1}', '={2;4}', '={"G";"H"}', '={"H";"G"}', '={"M1";"M2"}', "=", "=TRUE"]
     expected:
-      - ["Key1", "Side", "Team", "Own1", "OppTeam", "Opp1"]
-      - ["M1", 1, "G", 3, "H", 2]
-      - ["M1", 2, "H", 2, "G", 3]
-      - ["M2", 1, "H", 1, "G", 4]
-      - ["M2", 2, "G", 4, "H", 1]
+      - ["Key1", "Side", "Team", "OppTeam", "Own1", "Opp1"]
+      - ["M1", 1, "G", "H", 3, 2]
+      - ["M1", 2, "H", "G", 2, 3]
+      - ["M2", 1, "H", "G", 1, 4]
+      - ["M2", 2, "G", "H", 4, 1]
 
-  - name: default resultHeaders without IDs prepends Key1 Side Own Opp row
+  - name: default resultHeaders without IDs pairs Own1 Opp1 Own2 Opp2
     args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", '={"M1";"M2"}', "=", "=TRUE"]
     expected:
-      - ["Key1", "Side", "Own1", "Own2", "Opp1", "Opp2"]
-      - ["M1", 1, "Ann", 3, "Bob", 2]
-      - ["M1", 2, "Bob", 2, "Ann", 3]
-      - ["M2", 1, "Cat", 1, "Dan", 4]
-      - ["M2", 2, "Dan", 4, "Cat", 1]
+      - ["Key1", "Side", "Own1", "Opp1", "Own2", "Opp2"]
+      - ["M1", 1, "Ann", "Bob", 3, 2]
+      - ["M1", 2, "Bob", "Ann", 2, 3]
+      - ["M2", 1, "Cat", "Dan", 1, 4]
+      - ["M2", 2, "Dan", "Cat", 4, 1]
 
   - name: default resultHeaders without keys or IDs starts at Side
     args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", "=", "=", "=TRUE"]
     expected:
-      - ["Side", "Own1", "Own2", "Opp1", "Opp2"]
-      - [1, "Ann", 3, "Bob", 2]
-      - [2, "Bob", 2, "Ann", 3]
-      - [1, "Cat", 1, "Dan", 4]
-      - [2, "Dan", 4, "Cat", 1]
+      - ["Side", "Own1", "Opp1", "Own2", "Opp2"]
+      - [1, "Ann", "Bob", 3, 2]
+      - [2, "Bob", "Ann", 2, 3]
+      - [1, "Cat", "Dan", 1, 4]
+      - [2, "Dan", "Cat", 4, 1]
 
   - name: custom resultHeaders array
-    args: ['={3;1}', '={2;4}', '={"G";"H"}', '={"H";"G"}', '={"M1";"M2"}', "=", '={"Match","Side","Team","For","Opp","Against"}']
+    args: ['={3;1}', '={2;4}', '={"G";"H"}', '={"H";"G"}', '={"M1";"M2"}', "=", '={"Match","Side","Team","Opp","For","Against"}']
     expected:
-      - ["Match", "Side", "Team", "For", "Opp", "Against"]
-      - ["M1", 1, "G", 3, "H", 2]
-      - ["M1", 2, "H", 2, "G", 3]
-      - ["M2", 1, "H", 1, "G", 4]
-      - ["M2", 2, "G", 4, "H", 1]
+      - ["Match", "Side", "Team", "Opp", "For", "Against"]
+      - ["M1", 1, "G", "H", 3, 2]
+      - ["M1", 2, "H", "G", 2, 3]
+      - ["M2", 1, "H", "G", 1, 4]
+      - ["M2", 2, "G", "H", 4, 1]
 
   - name: multi-key columns repeat on both rows and header numbers them
     args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", '={"M1","Jan";"M2","Feb"}', "=", "=TRUE"]
     expected:
-      - ["Key1", "Key2", "Side", "Own1", "Own2", "Opp1", "Opp2"]
-      - ["M1", "Jan", 1, "Ann", 3, "Bob", 2]
-      - ["M1", "Jan", 2, "Bob", 2, "Ann", 3]
-      - ["M2", "Feb", 1, "Cat", 1, "Dan", 4]
-      - ["M2", "Feb", 2, "Dan", 4, "Cat", 1]
+      - ["Key1", "Key2", "Side", "Own1", "Opp1", "Own2", "Opp2"]
+      - ["M1", "Jan", 1, "Ann", "Bob", 3, 2]
+      - ["M1", "Jan", 2, "Bob", "Ann", 2, 3]
+      - ["M2", "Feb", 1, "Cat", "Dan", 1, 4]
+      - ["M2", "Feb", 2, "Dan", "Cat", 4, 1]
 
   - name: single match produces exactly two rows
     args: ['={"Ann",3}', '={"Bob",2}']
     expected:
-      - [1, "Ann", 3, "Bob", 2]
-      - [2, "Bob", 2, "Ann", 3]
+      - [1, "Ann", "Bob", 3, 2]
+      - [2, "Bob", "Ann", 2, 3]
 
   - name: single-column sides work
     args: ['={3;1}', '={2;4}']

--- a/lambdas/array/MATCHSPLIT.tests.yaml
+++ b/lambdas/array/MATCHSPLIT.tests.yaml
@@ -1,0 +1,86 @@
+tests:
+  - name: basic with keys interleaves each match's two rows adjacently
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1";"M2"}']
+    expected:
+      - ["M1", 1, "Ann", 3, "Bob", 2]
+      - ["M1", 2, "Bob", 2, "Ann", 3]
+      - ["M2", 1, "Cat", 1, "Dan", 4]
+      - ["M2", 2, "Dan", 4, "Cat", 1]
+
+  - name: no keyCols yields Side plus own plus opp columns only
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}']
+    expected:
+      - [1, "Ann", 3, "Bob", 2]
+      - [2, "Bob", 2, "Ann", 3]
+      - [1, "Cat", 1, "Dan", 4]
+      - [2, "Dan", 4, "Cat", 1]
+
+  - name: interleave FALSE stacks all side-1 rows then all side-2 rows
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1";"M2"}', "=FALSE"]
+    expected:
+      - ["M1", 1, "Ann", 3, "Bob", 2]
+      - ["M2", 1, "Cat", 1, "Dan", 4]
+      - ["M1", 2, "Bob", 2, "Ann", 3]
+      - ["M2", 2, "Dan", 4, "Cat", 1]
+
+  - name: default resultHeaders with keys prepends Key1 Side Own Opp row
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1";"M2"}', "=", "=TRUE"]
+    expected:
+      - ["Key1", "Side", "Own1", "Own2", "Opp1", "Opp2"]
+      - ["M1", 1, "Ann", 3, "Bob", 2]
+      - ["M1", 2, "Bob", 2, "Ann", 3]
+      - ["M2", 1, "Cat", 1, "Dan", 4]
+      - ["M2", 2, "Dan", 4, "Cat", 1]
+
+  - name: default resultHeaders without keys starts at Side
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', "=", "=", "=TRUE"]
+    expected:
+      - ["Side", "Own1", "Own2", "Opp1", "Opp2"]
+      - [1, "Ann", 3, "Bob", 2]
+      - [2, "Bob", 2, "Ann", 3]
+      - [1, "Cat", 1, "Dan", 4]
+      - [2, "Dan", 4, "Cat", 1]
+
+  - name: custom resultHeaders array
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1";"M2"}', "=", '={"Match","Side","Team","For","Opp","Against"}']
+    expected:
+      - ["Match", "Side", "Team", "For", "Opp", "Against"]
+      - ["M1", 1, "Ann", 3, "Bob", 2]
+      - ["M1", 2, "Bob", 2, "Ann", 3]
+      - ["M2", 1, "Cat", 1, "Dan", 4]
+      - ["M2", 2, "Dan", 4, "Cat", 1]
+
+  - name: multi-key columns repeat on both rows and header numbers them
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2;"Dan",4}', '={"M1","Jan";"M2","Feb"}', "=", "=TRUE"]
+    expected:
+      - ["Key1", "Key2", "Side", "Own1", "Own2", "Opp1", "Opp2"]
+      - ["M1", "Jan", 1, "Ann", 3, "Bob", 2]
+      - ["M1", "Jan", 2, "Bob", 2, "Ann", 3]
+      - ["M2", "Feb", 1, "Cat", 1, "Dan", 4]
+      - ["M2", "Feb", 2, "Dan", 4, "Cat", 1]
+
+  - name: single match produces exactly two rows
+    args: ['={"Ann",3}', '={"Bob",2}']
+    expected:
+      - [1, "Ann", 3, "Bob", 2]
+      - [2, "Bob", 2, "Ann", 3]
+
+  - name: single-column sides work
+    args: ['={3;1}', '={2;4}']
+    expected:
+      - [1, 3, 2]
+      - [2, 2, 3]
+      - [1, 1, 4]
+      - [2, 4, 1]
+
+  - name: row-count mismatch returns VALUE error
+    args: ['={"Ann",3;"Cat",1}', '={"Bob",2}']
+    expected: -2146826273
+
+  - name: width mismatch returns VALUE error
+    args: ['={"Ann",3;"Cat",1}', '={"Bob";"Dan"}']
+    expected: -2146826273
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

New `array` library LAMBDA: `MATCHSPLIT(sideA, sideB, [teamIdA], [teamIdB], [keyCols], [interleave], [resultHeaders])`.

Flattens a sports/league-style match table (one row per match, two symmetric side blocks) into one row per team per match — keys, explicit Side column (1 = listed first, 2 = listed second), then own/opponent column pairs: Team, OppTeam, Own1, Opp1, Own2, Opp2, ... "Score for team G in match 3" becomes a plain two-column filter; no opponent-score self-XLOOKUP.

## Design notes

- Core: VSTACK of the two perspectives, with the team-ID columns swapping sides exactly like the value blocks.
- Own/opp columns are paired adjacently via `CHOOSECOLS` over a column-major `TOROW(VSTACK(1..W, W+1..2W), , TRUE)` index, applied to both data blocks and the default header.
- `interleave` (default TRUE) pairs each match's two rows adjacently via `CHOOSEROWS` over a row-major `TOCOL` index — no sort needed.
- `resultHeaders` follows UNPIVOT's convention: TRUE gives default `Key1..KeyK, Side, Team, OppTeam, Own1, Opp1, ...` (Team/OppTeam only when IDs supplied); a custom array is used verbatim.
- Shape guards return `#VALUE!`: mismatched sideA/sideB shapes, a lone teamId column (must supply both or neither), or IDs whose row count/width is wrong — protects against mis-selected ranges instead of silently padding with `#N/A`.
- No array-lift dispatcher: all inputs are array-shaped by design.

## Testing

- Format validation: 816 passed.
- `LAMBDA_FILTER=MATCHSPLIT`: 17/17 passed (IDs with/without keys, keys/no-keys, interleave FALSE, default + custom headers, multi-key, single match, single-column sides, four shape-error cases, help).
- Full harness suite: 956 passed, 0 failed.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)