### PR TITLE
Add PIVOT - tidy long-format to wide crosstab, inverse of UNPIVOT

### DIFF
--- a/lambdas/array/PIVOT.lambda
+++ b/lambdas/array/PIVOT.lambda
@@ -1,0 +1,66 @@
+/*  FUNCTION NAME:      PIVOT
+    DESCRIPTION:*//**Reshapes a tidy long-format (keys, labels, values) table into a wide crosstab - the inverse of UNPIVOT. Text-safe, no grand totals, first-appearance ordering.*/
+/*  REVISIONS:          Date        Developer   Description
+                        2026-08-22  Claude      Initial version
+*/
+PIVOT = LAMBDA(
+//  Parameter Declarations
+    [keys],
+    [labels],
+    [values],
+    [fn],
+    [headers],
+    [if_empty],
+    [keep_keys],
+//  Help
+    LET(Help, TEXTSPLIT(
+                "FUNCTION:      →PIVOT(keys, labels, values, [fn], [headers], [if_empty], [keep_keys])¶" &
+                "DESCRIPTION:   →Reshapes a tidy long-format table into a wide crosstab: unique keys down (first-appearance order), unique labels across, values at the intersections. The inverse of UNPIVOT. Unlike native PIVOTBY it is text-safe by default, adds no grand totals, and preserves input order rather than sorting.¶" &
+                "VERSION:       →Aug 22 2026¶" &
+                "PARAMETERS:    →¶" &
+                "   keys           →(Required) Row keys: a 1-D array, or an H x K block for compound keys (mirrors UNPIVOT's multi-key output). A row-shaped 1-D input is treated as a column.¶" &
+                "   labels         →(Required) 1-D array of column labels, one per row of keys.¶" &
+                "   values         →(Required) 1-D array of values (any type, text included), one per row of keys.¶" &
+                "   fn             →(Optional) Aggregator for duplicate (key, label) pairs — a built-in by name (SUM, MAX, ...) or a LAMBDA over the column of matching values; must return a scalar. Omitted: a single value is placed as-is and unexpected duplicates are joined as text with "", "".¶" &
+                "   headers        →(Optional) TRUE [default] prepends the label row (and a blank corner above the key column(s)); FALSE returns the body only.¶" &
+                "   if_empty       →(Optional) Fill for (key, label) combinations with no value. Default """".¶" &
+                "   keep_keys      →(Optional) TRUE [default] includes the key column(s) on the left; FALSE returns just the pivoted value columns — handy when the key is an artificial index such as UNTILE's Section number.¶" &
+                "EXAMPLE:       →¶" &
+                "Formula        →=PIVOT({1;1;2;2}, {""Char"";""Code"";""Char"";""Code""}, {""A"";""O.n"";""B"";""On.""})¶" &
+                "Result         →{"""",""Char"",""Code"";1,""A"",""O.n"";2,""B"",""On.""}",
+                "→", "¶"
+                ),
+    //  Check inputs
+        Help?, ISOMITTED(keys),
+        hasFn, NOT(ISOMITTED(fn)),
+        hdr?, IF(ISOMITTED(headers), TRUE, headers),
+        empty, IF(ISOMITTED(if_empty), "", if_empty),
+        keep?, IF(ISOMITTED(keep_keys), TRUE, keep_keys),
+    //  Procedure
+        keyBlock, IF(AND(ROWS(keys) = 1, COLUMNS(keys) > 1), TRANSPOSE(keys), keys),
+        labelsC, TOCOL(labels),
+        valsC, TOCOL(values),
+        nk, COLUMNS(keyBlock),
+        comp, BYROW(keyBlock, LAMBDA(kr, TEXTJOIN(CHAR(30), FALSE, kr))),
+        uKeys, UNIQUE(keyBlock),
+        uComp, UNIQUE(comp),
+        uLabels, UNIQUE(labelsC),
+        kIdx, XMATCH(comp, uComp, 0),
+        lIdx, XMATCH(labelsC, uLabels, 0),
+        nKeys, ROWS(uComp),
+        nLabels, ROWS(uLabels),
+        cell, LAMBDA(ki, lj,
+                LET(hitMask, (kIdx = ki) * (lIdx = lj),
+                    cnt, SUM(hitMask),
+                    IF(cnt = 0, empty,
+                       LET(hits, FILTER(valsC, hitMask),
+                           IF(hasFn, fn(hits),
+                              IF(cnt = 1, @hits, TEXTJOIN(", ", TRUE, hits))))))),
+        body, MAKEARRAY(nKeys, nLabels, cell),
+        labelRow, TOROW(uLabels),
+        withKeys, IF(keep?, HSTACK(uKeys, body), body),
+        topRow, IF(keep?, HSTACK(EXPAND("", 1, nk, ""), labelRow), labelRow),
+        result, IF(hdr?, VSTACK(topRow, withKeys), withKeys),
+        IF(Help?, Help, result)
+)
+);

