### PR TITLE
Add CLUSTERAGG; LABELCLUSTERS accepts any direction notation via DIRDELTA

### DIFF
--- a/lambdas/maps/CLUSTERAGG.lambda
+++ b/lambdas/maps/CLUSTERAGG.lambda
@@ -1,0 +1,51 @@
+/*  FUNCTION NAME:      CLUSTERAGG
+    DESCRIPTION:*//**Groups the cells of a grid that satisfy a predicate into connected clusters and aggregates a value per cluster, returning a {clusterId, cellCount, aggregate} table sorted largest aggregate first.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-08-22  Claude      Initial version
+*/
+CLUSTERAGG = LAMBDA(
+//  Parameter Declarations
+    [grid],
+    [predicate],
+    [value_fn],
+    [agg_fn],
+    [deltas],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →CLUSTERAGG(grid, predicate, [value_fn], [agg_fn], [deltas])¶" &
+                "DESCRIPTION:   →Groups the cells of a grid that satisfy a predicate into connected clusters (via LABELCLUSTERS), maps each cell to a number, and aggregates per cluster. Returns a three-column {clusterId, cellCount, aggregate} table sorted by aggregate descending (ties by clusterId ascending), so the answer to ""largest / highest-scoring group"" is always row 1. Cluster ids are numbered by first appearance in reading order. Returns #N/A when no cell matches.¶" &
+                "VERSION:       →Aug 22 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   grid           →(Required) A 2D range or array of values (e.g. a map named range).¶" &
+                "   predicate      →(Required) LAMBDA(v, ...) returning TRUE for the cells that belong in clusters, e.g. LAMBDA(v, NOT(ISNUMBER(v))).¶" &
+                "   value_fn       →(Optional) LAMBDA(v, ...) mapping a matching cell's value to a number, e.g. LAMBDA(v, CODE(v) - 64). Only applied to cells that pass the predicate. Omitted: every cell counts 1, so the aggregate is the cluster size.¶" &
+                "   agg_fn         →(Optional) Aggregator applied to each cluster's column of mapped values. Pass a built-in by name (SUM, MAX, AVERAGE, ...) or a LAMBDA(values, ...). Default SUM.¶" &
+                "   deltas         →(Optional) Adjacency stencil in any direction notation — packed deltas (_dirOrthog), arrow glyphs (_arrowsOrthog), compass codes or screen directions; normalised via DIRDELTA. Default: 8-way (_dirAll).¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=CLUSTERAGG(mp, LAMBDA(v, NOT(ISNUMBER(v))), LAMBDA(v, CODE(v) - 64), , _dirOrthog)¶" &
+                "Result         →{3, 17, 2002; ...} — cluster 3 has 17 letters summing to 2002; =INDEX(result, 1, 3) is the answer",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(grid),
+        fn, IF(ISOMITTED(agg_fn), SUM, agg_fn),
+    //  Procedure
+        theMult, 100000,
+        nRows, ROWS(grid),
+        nCols, COLUMNS(grid),
+        mask, TOCOL(MAP(grid, predicate)),
+        posGrid, SEQUENCE(nRows) * theMult + SEQUENCE(1, nCols),
+        hitPos, FILTER(TOCOL(posGrid), mask, NA()),
+        hitVals, FILTER(TOCOL(grid), mask, NA()),
+        n, ROWS(hitPos),
+        weights, IF(ISOMITTED(value_fn), SEQUENCE(n, 1, 1, 0), MAP(hitVals, value_fn)),
+        dts, IF(ISOMITTED(deltas), {-100000;-99999;1;100001;100000;99999;-1;-100001}, DIRDELTA(deltas)),
+        labels, LABELCLUSTERS(hitPos, dts),
+        ids, UNIQUE(labels),
+        counts, MAP(ids, LAMBDA(k, SUM(--(labels = k)))),
+        aggs, MAP(ids, LAMBDA(k, fn(FILTER(weights, labels = k)))),
+        table, HSTACK(ids, counts, aggs),
+        result, IF(ISNA(@hitPos), NA(), SORTBY(table, aggs, -1, ids, 1)),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/maps/CLUSTERAGG.tests.yaml
+++ b/lambdas/maps/CLUSTERAGG.tests.yaml
@@ -1,0 +1,53 @@
+tests:
+  - name: letter clusters summed by letter value, 8-way default, largest first
+    args: ['={"A",1,"B";"C",2,"D";3,4,"E"}', '=LAMBDA(v, NOT(ISNUMBER(v)))', '=LAMBDA(v, CODE(v) - 64)']
+    expected: [[2, 3, 11], [1, 2, 4]]
+
+  - name: default value_fn counts cells (aggregate = cluster size)
+    args: ['={"A",1,"B";"C",2,"D";3,4,"E"}', '=LAMBDA(v, NOT(ISNUMBER(v)))']
+    expected: [[2, 3, 3], [1, 2, 2]]
+
+  - name: diagonal neighbours merge under the 8-way default
+    args: ['={"A",1;1,"B"}', '=LAMBDA(v, ISTEXT(v))']
+    expected: [[1, 2, 2]]
+
+  - name: 4-way compass codes split diagonals, ties ordered by cluster id
+    args: ['={"A",1;1,"B"}', '=LAMBDA(v, ISTEXT(v))', "=", "=", '={"N";"E";"S";"W"}']
+    expected: [[1, 1, 1], [2, 1, 1]]
+
+  - name: 4-way arrow glyphs via DIRDELTA
+    args: ['={"A",1,"B";"C",2,"D";3,4,"E"}', '=LAMBDA(v, NOT(ISNUMBER(v)))', '=LAMBDA(v, CODE(v) - 64)', "=", '={"↑";"→";"↓";"←"}']
+    expected: [[2, 3, 11], [1, 2, 4]]
+
+  - name: 4-way packed deltas via _dirOrthog literal
+    args: ['={"A",1,"B";"C",2,"D";3,4,"E"}', '=LAMBDA(v, NOT(ISNUMBER(v)))', '=LAMBDA(v, CODE(v) - 64)', "=", '={-100000;1;100000;-1}']
+    expected: [[2, 3, 11], [1, 2, 4]]
+
+  - name: custom agg_fn MAX per cluster
+    args: ['={"A",1,"B";"C",2,"D";3,4,"E"}', '=LAMBDA(v, NOT(ISNUMBER(v)))', '=LAMBDA(v, CODE(v) - 64)', "=MAX"]
+    expected: [[2, 3, 5], [1, 2, 3]]
+
+  - name: numeric grid, islands of values above a threshold
+    args: ['={9,1,1,8;9,1,1,8;1,1,1,1}', '=LAMBDA(v, v > 5)', '=LAMBDA(v, v)']
+    expected: [[1, 2, 18], [2, 2, 16]]
+
+  - name: no matching cells returns #N/A
+    args: ['={1,2;3,4}', '=LAMBDA(v, v > 100)']
+    expected: -2146826246
+
+  - name: real range input
+    setup:
+      cells:
+        - address: "G5:I7"
+          values:
+            - ["A", 1, 2]
+            - [3, "B", 4]
+            - [5, 6, "C"]
+      names:
+        - { name: "testGrid", refers_to: "G5:I7" }
+    args: ["=testGrid", "=LAMBDA(v, ISTEXT(v))", "=LAMBDA(v, CODE(v) - 64)"]
+    expected: [[1, 3, 6]]
+
+  - name: help text
+    args: []
+    expected_type: array

--- a/lambdas/maps/LABELCLUSTERS.lambda
+++ b/lambdas/maps/LABELCLUSTERS.lambda
@@ -3,6 +3,7 @@
 /*  REVISIONS:          Date        Developer   Description
                         2026-07-01  Claude      Initial version
                         2026-08-20  Claude      Default stencil re-ordered to the library canonical clockwise-from-north order (result is order-independent; no behaviour change)
+                        2026-08-22  Claude      deltas normalised via DIRDELTA so arrow glyphs / compass codes / screen directions are accepted alongside packed deltas
 */
 LABELCLUSTERS = LAMBDA(
 //  Parameter Declarations
@@ -13,10 +14,10 @@ LABELCLUSTERS = LAMBDA(
     LET(Help, TEXTSPLIT(
                 "FUNCTION:      →LABELCLUSTERS(cells, [deltas], [group])¶" &
                 "DESCRIPTION:   →Labels each input cell with an integer cluster id such that two cells in the same group share an id whenever they are adjacent, directly or transitively. Uses full transitive closure (min-label relaxation) so the result is independent of input order.¶" &
-                "VERSION:       →Jul 01 2026¶" &
+                "VERSION:       →Aug 22 2026¶" &
                 "PARAMETERS:    →¶" &
                 "   cells          →(Required) A column of cells — A1 address text (e.g. ""B7"") OR encoded scalar positions (row*100000+col). Auto-detected per element via ISNUMBER; text is normalised internally via CELLTOPOS.¶" &
-                "   deltas         →(Optional) A 1-D array of scalar position deltas defining connectivity. Default: the 8 compass directions in canonical clockwise order ({-100000;-99999;1;100001;100000;99999;-1;-100001}, i.e. _dirAll). Pass {-100000;1;100000;-1} (_dirOrthog) for 4-way, or any custom stencil (e.g. knight moves). Assumes the library default mult=100000.¶" &
+                "   deltas         →(Optional) A 1-D array defining connectivity, in any direction notation — packed position deltas (_dirOrthog, _dirAll, knight moves ...), arrow glyphs (_arrowsOrthog, ↑ → ↓ ←), compass codes (N, NE, north-east ...) or screen directions (U, DR, up-left ...); normalised via DIRDELTA. Default: the 8 compass directions in canonical clockwise order ({-100000;-99999;1;100001;100000;99999;-1;-100001}, i.e. _dirAll). Pass _dirOrthog or _arrowsOrthog for 4-way. Assumes the library default mult=100000.¶" &
                 "   group          →(Optional) Column of area / sheet keys (numeric or text). Adjacency is only tested between cells sharing the same key, so multi-sheet maps stay partitioned. Omitted: all cells treated as one group.¶" &
                 "EXAMPLE:       →¶" &
                 "Formula        →=LABELCLUSTERS({""A1"";""A3"";""A2""})¶" &
@@ -34,7 +35,7 @@ LABELCLUSTERS = LAMBDA(
         gi, XMATCH(grpRaw, UNIQUE(grpRaw)),
         BIG, 1000000000000,
         K, gi * BIG + pos,
-        dts, IF(ISOMITTED(deltas), {-100000;-99999;1;100001;100000;99999;-1;-100001}, deltas),
+        dts, IF(ISOMITTED(deltas), {-100000;-99999;1;100001;100000;99999;-1;-100001}, DIRDELTA(deltas)),
         relaxStep, LAMBDA(lab,
                       REDUCE(lab, dts, LAMBDA(acc, dlt,
                         LET(nl, XLOOKUP(K + dlt, K, lab, n + 1),

--- a/lambdas/maps/LABELCLUSTERS.tests.yaml
+++ b/lambdas/maps/LABELCLUSTERS.tests.yaml
@@ -27,6 +27,18 @@ tests:
     args: ['={200002;300002}']
     expected: [[1], [1]]
 
+  - name: diagonal pair splits under 4-way arrow glyphs (DIRDELTA normalisation)
+    args: ['={"B2";"C3"}', '={"↑";"→";"↓";"←"}']
+    expected: [[1], [2]]
+
+  - name: diagonal pair merges under 8-way compass codes
+    args: ['={"B2";"C3"}', '={"N";"NE";"E";"SE";"S";"SW";"W";"NW"}']
+    expected: [[1], [1]]
+
+  - name: orthogonal pair merges under screen-direction names
+    args: ['={"B2";"B3"}', '={"up";"down";"left";"right"}']
+    expected: [[1], [1]]
+
   - name: help text
     args: []
     expected_type: array


### PR DESCRIPTION
Closes #337
Closes #338

## Summary
- **LABELCLUSTERS** (#338): `deltas` now goes through `DIRDELTA`, so `_arrowsOrthog`, compass codes (`N`, `north-east`) and screen directions (`up`, `DR`) all work. Packed deltas pass through unchanged — fully backwards compatible. Help text updated.
- **CLUSTERAGG** (#337): `CLUSTERAGG(grid, predicate, [value_fn], [agg_fn], [deltas])` — mask, position list, LABELCLUSTERS and per-cluster aggregate in one call. Returns `{clusterId, cellCount, aggregate}` sorted by aggregate desc (ties by id asc); row 1 answers "largest / highest-scoring group". `value_fn` is only applied to cells passing the predicate (so `CODE(v)-64` never sees a number). `agg_fn` takes a built-in by name or a LAMBDA; default SUM.

## Design note
The idea listed an `origin` parameter. I've omitted it: the output table contains no addresses or positions, so an address frame would have no observable effect. If agg_fn later gains access to cluster addresses (bounding box / perimeter outputs mentioned in the issue), origin can be added then without a breaking change.

## Testing
- Format tests: 888 passed.
- Harness (`LAMBDA_FILTER=CLUSTER`): 22/22 — LABELCLUSTERS gains arrow / compass / screen-name cases; CLUSTERAGG covers 8-way default, 4-way via three notations, default count vs value_fn, MAX agg_fn, numeric thresholds, no-match (#N/A) and a real-range input.