### PR TITLE
Add GRIDWHERE - cells of a grid satisfying a predicate

### DIFF
--- a/lambdas/maps/GRIDWHERE.lambda
+++ b/lambdas/maps/GRIDWHERE.lambda
@@ -1,0 +1,53 @@
+/*  FUNCTION NAME:      GRIDWHERE
+    DESCRIPTION:*//**Returns the cells of a grid that satisfy a predicate, as a column of addresses, values, address/value pairs, or encoded positions in reading order.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-08-22  Claude      Initial version
+*/
+GRIDWHERE = LAMBDA(
+//  Parameter Declarations
+    [grid],
+    [predicate],
+    [return_mode],
+    [origin],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →GRIDWHERE(grid, predicate, [return_mode], [origin])¶" &
+                "DESCRIPTION:   →Returns the cells of a grid that satisfy a predicate, as a single column in reading order (row by row, left to right). Replaces the mask-spill + FILTER(TOCOL(ADDRESSES(mask)), TOCOL(mask)) pattern that precedes most Maps-library calls; the output feeds LABELCLUSTERS, DISTFROM, MAZE targets etc. directly. Returns #N/A when no cell matches.¶" &
+                "VERSION:       →Aug 22 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   grid           →(Required) A 2D range or array of values (e.g. a map named range).¶" &
+                "   predicate      →(Required) LAMBDA(v, ...) returning TRUE/FALSE for each cell value, e.g. LAMBDA(v, NOT(ISNUMBER(v))).¶" &
+                "   return_mode    →(Optional) What to return per matching cell: (0) A1 address text [default], (1) the cell value, (2) a two-column {address, value} table, (3) encoded position row*100000+col (the CELLTOPOS convention).¶" &
+                "   origin         →(Optional) Top-left anchor as a workbook reference — a single cell or a range (a range's top-left is used). Anchors an in-memory grid to a worksheet position so addresses/positions map to that frame, matching GRIDLOOKUP / MAZE / SUBGRID. Defaults to the grid's own top-left — inferred for a reference, (1,1) for an array.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=GRIDWHERE(mp, LAMBDA(v, NOT(ISNUMBER(v))))¶" &
+                "Result         →Column of addresses of the non-numeric cells of mp, e.g. {""X24"";""Z24"";""AB24""}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(grid),
+        mode, IF(ISOMITTED(return_mode), 0, return_mode),
+    //  Procedure
+        theMult, 100000,
+        baseRow, IFERROR(MIN(ROW(grid)), 1),
+        baseCol, IFERROR(MIN(COLUMN(grid)), 1),
+        originRow, IF(ISOMITTED(origin), baseRow, MIN(ROW(origin))),
+        originCol, IF(ISOMITTED(origin), baseCol, MIN(COLUMN(origin))),
+        nRows, ROWS(grid),
+        nCols, COLUMNS(grid),
+        mask, TOCOL(MAP(grid, predicate)),
+        rowNums, TOCOL(SEQUENCE(nRows, 1, originRow) + SEQUENCE(1, nCols, 0, 0)),
+        colNums, TOCOL(SEQUENCE(nRows, 1, 0, 0) + SEQUENCE(1, nCols, originCol)),
+        vals, TOCOL(grid),
+        hitRows, FILTER(rowNums, mask, NA()),
+        hitCols, FILTER(colNums, mask, NA()),
+        hitVals, FILTER(vals, mask, NA()),
+        addrs, ADDRESS(hitRows, hitCols, 4),
+        result, IF(ISNA(@hitRows), NA(),
+                IF(mode = 1, hitVals,
+                IF(mode = 2, HSTACK(addrs, hitVals),
+                IF(mode = 3, hitRows * theMult + hitCols,
+                   addrs)))),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/GRIDWHERE.tests.yaml
+++ b/lambdas/maps/GRIDWHERE.tests.yaml
@@ -1,0 +1,61 @@
+tests:
+  - name: addresses of non-numeric cells in reading order (array grid anchors at A1)
+    args: ['={1,"A",2;"B",3,"C"}', '=LAMBDA(v, NOT(ISNUMBER(v)))']
+    expected: [["B1"], ["A2"], ["C2"]]
+
+  - name: return_mode 1 returns the matching values
+    args: ['={1,"A",2;"B",3,"C"}', '=LAMBDA(v, NOT(ISNUMBER(v)))', '=1']
+    expected: [["A"], ["B"], ["C"]]
+
+  - name: return_mode 2 returns address/value pairs
+    args: ['={1,"A",2;"B",3,"C"}', '=LAMBDA(v, ISNUMBER(v))', '=2']
+    expected: [["A1", 1], ["C1", 2], ["B2", 3]]
+
+  - name: return_mode 3 returns encoded positions
+    args: ['={1,"A",2;"B",3,"C"}', '=LAMBDA(v, NOT(ISNUMBER(v)))', '=3']
+    expected: [[100002], [200001], [200003]]
+
+  - name: numeric predicate on values
+    args: ['={5,12;20,3}', '=LAMBDA(v, v > 10)']
+    expected: [["B1"], ["A2"]]
+
+  - name: single match returns a scalar-shaped address
+    args: ['={5,12;20,3}', '=LAMBDA(v, v > 15)']
+    expected: "A2"
+
+  - name: no match returns #N/A
+    args: ['={5,12;20,3}', '=LAMBDA(v, v > 100)']
+    expected: -2146826246
+
+  - name: real range input infers its own top-left frame
+    setup:
+      cells:
+        - address: "G5:I7"
+          values:
+            - ["A", 1, 2]
+            - [3, "B", 4]
+            - [5, 6, "C"]
+      names:
+        - { name: "testGrid", refers_to: "G5:I7" }
+    args: ["=testGrid", "=LAMBDA(v, ISTEXT(v))"]
+    expected: [["G5"], ["H6"], ["I7"]]
+
+  - name: origin re-bases an array grid to a worksheet frame
+    setup:
+      cells:
+        - address: "M10"
+          values: "anchor"
+    args: ['={"A",1;1,"B"}', '=LAMBDA(v, ISTEXT(v))', "=", "=M10"]
+    expected: [["M10"], ["N11"]]
+
+  - name: origin with return_mode 3 encodes in the origin frame
+    setup:
+      cells:
+        - address: "M10"
+          values: "anchor"
+    args: ['={"A",1;1,"B"}', '=LAMBDA(v, ISTEXT(v))', "=3", "=M10"]
+    expected: [[1000013], [1100014]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
Closes #336

## Summary
- `GRIDWHERE(grid, predicate, [return_mode], [origin])` in the maps library.
- Returns matching cells as a single column in reading order. `return_mode`: 0 addresses (default), 1 values, 2 `{address, value}`, 3 encoded positions (row*100000+col).
- `origin` is a reference-only anchor (same convention as GRIDLOOKUP / SUBGRID); array grids default to an A1 frame, real ranges infer their own top-left.
- No match returns `#N/A` (rather than FILTER's `#CALC!`).

## Testing
- Format tests: 888 passed.
- Harness (`LAMBDA_FILTER=GRIDWHERE`): 11/11 passed, covering all four return modes, real-range frame inference, origin re-basing, single-match and no-match cases.