### PR TITLE
Add NEIGHBOURS - addresses of all cells within a distance of a centre cell

### DIFF
--- a/lambdas/maps/NEIGHBOURS.lambda
+++ b/lambdas/maps/NEIGHBOURS.lambda
@@ -1,0 +1,56 @@
+/*  FUNCTION NAME:      NEIGHBOURS
+    DESCRIPTION:*//**Returns the A1-style addresses of all cells within a given distance of a centre cell (Manhattan, Chebyshev, or Euclidean), excluding the centre.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-08-08  Claude      Initial version
+*/
+NEIGHBOURS = LAMBDA(
+//  Parameter Declarations
+    [centerCell],
+    [distance],
+    [metric],
+    [grid],
+    [origin],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →NEIGHBOURS(centerCell, [distance], [metric], [grid], [origin])¶" &
+                "DESCRIPTION:   →Returns the A1-style addresses of all cells within a given distance of a centre cell, excluding the centre itself. Result is a column of addresses in reading order (row by row, left to right); #N/A when no cells qualify.¶" &
+                "VERSION:       →Aug 08 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   centerCell     →(Required) Centre cell address as text (e.g. ""C3""), or a cell containing one. Scalar only.¶" &
+                "   distance       →(Optional) Maximum distance from the centre; cells with 0 < dist <= distance are returned. Default 1. Non-integer values are meaningful for the Euclidean metric (e.g. 1.5 includes diagonals).¶" &
+                "   metric         →(Optional) Distance metric: 0 Manhattan (default, 4-directional), 1 Chebyshev (8-directional, diagonals count as 1), 2 Euclidean (straight-line). Mirrors CELLDIST.¶" &
+                "   grid           →(Optional) A grid range or array bounding the result - neighbours outside it are dropped. Omitted, results are bounded only by the sheet edges.¶" &
+                "   origin         →(Optional) Top-left anchor as a workbook reference - a single cell or a range (a range's top-left is used). Anchors an in-memory grid to a worksheet position - matches GRIDAREA/SUBGRID convention. Ignored when grid is omitted. Defaults to the grid's own top-left - inferred for a reference, (1,1) for an array.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=NEIGHBOURS(""C3"")¶" &
+                "Result         →C2, B3, D3, C4 (column of the 4 Manhattan neighbours)",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(centerCell),
+    //  Procedure
+        safeMult, 16385,
+        rad, IF(ISOMITTED(distance), 1, @distance),
+        met, IF(ISOMITTED(metric), 0, @metric),
+        pos, CELLTOPOS(@centerCell, safeMult),
+        ctrRow, INT(pos / safeMult),
+        ctrCol, MOD(pos, safeMult),
+        span, INT(rad),
+        dRow, SEQUENCE(2 * span + 1, 1, -span),
+        dCol, SEQUENCE(1, 2 * span + 1, -span),
+        distGrid, IF(met = 2, SQRT(dRow ^ 2 + dCol ^ 2),
+                  IF(met = 1, IF(ABS(dRow) > ABS(dCol), ABS(dRow), ABS(dCol)),
+                              ABS(dRow) + ABS(dCol))),
+        cellRow, ctrRow + dRow,
+        cellCol, ctrCol + dCol,
+        baseRow, IF(ISOMITTED(grid), 1, IF(ISOMITTED(origin), IFERROR(MIN(ROW(grid)), 1), MIN(ROW(origin)))),
+        baseCol, IF(ISOMITTED(grid), 1, IF(ISOMITTED(origin), IFERROR(MIN(COLUMN(grid)), 1), MIN(COLUMN(origin)))),
+        maxRow, IF(ISOMITTED(grid), 1048576, baseRow + ROWS(grid) - 1),
+        maxCol, IF(ISOMITTED(grid), 16384, baseCol + COLUMNS(grid) - 1),
+        inBounds, (cellRow >= baseRow) * (cellRow <= maxRow) * (cellCol >= baseCol) * (cellCol <= maxCol),
+        keep, (distGrid > 0) * (distGrid <= rad) * inBounds,
+        addrGrid, ADDRESS(cellRow, cellCol, 4),
+        result, IFERROR(TOCOL(IF(keep = 1, addrGrid, NA()), 2), NA()),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/NEIGHBOURS.tests.yaml
+++ b/lambdas/maps/NEIGHBOURS.tests.yaml
@@ -1,0 +1,52 @@
+tests:
+  - name: manhattan default distance 1
+    args: ["C3"]
+    expected: [["C2"], ["B3"], ["D3"], ["C4"]]
+
+  - name: chebyshev distance 1 gives 8 neighbours
+    args: ["C3", "=1", "=1"]
+    expected: [["B2"], ["C2"], ["D2"], ["B3"], ["D3"], ["B4"], ["C4"], ["D4"]]
+
+  - name: manhattan distance 2 gives diamond
+    args: ["C3", "=2"]
+    expected: [["C1"], ["B2"], ["C2"], ["D2"], ["A3"], ["B3"], ["D3"], ["E3"], ["B4"], ["C4"], ["D4"], ["C5"]]
+
+  - name: euclidean distance 2 gives disc
+    args: ["C3", "=2", "=2"]
+    expected: [["C1"], ["B2"], ["C2"], ["D2"], ["A3"], ["B3"], ["D3"], ["E3"], ["B4"], ["C4"], ["D4"], ["C5"]]
+
+  - name: euclidean distance 1.5 includes diagonals
+    args: ["C3", "=1.5", "=2"]
+    expected: [["B2"], ["C2"], ["D2"], ["B3"], ["D3"], ["B4"], ["C4"], ["D4"]]
+
+  - name: sheet edges clamp at A1
+    args: ["A1"]
+    expected: [["B1"], ["A2"]]
+
+  - name: grid bounds clamp neighbours
+    args: ["C3", "=1", "=1", "=SEQUENCE(3,3)"]
+    expected: [["B2"], ["C2"], ["B3"]]
+
+  - name: origin anchors in-memory grid bounds
+    args: ["E5", "=1", "=0", "=SEQUENCE(3,3)", "=E5"]
+    expected: [["F5"], ["E6"]]
+
+  - name: distance 0 returns NA
+    args: ["C3", "=0"]
+    expected: -2146826246
+
+  - name: 1x1 array centre behaves as scalar
+    args: ['=CHOOSEROWS({"C3";"Z9"},1)']
+    expected: [["C2"], ["B3"], ["D3"], ["C4"]]
+
+  - name: 1x1 array distance behaves as scalar
+    args: ["C3", "=CHOOSEROWS({2;9},1)"]
+    expected: [["C1"], ["B2"], ["C2"], ["D2"], ["A3"], ["B3"], ["D3"], ["E3"], ["B4"], ["C4"], ["D4"], ["C5"]]
+
+  - name: multi-letter column centre
+    args: ["AA10"]
+    expected: [["AA9"], ["Z10"], ["AB10"], ["AA11"]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
## Summary

New MAPS lambda **NEIGHBOURS(centerCell, [distance], [metric], [grid], [origin])** — returns a column of A1-style addresses for every cell with `0 < dist <= distance` from the centre cell, excluding the centre itself, in reading order (row by row, left to right).

- **metric** mirrors CELLDIST: 0 Manhattan (default), 1 Chebyshev, 2 Euclidean. Non-integer distances are meaningful for Euclidean (e.g. 1.5 includes diagonals).
- **grid** (optional) bounds the result; **origin** anchors an in-memory grid per the GRIDAREA/SUBGRID reference-anchor convention. Omitted, only sheet edges clamp.
- Returns #N/A when no cells qualify (e.g. distance 0).
- Scalar params are @-dereffed against 1x1-array poisoning (#318 family); output is inherently an array so no lifting dispatcher.

## Testing

- Format validation: 840 passed
- NEIGHBOURS harness tests: 13/13 passed (all three metrics, sheet-edge + grid + origin clamping, 1x1-array centre and distance, multi-letter column, NA case, help)
- Full harness suite: 998 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)