### PR TITLE
Add BYRECTANGLE and MASK grid lambdas

### DIFF
--- a/lambdas/maps/BYRECTANGLE.lambda
+++ b/lambdas/maps/BYRECTANGLE.lambda
@@ -1,0 +1,54 @@
+/*  FUNCTION NAME:      BYRECTANGLE
+    DESCRIPTION:*//**Applies an operation (default SUM) to every rows x cols sub-rectangle of grid, as sliding windows or non-overlapping tiles.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-08-20  Claude      Initial version
+*/
+BYRECTANGLE = LAMBDA(
+//  Parameter Declarations
+    [grid],
+    [rows],
+    [cols],
+    [operation],
+    [mode],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →BYRECTANGLE(grid, [rows], [cols], [operation], [mode])¶" &
+                "DESCRIPTION:   →Applies an operation (default SUM) to every rows x cols sub-rectangle of grid, as sliding windows or non-overlapping tiles.¶" &
+                "VERSION:       →Aug 20 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   grid           →(Required) Grid to window over - an array or a real range. When a real range is passed, operation receives true sub-range references, so reference-only functions like SUBTOTAL work.¶" &
+                "   rows           →(Optional) Window height. Default 1.¶" &
+                "   cols           →(Optional) Window width. Default 1.¶" &
+                "   operation      →(Optional) LAMBDA(area) returning a scalar, applied to each sub-rectangle. Built-ins can be passed by name (e.g. MAX). Default SUM.¶" &
+                "   mode           →(Optional) (0) sliding [default] - every overlapping window, output is (R-rows+1) x (C-cols+1); (1) tiles - non-overlapping blocks from the top-left, output is ROUNDUP(R/rows) x ROUNDUP(C/cols) with partial edge tiles included.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=BYRECTANGLE(SEQUENCE(3,3), 2, 2)¶" &
+                "Result         →{12,16;24,28}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(grid),
+    //  Procedure
+        winRows, IF(ISOMITTED(rows), 1, rows),
+        winCols, IF(ISOMITTED(cols), 1, cols),
+        fn, IF(ISOMITTED(operation), SUM, operation),
+        tiled, IF(ISOMITTED(mode), 0, mode) = 1,
+        gridRows, ROWS(grid),
+        gridCols, COLUMNS(grid),
+    //  Real-range input gets true sub-range references via OFFSET; arrays get INDEX slices
+        slice, IF(ISREF(grid),
+                  LAMBDA(topRow, leftCol, height, width, OFFSET(grid, topRow - 1, leftCol - 1, height, width)),
+                  LAMBDA(topRow, leftCol, height, width, INDEX(grid, SEQUENCE(height, 1, topRow), SEQUENCE(1, width, leftCol)))),
+        outRows, IF(tiled, ROUNDUP(gridRows / winRows, 0), gridRows - winRows + 1),
+        outCols, IF(tiled, ROUNDUP(gridCols / winCols, 0), gridCols - winCols + 1),
+    //  Loud failure: a window larger than the grid errors rather than clips
+        result, IF(OR(winRows > gridRows, winCols > gridCols), NA(),
+                   MAKEARRAY(outRows, outCols, LAMBDA(rIdx, cIdx,
+                       LET(topRow, IF(tiled, (rIdx - 1) * winRows + 1, rIdx),
+                           leftCol, IF(tiled, (cIdx - 1) * winCols + 1, cIdx),
+                           height, IF(tiled, MIN(winRows, gridRows - topRow + 1), winRows),
+                           width, IF(tiled, MIN(winCols, gridCols - leftCol + 1), winCols),
+                           fn(slice(topRow, leftCol, height, width)))))),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/BYRECTANGLE.tests.yaml
+++ b/lambdas/maps/BYRECTANGLE.tests.yaml
@@ -1,0 +1,62 @@
+tests:
+  - name: default 1x1 window with default SUM is identity
+    args: ['={1,2;3,4}']
+    expected: [[1, 2], [3, 4]]
+
+  - name: 2x2 sliding sums over 3x3 grid
+    args: ['=SEQUENCE(3,3)', '=2', '=2']
+    expected: [[12, 16], [24, 28]]
+
+  - name: 2x2 sliding max via custom operation
+    args: ['=SEQUENCE(3,3)', '=2', '=2', '=LAMBDA(area, MAX(area))']
+    expected: [[5, 6], [8, 9]]
+
+  - name: built-in passed by name as operation
+    args: ['=SEQUENCE(3,3)', '=2', '=2', '=MIN']
+    expected: [[1, 2], [4, 5]]
+
+  - name: 1x3 horizontal sliding window (moving sum along a row)
+    args: ['={1,2,3,4,5}', '=1', '=3']
+    expected: [[6, 9, 12]]
+
+  - name: tiling mode 2x2 over 4x4
+    args: ['=SEQUENCE(4,4)', '=2', '=2', '=', '=1']
+    expected: [[14, 22], [46, 54]]
+
+  - name: tiling includes partial edge tiles on 3x3
+    args: ['=SEQUENCE(3,3)', '=2', '=2', '=', '=1']
+    expected: [[12, 9], [15, 9]]
+
+  - name: real range input via named range
+    setup:
+      cells:
+        - address: "E3:G5"
+          values:
+            - [1, 2, 3]
+            - [4, 5, 6]
+            - [7, 8, 9]
+      names:
+        - { name: "testGrid", refers_to: "E3:G5" }
+    args: ["=testGrid", "=2", "=2"]
+    expected: [[12, 16], [24, 28]]
+
+  - name: real range input hands operation a true reference (SUBTOTAL works)
+    setup:
+      cells:
+        - address: "E3:G5"
+          values:
+            - [1, 2, 3]
+            - [4, 5, 6]
+            - [7, 8, 9]
+      names:
+        - { name: "testGrid", refers_to: "E3:G5" }
+    args: ["=testGrid", "=2", "=2", "=LAMBDA(area, SUBTOTAL(9, area))"]
+    expected: [[12, 16], [24, 28]]
+
+  - name: window larger than grid returns NA
+    args: ['={1,2;3,4}', '=3', '=3']
+    expected: -2146826246
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/maps/MASK.lambda
+++ b/lambdas/maps/MASK.lambda
@@ -1,21 +1,24 @@
 /*  FUNCTION NAME:      MASK
-    DESCRIPTION:*//**Builds a 2d mask of 1s and 0s sized to grid: cross, diagonals, star, circle, triangles, border, diamond or checkerboard.*/
+    DESCRIPTION:*//**Builds a 2d mask of 1s and 0s sized to grid: cross, diagonals, star, circle, half-area triangle, border, diamond or checkerboard.*/
 /*  REVISIONS:          Date        Developer   Description
                         2026-08-20  Claude      Initial version
+                        2026-08-20  Claude      Split type into shape + rotation; triangle is now a right-angled half-area triangle oriented by rotation
 */
 MASK = LAMBDA(
 //  Parameter Declarations
     [grid],
-    [type],
+    [shape],
+    [rotation],
     [invert],
 //  Help
     LET(Help, TEXTSPLIT(
-                "FUNCTION:      →MASK(grid, [type], [invert])¶" &
-                "DESCRIPTION:   →Builds a 2d mask of 1s and 0s sized to grid: cross, diagonals, star, circle, triangles, border, diamond or checkerboard. Shapes are centred and scale to the grid's dimensions.¶" &
+                "FUNCTION:      →MASK(grid, [shape], [rotation], [invert])¶" &
+                "DESCRIPTION:   →Builds a 2d mask of 1s and 0s sized to grid: cross, diagonals, star, circle, half-area triangle, border, diamond or checkerboard. Shapes are centred and scale to the grid's dimensions.¶" &
                 "VERSION:       →Aug 20 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   grid           →(Required) Grid whose dimensions size the mask; its values are ignored.¶" &
-                "   type           →(Optional) Shape: (0) cross [default], (1) diagonals (X), (2) star (cross + X), (3) circle (ellipse on non-square grids), (4) triangle up, (5) triangle right, (6) triangle down, (7) triangle left, (8) border, (9) diamond, (10) checkerboard. Any other value returns #N/A.¶" &
+                "   shape          →(Optional) Shape: (0) cross [default], (1) diagonals (X), (2) star (cross + X), (3) circle (ellipse on non-square grids), (4) triangle (right-angled, covers half the area, diagonal included), (5) border, (6) diamond, (7) checkerboard. Any other value returns #N/A.¶" &
+                "   rotation       →(Optional) Quarter-turns clockwise from the shape's default orientation; wraps mod 4, so -1 is one turn anticlockwise. Only triangle is orientation-sensitive - right angle at: (0) bottom-left [default], (1) top-left, (2) top-right, (3) bottom-right. The other shapes are rotation-symmetric and ignore it.¶" &
                 "   invert         →(Optional) (0) as-is [default], (1) swap the 1s and 0s. TRUE is also accepted.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=MASK(SEQUENCE(3,3), 0)¶" &
@@ -25,7 +28,8 @@ MASK = LAMBDA(
     //  Check inputs
         Help?, ISOMITTED(grid),
     //  Procedure
-        maskType, IF(ISOMITTED(type), 0, type),
+        maskShape, IF(ISOMITTED(shape), 0, shape),
+        rot, MOD(IF(ISOMITTED(rotation), 0, rotation), 4),
         inv, N(IF(ISOMITTED(invert), 0, invert)),
         nRows, ROWS(grid),
         nCols, COLUMNS(grid),
@@ -35,7 +39,6 @@ MASK = LAMBDA(
         ctrCol, (nCols + 1) / 2,
     //  Degenerate-dimension guards: spans avoid divide-by-zero on 1-row / 1-col grids
         spanRows, MAX(nRows - 1, 1),
-        spanCols, MAX(nCols - 1, 1),
         halfRows, (nRows - 1) / 2,
         halfCols, (nCols - 1) / 2,
     //  Shape predicates (booleans, broadcast to nRows x nCols)
@@ -47,24 +50,22 @@ MASK = LAMBDA(
         diagMask, (mainDiag + antiDiag) > 0,
         starMask, (crossMask + diagMask) > 0,
         circleMask, ((rowIdx - ctrRow) / (nRows / 2))^2 + ((colIdx - ctrCol) / (nCols / 2))^2 <= 1,
-        triUp, ABS(colIdx - ctrCol) <= (rowIdx - 1) * halfCols / spanRows,
-        triRight, ABS(rowIdx - ctrRow) <= (nCols - colIdx) * halfRows / spanCols,
-        triDown, ABS(colIdx - ctrCol) <= (nRows - rowIdx) * halfCols / spanRows,
-        triLeft, ABS(rowIdx - ctrRow) <= (colIdx - 1) * halfRows / spanCols,
+    //  Right-angled half-area triangle, hypotenuse scaled to the grid; rot picks the right-angle corner
+        triMask, IFS(rot = 0, (colIdx - 1) * (nRows - 1) <= (rowIdx - 1) * (nCols - 1),
+                     rot = 1, (colIdx - 1) * (nRows - 1) <= (nRows - rowIdx) * (nCols - 1),
+                     rot = 2, (colIdx - 1) * (nRows - 1) >= (rowIdx - 1) * (nCols - 1),
+                     TRUE, (colIdx - 1) * (nRows - 1) >= (nRows - rowIdx) * (nCols - 1)),
         borderMask, ((rowIdx = 1) + (rowIdx = nRows) + (colIdx = 1) + (colIdx = nCols)) > 0,
         diamondMask, ABS(rowIdx - ctrRow) / MAX(halfRows, 0.5) + ABS(colIdx - ctrCol) / MAX(halfCols, 0.5) <= 1,
         checkerMask, MOD(rowIdx + colIdx, 2) = 0,
-        chosen, IFS(maskType = 0, crossMask,
-                    maskType = 1, diagMask,
-                    maskType = 2, starMask,
-                    maskType = 3, circleMask,
-                    maskType = 4, triUp,
-                    maskType = 5, triRight,
-                    maskType = 6, triDown,
-                    maskType = 7, triLeft,
-                    maskType = 8, borderMask,
-                    maskType = 9, diamondMask,
-                    maskType = 10, checkerMask,
+        chosen, IFS(maskShape = 0, crossMask,
+                    maskShape = 1, diagMask,
+                    maskShape = 2, starMask,
+                    maskShape = 3, circleMask,
+                    maskShape = 4, triMask,
+                    maskShape = 5, borderMask,
+                    maskShape = 6, diamondMask,
+                    maskShape = 7, checkerMask,
                     TRUE, NA()),
         bits, --(chosen),
         result, IF(inv = 1, 1 - bits, bits),

--- a/lambdas/maps/MASK.lambda
+++ b/lambdas/maps/MASK.lambda
@@ -1,0 +1,73 @@
+/*  FUNCTION NAME:      MASK
+    DESCRIPTION:*//**Builds a 2d mask of 1s and 0s sized to grid: cross, diagonals, star, circle, triangles, border, diamond or checkerboard.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-08-20  Claude      Initial version
+*/
+MASK = LAMBDA(
+//  Parameter Declarations
+    [grid],
+    [type],
+    [invert],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →MASK(grid, [type], [invert])¶" &
+                "DESCRIPTION:   →Builds a 2d mask of 1s and 0s sized to grid: cross, diagonals, star, circle, triangles, border, diamond or checkerboard. Shapes are centred and scale to the grid's dimensions.¶" &
+                "VERSION:       →Aug 20 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   grid           →(Required) Grid whose dimensions size the mask; its values are ignored.¶" &
+                "   type           →(Optional) Shape: (0) cross [default], (1) diagonals (X), (2) star (cross + X), (3) circle (ellipse on non-square grids), (4) triangle up, (5) triangle right, (6) triangle down, (7) triangle left, (8) border, (9) diamond, (10) checkerboard. Any other value returns #N/A.¶" &
+                "   invert         →(Optional) (0) as-is [default], (1) swap the 1s and 0s. TRUE is also accepted.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=MASK(SEQUENCE(3,3), 0)¶" &
+                "Result         →{0,1,0;1,1,1;0,1,0}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(grid),
+    //  Procedure
+        maskType, IF(ISOMITTED(type), 0, type),
+        inv, N(IF(ISOMITTED(invert), 0, invert)),
+        nRows, ROWS(grid),
+        nCols, COLUMNS(grid),
+        rowIdx, SEQUENCE(nRows),
+        colIdx, SEQUENCE(1, nCols),
+        ctrRow, (nRows + 1) / 2,
+        ctrCol, (nCols + 1) / 2,
+    //  Degenerate-dimension guards: spans avoid divide-by-zero on 1-row / 1-col grids
+        spanRows, MAX(nRows - 1, 1),
+        spanCols, MAX(nCols - 1, 1),
+        halfRows, (nRows - 1) / 2,
+        halfCols, (nCols - 1) / 2,
+    //  Shape predicates (booleans, broadcast to nRows x nCols)
+        onCtrRow, ABS(rowIdx - ctrRow) < 1,
+        onCtrCol, ABS(colIdx - ctrCol) < 1,
+        crossMask, (onCtrRow + onCtrCol) > 0,
+        mainDiag, ROUND((rowIdx - 1) * (nCols - 1) / spanRows, 0) = (colIdx - 1),
+        antiDiag, ROUND((nCols - 1) - (rowIdx - 1) * (nCols - 1) / spanRows, 0) = (colIdx - 1),
+        diagMask, (mainDiag + antiDiag) > 0,
+        starMask, (crossMask + diagMask) > 0,
+        circleMask, ((rowIdx - ctrRow) / (nRows / 2))^2 + ((colIdx - ctrCol) / (nCols / 2))^2 <= 1,
+        triUp, ABS(colIdx - ctrCol) <= (rowIdx - 1) * halfCols / spanRows,
+        triRight, ABS(rowIdx - ctrRow) <= (nCols - colIdx) * halfRows / spanCols,
+        triDown, ABS(colIdx - ctrCol) <= (nRows - rowIdx) * halfCols / spanRows,
+        triLeft, ABS(rowIdx - ctrRow) <= (colIdx - 1) * halfRows / spanCols,
+        borderMask, ((rowIdx = 1) + (rowIdx = nRows) + (colIdx = 1) + (colIdx = nCols)) > 0,
+        diamondMask, ABS(rowIdx - ctrRow) / MAX(halfRows, 0.5) + ABS(colIdx - ctrCol) / MAX(halfCols, 0.5) <= 1,
+        checkerMask, MOD(rowIdx + colIdx, 2) = 0,
+        chosen, IFS(maskType = 0, crossMask,
+                    maskType = 1, diagMask,
+                    maskType = 2, starMask,
+                    maskType = 3, circleMask,
+                    maskType = 4, triUp,
+                    maskType = 5, triRight,
+                    maskType = 6, triDown,
+                    maskType = 7, triLeft,
+                    maskType = 8, borderMask,
+                    maskType = 9, diamondMask,
+                    maskType = 10, checkerMask,
+                    TRUE, NA()),
+        bits, --(chosen),
+        result, IF(inv = 1, 1 - bits, bits),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/MASK.tests.yaml
+++ b/lambdas/maps/MASK.tests.yaml
@@ -1,0 +1,72 @@
+tests:
+  - name: cross on 5x5 (default type)
+    args: ['=SEQUENCE(5,5)']
+    expected: [[0, 0, 1, 0, 0], [0, 0, 1, 0, 0], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0], [0, 0, 1, 0, 0]]
+
+  - name: cross on even 4x4 uses the two centre rows and columns
+    args: ['=SEQUENCE(4,4)', '=0']
+    expected: [[0, 1, 1, 0], [1, 1, 1, 1], [1, 1, 1, 1], [0, 1, 1, 0]]
+
+  - name: diagonals X on 5x5
+    args: ['=SEQUENCE(5,5)', '=1']
+    expected: [[1, 0, 0, 0, 1], [0, 1, 0, 1, 0], [0, 0, 1, 0, 0], [0, 1, 0, 1, 0], [1, 0, 0, 0, 1]]
+
+  - name: diagonals scale on non-square 3x5
+    args: ['=SEQUENCE(3,5)', '=1']
+    expected: [[1, 0, 0, 0, 1], [0, 0, 1, 0, 0], [1, 0, 0, 0, 1]]
+
+  - name: star on 5x5 combines cross and X
+    args: ['=SEQUENCE(5,5)', '=2']
+    expected: [[1, 0, 1, 0, 1], [0, 1, 1, 1, 0], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0], [1, 0, 1, 0, 1]]
+
+  - name: circle on 5x5
+    args: ['=SEQUENCE(5,5)', '=3']
+    expected: [[0, 1, 1, 1, 0], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0]]
+
+  - name: triangle up on 5x5
+    args: ['=SEQUENCE(5,5)', '=4']
+    expected: [[0, 0, 1, 0, 0], [0, 0, 1, 0, 0], [0, 1, 1, 1, 0], [0, 1, 1, 1, 0], [1, 1, 1, 1, 1]]
+
+  - name: triangle right on 5x5
+    args: ['=SEQUENCE(5,5)', '=5']
+    expected: [[1, 0, 0, 0, 0], [1, 1, 1, 0, 0], [1, 1, 1, 1, 1], [1, 1, 1, 0, 0], [1, 0, 0, 0, 0]]
+
+  - name: triangle down on 5x5
+    args: ['=SEQUENCE(5,5)', '=6']
+    expected: [[1, 1, 1, 1, 1], [0, 1, 1, 1, 0], [0, 1, 1, 1, 0], [0, 0, 1, 0, 0], [0, 0, 1, 0, 0]]
+
+  - name: triangle left on 5x5
+    args: ['=SEQUENCE(5,5)', '=7']
+    expected: [[0, 0, 0, 0, 1], [0, 0, 1, 1, 1], [1, 1, 1, 1, 1], [0, 0, 1, 1, 1], [0, 0, 0, 0, 1]]
+
+  - name: border on 4x4
+    args: ['=SEQUENCE(4,4)', '=8']
+    expected: [[1, 1, 1, 1], [1, 0, 0, 1], [1, 0, 0, 1], [1, 1, 1, 1]]
+
+  - name: diamond on 5x5
+    args: ['=SEQUENCE(5,5)', '=9']
+    expected: [[0, 0, 1, 0, 0], [0, 1, 1, 1, 0], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0], [0, 0, 1, 0, 0]]
+
+  - name: checkerboard on 3x3
+    args: ['=SEQUENCE(3,3)', '=10']
+    expected: [[1, 0, 1], [0, 1, 0], [1, 0, 1]]
+
+  - name: inverted cross on 3x3
+    args: ['=SEQUENCE(3,3)', '=0', '=1']
+    expected: [[1, 0, 1], [0, 0, 0], [1, 0, 1]]
+
+  - name: invert accepts TRUE
+    args: ['=SEQUENCE(3,3)', '=0', '=TRUE']
+    expected: [[1, 0, 1], [0, 0, 0], [1, 0, 1]]
+
+  - name: single-row grid cross fills the row
+    args: ['={1,2,3,4,5}', '=0']
+    expected: [[1, 1, 1, 1, 1]]
+
+  - name: unknown type returns NA
+    args: ['=SEQUENCE(3,3)', '=99']
+    expected: -2146826246
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/maps/MASK.tests.yaml
+++ b/lambdas/maps/MASK.tests.yaml
@@ -1,11 +1,15 @@
 tests:
-  - name: cross on 5x5 (default type)
+  - name: cross on 5x5 (default shape)
     args: ['=SEQUENCE(5,5)']
     expected: [[0, 0, 1, 0, 0], [0, 0, 1, 0, 0], [1, 1, 1, 1, 1], [0, 0, 1, 0, 0], [0, 0, 1, 0, 0]]
 
   - name: cross on even 4x4 uses the two centre rows and columns
     args: ['=SEQUENCE(4,4)', '=0']
     expected: [[0, 1, 1, 0], [1, 1, 1, 1], [1, 1, 1, 1], [0, 1, 1, 0]]
+
+  - name: rotation is ignored by symmetric shapes
+    args: ['=SEQUENCE(3,3)', '=0', '=1']
+    expected: [[0, 1, 0], [1, 1, 1], [0, 1, 0]]
 
   - name: diagonals X on 5x5
     args: ['=SEQUENCE(5,5)', '=1']
@@ -23,47 +27,59 @@ tests:
     args: ['=SEQUENCE(5,5)', '=3']
     expected: [[0, 1, 1, 1, 0], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0]]
 
-  - name: triangle up on 5x5
+  - name: triangle default rotation has right angle bottom-left
     args: ['=SEQUENCE(5,5)', '=4']
-    expected: [[0, 0, 1, 0, 0], [0, 0, 1, 0, 0], [0, 1, 1, 1, 0], [0, 1, 1, 1, 0], [1, 1, 1, 1, 1]]
+    expected: [[1, 0, 0, 0, 0], [1, 1, 0, 0, 0], [1, 1, 1, 0, 0], [1, 1, 1, 1, 0], [1, 1, 1, 1, 1]]
 
-  - name: triangle right on 5x5
-    args: ['=SEQUENCE(5,5)', '=5']
-    expected: [[1, 0, 0, 0, 0], [1, 1, 1, 0, 0], [1, 1, 1, 1, 1], [1, 1, 1, 0, 0], [1, 0, 0, 0, 0]]
+  - name: triangle rotation 1 has right angle top-left
+    args: ['=SEQUENCE(5,5)', '=4', '=1']
+    expected: [[1, 1, 1, 1, 1], [1, 1, 1, 1, 0], [1, 1, 1, 0, 0], [1, 1, 0, 0, 0], [1, 0, 0, 0, 0]]
 
-  - name: triangle down on 5x5
-    args: ['=SEQUENCE(5,5)', '=6']
-    expected: [[1, 1, 1, 1, 1], [0, 1, 1, 1, 0], [0, 1, 1, 1, 0], [0, 0, 1, 0, 0], [0, 0, 1, 0, 0]]
+  - name: triangle rotation 2 has right angle top-right
+    args: ['=SEQUENCE(5,5)', '=4', '=2']
+    expected: [[1, 1, 1, 1, 1], [0, 1, 1, 1, 1], [0, 0, 1, 1, 1], [0, 0, 0, 1, 1], [0, 0, 0, 0, 1]]
 
-  - name: triangle left on 5x5
-    args: ['=SEQUENCE(5,5)', '=7']
-    expected: [[0, 0, 0, 0, 1], [0, 0, 1, 1, 1], [1, 1, 1, 1, 1], [0, 0, 1, 1, 1], [0, 0, 0, 0, 1]]
+  - name: triangle rotation 3 has right angle bottom-right
+    args: ['=SEQUENCE(5,5)', '=4', '=3']
+    expected: [[0, 0, 0, 0, 1], [0, 0, 0, 1, 1], [0, 0, 1, 1, 1], [0, 1, 1, 1, 1], [1, 1, 1, 1, 1]]
+
+  - name: negative rotation wraps (-1 = rotation 3)
+    args: ['=SEQUENCE(5,5)', '=4', '=-1']
+    expected: [[0, 0, 0, 0, 1], [0, 0, 0, 1, 1], [0, 0, 1, 1, 1], [0, 1, 1, 1, 1], [1, 1, 1, 1, 1]]
+
+  - name: triangle hypotenuse scales on non-square 3x5
+    args: ['=SEQUENCE(3,5)', '=4']
+    expected: [[1, 0, 0, 0, 0], [1, 1, 1, 0, 0], [1, 1, 1, 1, 1]]
+
+  - name: single-row triangle degenerates to a full row
+    args: ['={1,2,3}', '=4']
+    expected: [[1, 1, 1]]
 
   - name: border on 4x4
-    args: ['=SEQUENCE(4,4)', '=8']
+    args: ['=SEQUENCE(4,4)', '=5']
     expected: [[1, 1, 1, 1], [1, 0, 0, 1], [1, 0, 0, 1], [1, 1, 1, 1]]
 
   - name: diamond on 5x5
-    args: ['=SEQUENCE(5,5)', '=9']
+    args: ['=SEQUENCE(5,5)', '=6']
     expected: [[0, 0, 1, 0, 0], [0, 1, 1, 1, 0], [1, 1, 1, 1, 1], [0, 1, 1, 1, 0], [0, 0, 1, 0, 0]]
 
   - name: checkerboard on 3x3
-    args: ['=SEQUENCE(3,3)', '=10']
+    args: ['=SEQUENCE(3,3)', '=7']
     expected: [[1, 0, 1], [0, 1, 0], [1, 0, 1]]
 
-  - name: inverted cross on 3x3
-    args: ['=SEQUENCE(3,3)', '=0', '=1']
+  - name: inverted cross on 3x3 (rotation omitted mid-args)
+    args: ['=SEQUENCE(3,3)', '=0', '=', '=1']
     expected: [[1, 0, 1], [0, 0, 0], [1, 0, 1]]
 
   - name: invert accepts TRUE
-    args: ['=SEQUENCE(3,3)', '=0', '=TRUE']
+    args: ['=SEQUENCE(3,3)', '=0', '=', '=TRUE']
     expected: [[1, 0, 1], [0, 0, 0], [1, 0, 1]]
 
   - name: single-row grid cross fills the row
     args: ['={1,2,3,4,5}', '=0']
     expected: [[1, 1, 1, 1, 1]]
 
-  - name: unknown type returns NA
+  - name: unknown shape returns NA
     args: ['=SEQUENCE(3,3)', '=99']
     expected: -2146826246
 


### PR DESCRIPTION
## Summary

Two new lambdas in the **maps** library (no cross-lambda dependencies).

### BYRECTANGLE(grid, [rows], [cols], [operation], [mode])
Applies an operation (default `SUM`) to every `rows` x `cols` sub-rectangle of `grid`.
- `mode` 0 (default): sliding window — every overlapping window, output `(R-rows+1) x (C-cols+1)`.
- `mode` 1: non-overlapping tiles from the top-left, partial edge tiles included.
- When `grid` is a real range, `operation` receives **true sub-range references** via OFFSET — verified by a `SUBTOTAL(9, area)` test. Array input falls back to INDEX slices.
- Window larger than the grid fails loud with `#N/A`.

### MASK(grid, [shape], [rotation], [invert])
Builds a 2d mask of 1s/0s sized to `grid` (values ignored), centred and scaled to its dimensions.
- `shape`: (0) cross, (1) diagonals X, (2) star, (3) circle/ellipse, (4) right-angled half-area triangle (diagonal included, hypotenuse scaled on non-square grids), (5) border, (6) diamond, (7) checkerboard. Unknown shapes return `#N/A`.
- `rotation`: quarter-turns clockwise, wraps mod 4 (-1 = anticlockwise). Only triangle is orientation-sensitive (right angle at bottom-left / top-left / top-right / bottom-right); symmetric shapes ignore it. Numeric for now — arrow-based direction can layer onto the same parameter later.
- `invert` = 1 (or TRUE) swaps 1s and 0s.

## Testing
- Format validation: 872 passed.
- Harness (scoped): BYRECTANGLE 11/11, MASK 22/22 — includes real-range setup tests, all four triangle rotations, negative-rotation wrap, non-square shapes, even dimensions, degenerate 1-row grids, invert via gap-arg, and loud-failure cases.
- Full suite: 1080/1080 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)