--- a/lambdas/array/PIVOT.tests.yaml
+++ b/lambdas/array/PIVOT.tests.yaml
@@ -1,0 +1,60 @@
+tests:
+  - name: basic long-to-wide with headers and keys (defaults)
+    args: ['={1;1;2;2}', '={"Char";"Code";"Char";"Code"}', '={"A";"O.n";"B";"On."}']
+    expected: [["", "Char", "Code"], [1, "A", "O.n"], [2, "B", "On."]]
+
+  - name: keep_keys FALSE drops the key column (UNTILE Section index case)
+    args: ['={1;1;2;2}', '={"Char";"Code";"Char";"Code"}', '={"A";"O.n";"B";"On."}', "=", "=", "=", "=FALSE"]
+    expected: [["Char", "Code"], ["A", "O.n"], ["B", "On."]]
+
+  - name: headers FALSE returns body only
+    args: ['={1;1;2;2}', '={"Char";"Code";"Char";"Code"}', '={"A";"O.n";"B";"On."}', "=", "=FALSE"]
+    expected: [[1, "A", "O.n"], [2, "B", "On."]]
+
+  - name: no headers and no keys returns just the value grid
+    args: ['={1;1;2;2}', '={"Char";"Code";"Char";"Code"}', '={"A";"O.n";"B";"On."}', "=", "=FALSE", "=", "=FALSE"]
+    expected: [["A", "O.n"], ["B", "On."]]
+
+  - name: missing combinations fill with if_empty default blank
+    args: ['={1;2}', '={"X";"Y"}', '={5;6}']
+    expected: [["", "X", "Y"], [1, 5, ""], [2, "", 6]]
+
+  - name: custom if_empty fill
+    args: ['={1;2}', '={"X";"Y"}', '={5;6}', "=", "=FALSE", "=0"]
+    expected: [[1, 5, 0], [2, 0, 6]]
+
+  - name: first-appearance order is preserved for keys and labels (not sorted)
+    args: ['={"z";"z";"a"}', '={"q";"p";"p"}', '={1;2;3}', "=", "=FALSE"]
+    expected: [["z", 1, 2], ["a", "", 3]]
+
+  - name: duplicates aggregated with fn SUM
+    args: ['={1;1;1}', '={"a";"a";"b"}', '={1;2;3}', "=SUM", "=FALSE"]
+    expected: [[1, 3, 3]]
+
+  - name: duplicates aggregated with a LAMBDA fn
+    args: ['={1;1;1}', '={"a";"a";"b"}', '={1;2;3}', "=LAMBDA(v, MAX(v) - MIN(v))", "=FALSE"]
+    expected: [[1, 1, 0]]
+
+  - name: duplicates without fn are joined as text
+    args: ['={1;1;1}', '={"a";"a";"b"}', '={"x";"y";"z"}', "=", "=FALSE"]
+    expected: [[1, "x, y", "z"]]
+
+  - name: multi-column keys pivot on the compound key
+    args: ['={"x","p";"x","q";"x","p"}', '={"a";"b";"a"}', '={1;2;3}', "=SUM", "=FALSE"]
+    expected: [["x", "p", 4, ""], ["x", "q", "", 2]]
+
+  - name: multi-column keys header has a blank corner per key column
+    args: ['={"x","p";"x","q"}', '={"a";"b"}', '={1;2}']
+    expected: [["", "", "a", "b"], ["x", "p", 1, ""], ["x", "q", "", 2]]
+
+  - name: row-shaped 1-D inputs are treated as columns
+    args: ['={1,2}', '={"a","b"}', '={10,20}', "=", "=FALSE"]
+    expected: [[1, 10, ""], [2, "", 20]]
+
+  - name: single key single label
+    args: ['={"k"}', '={"c"}', '={"v"}']
+    expected: [["", "c"], ["k", "v"]]
+
+  - name: help text
+    args: []
+    expected_type: array


### PR DESCRIPTION
Closes #339

## Summary
- `PIVOT(keys, labels, values, [fn], [headers], [if_empty], [keep_keys])` in the array library.
- Unique keys down / unique labels across, both in first-appearance order; values (any type, text included) at the intersections. No grand totals.
- `keys` accepts a 1-D array or an H x K block for compound keys (mirrors UNPIVOT's multi-key output); the header row gets one blank corner cell per key column.
- `fn` aggregates duplicate (key, label) pairs — built-in by name or a LAMBDA over the matching column. With no `fn`, a single value is placed as-is and unexpected duplicates are joined as text with ", " (chosen over erroring so the sheet still shows something useful; easy to flip if you'd rather it error).
- `headers` / `keep_keys` default TRUE; `if_empty` default "".

## Testing
- Format tests: 888 passed.
- Harness (`LAMBDA_FILTER=PIVOT`): 15/15 PIVOT cases — defaults, keep_keys FALSE (the UNTILE braille case), headers FALSE, if_empty, ordering preservation, SUM / LAMBDA / no-fn duplicate handling, compound keys, row-shaped inputs, 1x1.
- Full harness suite on this branch: 1126/1126 passed.